### PR TITLE
Fix DiffCalculator error when going back in history

### DIFF
--- a/crates/loro-internal/fuzz/Cargo.lock
+++ b/crates/loro-internal/fuzz/Cargo.lock
@@ -25,9 +25,6 @@ name = "append-only-bytes"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd736657a12852ffb42ed309ac3409382d93f76f49ae0ad69fae4ca927e584d9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "arbitrary"

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -245,7 +245,15 @@ fn check_eq_refactored(site_a: &mut LoroDoc, site_b: &mut LoroDoc) {
     let text_b = b.get_text("text");
     let value_a = text_a.get_value();
     let value_b = text_b.get_value();
-    assert_eq!(value_a, value_b);
+    assert_eq!(
+        value_a,
+        value_b,
+        "peer{}={:?}, peer{}={:?}",
+        site_a.peer_id(),
+        value_a,
+        site_b.peer_id(),
+        value_b
+    );
 }
 
 pub fn minify_error<T, F, N>(site_num: u8, actions: Vec<T>, f: F, normalize: N)
@@ -994,6 +1002,31 @@ mod test {
                     content: 10794,
                     pos: 30,
                     site: 0,
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn checkout() {
+        test_multi_sites_refactored(
+            4,
+            &mut [
+                Ins {
+                    content: 53,
+                    pos: 4,
+                    site: 2,
+                },
+                SyncAll,
+                Ins {
+                    content: 0,
+                    pos: 1,
+                    site: 0,
+                },
+                Del {
+                    pos: 4,
+                    len: 1,
+                    site: 2,
                 },
             ],
         )

--- a/crates/loro-internal/src/version.rs
+++ b/crates/loro-internal/src/version.rs
@@ -475,6 +475,21 @@ impl VersionVector {
             .collect()
     }
 
+    pub fn distance_to(&self, other: &Self) -> usize {
+        let mut ans = 0;
+        for (client_id, &counter) in self.iter() {
+            if let Some(&other_counter) = other.get(client_id) {
+                if counter > other_counter {
+                    ans += counter - other_counter;
+                }
+            } else if counter > 0 {
+                ans += counter;
+            }
+        }
+
+        ans as usize
+    }
+
     pub fn to_spans(&self) -> IdSpanVector {
         self.iter()
             .map(|(client_id, &counter)| {
@@ -570,6 +585,17 @@ impl VersionVector {
             } else {
                 self.0.insert(client_id, other_end);
             }
+        }
+    }
+
+    pub fn includes_vv(&self, other: &VersionVector) -> bool {
+        match self.partial_cmp(other) {
+            Some(ord) => match ord {
+                Ordering::Less => false,
+                Ordering::Equal => true,
+                Ordering::Greater => true,
+            },
+            None => false,
         }
     }
 

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -18,7 +18,7 @@ fn test_timestamp() {
 }
 
 #[test]
-fn test_checkout() {
+fn test_text_checkout() {
     let mut doc = LoroDoc::new();
     let text = doc.get_text("text");
     let mut txn = doc.txn().unwrap();
@@ -44,6 +44,12 @@ fn test_checkout() {
     assert_eq!(text.len_unicode(), 4);
     assert_eq!(text.len_utf8(), 12);
     assert_eq!(text.len_unicode(), 4);
+
+    doc.checkout_to_latest();
+    doc.with_txn(|txn| text.delete(txn, 3, 1)).unwrap();
+    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世");
+    doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 3)].as_slice()));
+    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世界");
 }
 
 #[test]


### PR DESCRIPTION
The diff could not be calculated if the destination version is older than the source version, and deletions have occurred between the two versions.

In this fix, we will use a DiffCalculator that has the full history to allow us traval back. There are things that can be optimized futher in this case, but they are enough for now.