### PR TITLE
fix: utf16 len fallback to utf8 when unknown

### DIFF
--- a/crates/loro-internal/src/container/text/rope.rs
+++ b/crates/loro-internal/src/container/text/rope.rs
@@ -51,9 +51,21 @@ impl Rope {
             index,
             |x| x.utf8 as usize,
             |x| x.atom_len(),
-            |x| x.utf16 as usize,
-            |x| x.utf16_length as usize,
-            |s, src_offset| s.utf8_index_to_utf16(src_offset).unwrap_or(0),
+            |x| {
+                if x.unknown_elem_len != 0 {
+                    x.utf8 as usize
+                } else {
+                    x.utf16 as usize
+                }
+            },
+            |x| {
+                if x.slice.is_some() {
+                    x.utf16_length as usize
+                } else {
+                    x.unknown_len as usize
+                }
+            },
+            |s, src_offset| s.utf8_index_to_utf16(src_offset).unwrap_or(src_offset),
         )
     }
 

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -82,7 +82,6 @@ impl Meta for Utf16Meta {
                 utf16_len
             );
             *utf16_len -= other_len;
-            debug_assert_ne!(*utf16_len, 0);
         }
 
         *other


### PR DESCRIPTION
This may avoid utf16 overflow when composing Delta