### PR TITLE
fix: map version checkout err

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
   ],
   "rust-analyzer.runnableEnv": {
     "RUST_BACKTRACE": "full",
-    // "DEBUG": "*"
+    "DEBUG": "*"
   },
   "rust-analyzer.cargo.features": ["test_utils"],
   "editor.defaultFormatter": "rust-lang.rust-analyzer",

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -115,6 +115,16 @@ impl LoroDoc {
         self.txn_with_origin("")
     }
 
+    #[inline(always)]
+    pub fn with_txn<F>(&self, f: F) -> LoroResult<()>
+    where
+        F: Fn(&mut Transaction),
+    {
+        let mut txn = self.txn().unwrap();
+        f(&mut txn);
+        txn.commit()
+    }
+
     /// Create a new transaction with specified origin.
     ///
     /// The origin will be propagated to the events.

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -244,7 +244,6 @@ impl DocState {
         if self.is_recording() {
             self.record_diff(diff)
         }
-        debug_dbg!(self.get_deep_value());
     }
 
     pub fn apply_local_op(&mut self, op: RawOp) -> LoroResult<()> {

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -138,7 +138,13 @@ impl MapState {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&InternalString, &MapValue)> {
+    pub fn iter(
+        &self,
+    ) -> std::collections::hash_map::Iter<
+        '_,
+        string_cache::Atom<string_cache::EmptyStaticAtomSet>,
+        MapValue,
+    > {
         self.map.iter()
     }
 


### PR DESCRIPTION
Use a new design to switch to a different version of the Map containers. The original design is faulty. 

In this version, when it cannot find the map value from LCA, it will build a map value lookup table for any version by traveling the whole graph. It's costly and can be optimized further. But it can only be triggered when users switch to an old version and only needs to travel the graph once.