### PR TITLE
Feat: wasm loro class inner mutability

### DIFF
--- a/crates/loro-core/src/context.rs
+++ b/crates/loro-core/src/context.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::{
+    cell::RefCell,
+    sync::{Arc, Mutex, RwLock, Weak},
+};
 
 use crate::{
     container::{registry::ContainerInstance, ContainerID},
@@ -23,5 +26,22 @@ impl Context for LoroCore {
 
     fn get_container(&self, id: &ContainerID) -> Option<Weak<Mutex<ContainerInstance>>> {
         self.log_store.try_read().unwrap().get_container(id)
+    }
+}
+
+impl<T> Context for RefCell<T>
+where
+    T: Context,
+{
+    fn log_store(&self) -> Arc<RwLock<LogStore>> {
+        self.borrow().log_store()
+    }
+
+    fn hierarchy(&self) -> Arc<Mutex<Hierarchy>> {
+        self.borrow().hierarchy()
+    }
+
+    fn get_container(&self, id: &ContainerID) -> Option<Weak<Mutex<ContainerInstance>>> {
+        self.borrow().get_container(id)
     }
 }

--- a/crates/loro-wasm/deno_test/test.ts
+++ b/crates/loro-wasm/deno_test/test.ts
@@ -63,14 +63,14 @@ Deno.test({ name: "sync" }, async (t) => {
     let b_version: undefined | Uint8Array = undefined;
     a.subscribe((local: boolean) => {
       if (local) {
-        let exported = a.exportUpdates(a_version);
+        const exported = a.exportUpdates(a_version);
         b.importUpdates(exported);
         a_version = a.version();
       }
     });
     b.subscribe((local: boolean) => {
       if (local) {
-        let exported = b.exportUpdates(b_version);
+        const exported = b.exportUpdates(b_version);
         a.importUpdates(exported);
         b_version = b.version();
       }
@@ -190,4 +190,19 @@ Deno.test("subscribe_lock", () => {
   loro.unsubscribe(sub);
   text.insert(loro, 0, "hello world");
   assertEquals(count, 3);
+});
+
+Deno.test("subscribe_lock2", () => {
+  const loro = new Loro();
+  const text = loro.getText("text");
+  let count = 0;
+  const sub = loro.subscribe(() => {
+    count += 1;
+    loro.unsubscribe(sub);
+  });
+  assertEquals(count, 0);
+  text.insert(loro, 0, "hello world");
+  assertEquals(count, 1);
+  text.insert(loro, 0, "hello world");
+  assertEquals(count, 1);
 });

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -7,10 +7,7 @@ use loro_core::{
     log_store::{EncodeConfig, EncodeMode},
     ContainerType, List, LoroCore, Map, Text, VersionVector,
 };
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+use std::{cell::RefCell, ops::Deref, sync::Arc};
 use wasm_bindgen::prelude::*;
 mod log;
 mod prelim;
@@ -34,10 +31,10 @@ pub fn set_panic_hook() {
 type JsResult<T> = Result<T, JsValue>;
 
 #[wasm_bindgen]
-pub struct Loro(LoroCore);
+pub struct Loro(RefCell<LoroCore>);
 
 impl Deref for Loro {
-    type Target = LoroCore;
+    type Target = RefCell<LoroCore>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -48,12 +45,6 @@ impl Deref for Loro {
 extern "C" {
     #[wasm_bindgen(typescript_type = "ContainerID")]
     pub type JsContainerID;
-}
-
-impl DerefMut for Loro {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
 }
 
 struct MathRandom;
@@ -84,49 +75,50 @@ impl Loro {
             get_time: || js_sys::Date::now() as i64,
             rand: Arc::new(MathRandom),
         };
-        Self(LoroCore::new(cfg, None))
+        Self(RefCell::new(LoroCore::new(cfg, None)))
     }
 
     #[wasm_bindgen(js_name = "clientId", method, getter)]
     pub fn client_id(&self) -> u64 {
-        self.0.client_id()
+        self.0.borrow().client_id()
     }
 
     #[wasm_bindgen(js_name = "getText")]
-    pub fn get_text(&mut self, name: &str) -> JsResult<LoroText> {
-        let text = self.0.get_text(name);
+    pub fn get_text(&self, name: &str) -> JsResult<LoroText> {
+        let text = self.0.borrow_mut().get_text(name);
         Ok(LoroText(text))
     }
 
     #[wasm_bindgen(js_name = "getMap")]
-    pub fn get_map(&mut self, name: &str) -> JsResult<LoroMap> {
-        let map = self.0.get_map(name);
+    pub fn get_map(&self, name: &str) -> JsResult<LoroMap> {
+        let map = self.0.borrow_mut().get_map(name);
         Ok(LoroMap(map))
     }
 
     #[wasm_bindgen(js_name = "getList")]
-    pub fn get_list(&mut self, name: &str) -> JsResult<LoroList> {
-        let list = self.0.get_list(name);
+    pub fn get_list(&self, name: &str) -> JsResult<LoroList> {
+        let list = self.0.borrow_mut().get_list(name);
         Ok(LoroList(list))
     }
 
     #[wasm_bindgen(skip_typescript, js_name = "getContainerById")]
-    pub fn get_container_by_id(&mut self, container_id: JsContainerID) -> JsResult<JsValue> {
+    pub fn get_container_by_id(&self, container_id: JsContainerID) -> JsResult<JsValue> {
         let container_id: ContainerID = container_id.to_owned().try_into()?;
         let ty = container_id.container_type();
-        let container = self.0.get_container(&container_id);
+        let container = self.0.borrow_mut().get_container(&container_id);
         if let Some(container) = container {
+            let client_id = self.0.borrow().client_id();
             Ok(match ty {
                 ContainerType::Text => {
-                    let text: Text = Text::from_instance(container, self.0.client_id());
+                    let text: Text = Text::from_instance(container, client_id);
                     LoroText(text).into()
                 }
                 ContainerType::Map => {
-                    let map: Map = Map::from_instance(container, self.0.client_id());
+                    let map: Map = Map::from_instance(container, client_id);
                     LoroMap(map).into()
                 }
                 ContainerType::List => {
-                    let list: List = List::from_instance(container, self.0.client_id());
+                    let list: List = List::from_instance(container, client_id);
                     LoroList(list).into()
                 }
             })
@@ -137,19 +129,20 @@ impl Loro {
 
     #[inline(always)]
     pub fn version(&self) -> Vec<u8> {
-        self.0.vv_cloned().encode()
+        self.0.borrow().vv_cloned().encode()
     }
 
     #[wasm_bindgen(js_name = "exportSnapshot")]
     pub fn export_snapshot(&self) -> JsResult<Vec<u8>> {
         Ok(self
             .0
+            .borrow()
             .encode(EncodeConfig::new(EncodeMode::Snapshot, None))?)
     }
 
     #[wasm_bindgen(js_name = "importSnapshot")]
-    pub fn import_snapshot(&mut self, input: Vec<u8>) -> JsResult<()> {
-        self.decode(&input)?;
+    pub fn import_snapshot(&self, input: Vec<u8>) -> JsResult<()> {
+        self.0.borrow_mut().decode(&input)?;
         Ok(())
     }
 
@@ -169,17 +162,18 @@ impl Loro {
 
         Ok(self
             .0
+            .borrow()
             .encode(EncodeConfig::new(EncodeMode::Updates(vv), None))?)
     }
 
     #[wasm_bindgen(js_name = "importUpdates")]
-    pub fn import_updates(&mut self, data: Vec<u8>) -> JsResult<()> {
-        self.0.decode(&data)?;
+    pub fn import_updates(&self, data: Vec<u8>) -> JsResult<()> {
+        self.0.borrow_mut().decode(&data)?;
         Ok(())
     }
 
     #[wasm_bindgen(js_name = "importUpdateBatch")]
-    pub fn import_update_batch(&mut self, data: Array) -> JsResult<()> {
+    pub fn import_update_batch(&self, data: Array) -> JsResult<()> {
         let data = data
             .iter()
             .map(|x| {
@@ -187,25 +181,25 @@ impl Loro {
                 arr.to_vec()
             })
             .collect::<Vec<_>>();
-        Ok(self.0.import_updates_batch(&data)?)
+        Ok(self.0.borrow_mut().import_updates_batch(&data)?)
     }
 
     #[wasm_bindgen(js_name = "toJson")]
     pub fn to_json(&self) -> JsResult<JsValue> {
-        let json = self.0.to_json();
+        let json = self.0.borrow().to_json();
         Ok(json.into())
     }
 
     // TODO: convert event and event sub config
-    pub fn subscribe(&mut self, f: js_sys::Function) -> u32 {
-        self.0.subscribe_deep(Box::new(move |e| {
+    pub fn subscribe(&self, f: js_sys::Function) -> u32 {
+        self.0.borrow_mut().subscribe_deep(Box::new(move |e| {
             f.call1(&JsValue::NULL, &JsValue::from_bool(e.local))
                 .unwrap();
         }))
     }
 
-    pub fn unsubscribe(&mut self, subscription: u32) -> bool {
-        self.0.unsubscribe_deep(subscription)
+    pub fn unsubscribe(&self, subscription: u32) -> bool {
+        self.0.borrow_mut().unsubscribe_deep(subscription)
     }
 }
 


### PR DESCRIPTION
# Background

Sometimes, users could create containers, subscribe observers and unsubscribe observers, etc., which breaks Rust's borrowing rules.

> - At any given time, you can have either but not both of the following: one mutable reference or any number of immutable references.
> - References must always be valid.

```typescript

const loro = new Loro();
const text = loro.getText("text");
const sub = loro.subscribe(() => {
  loro.unsubscribe(sub);
});
```

# Proposal

We can use the [`Interior mutability pattern`](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) to resolve this.

