### PR TITLE
Fix: implement Fugue correctly

### DIFF
--- a/crates/loro-internal/benches/encode.rs
+++ b/crates/loro-internal/benches/encode.rs
@@ -13,9 +13,9 @@ mod sync {
         b.bench_function("update", |b| {
             b.iter(|| {
                 let c1 = LoroDoc::new();
-                c1.set_peer_id(1);
+                c1.set_peer_id(1).unwrap();
                 let c2 = LoroDoc::new();
-                c1.set_peer_id(2);
+                c1.set_peer_id(2).unwrap();
                 let t1 = c1.get_text("text");
                 let t2 = c2.get_text("text");
                 for (i, action) in actions.iter().enumerate() {
@@ -121,9 +121,9 @@ mod import {
         b.bench_function("parallel_500", |b| {
             b.iter(|| {
                 let c1 = LoroDoc::new();
-                c1.set_peer_id(1);
+                c1.set_peer_id(1).unwrap();
                 let c2 = LoroDoc::new();
-                c1.set_peer_id(2);
+                c1.set_peer_id(2).unwrap();
 
                 let text1 = c1.get_text("text");
                 let text2 = c2.get_text("text");

--- a/crates/loro-internal/benches/text_r.rs
+++ b/crates/loro-internal/benches/text_r.rs
@@ -30,7 +30,7 @@ mod run {
         b.bench_function("B4 with 100K actors history", |b| {
             let store = LoroDoc::default();
             for i in 0..100_000 {
-                store.set_peer_id(i);
+                store.set_peer_id(i).unwrap();
                 let list = store.get_list("list");
                 let value: LoroValue = i.to_string().into();
                 let mut txn = store.txn().unwrap();

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -229,6 +229,7 @@ impl Tracker {
         self._checkout(to, true);
         // debug_log::debug_dbg!(from, to, &self);
         // self.id_to_cursor.diagnose();
+        debug_log::debug_dbg!(&self);
         self.rope.get_diff()
     }
 }

--- a/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
+++ b/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
@@ -55,6 +55,8 @@ impl CrdtRope {
             };
         }
 
+        // debug_log::group!("Inserting {} len={}", content.id, content.rle_len());
+        // debug_log::debug_dbg!(&self.tree);
         let pos = pos as i32;
         let start = self.tree.query::<ActiveLenQueryPreferLeft>(&pos).unwrap();
 
@@ -97,7 +99,7 @@ impl CrdtRope {
                     if !iter.elem.status.future {
                         origin_right = Some(iter.elem.id.inc(iter.start.unwrap_or(0) as Counter));
                         let parent_right = match iter.start {
-                            Some(_) => {
+                            Some(offset) if offset > 0 => {
                                 // It's guaranteed that origin_right's origin_left == this.origin_left.
                                 // Because the first non-future node is just the leaf node in `start.cursor` node (iter.start.is_some())
                                 // Thus parent_right = origin_right
@@ -128,6 +130,7 @@ impl CrdtRope {
             (parent_right_leaf, in_between)
         };
 
+        // debug_log::debug_dbg!(&parent_right_leaf, &in_between);
         let mut insert_pos = start.cursor;
 
         if !in_between.is_empty() {
@@ -135,14 +138,17 @@ impl CrdtRope {
             let mut scanning = false;
             let mut visited: SmallVec<[IdSpan; 4]> = Default::default();
             for (other_leaf, other_elem) in in_between.iter() {
+                // debug_log::debug_log!("Visiting {}", &other_elem.id);
                 let other_origin_left = other_elem.origin_left;
-                if other_origin_left
-                    .map(|left| visited.iter().all(|x| !x.contains_id(left)))
-                    .unwrap_or(true)
-                    && other_origin_left != content.origin_left
+                if other_origin_left != content.origin_left
+                    && other_origin_left
+                        .map(|left| visited.iter().all(|x| !x.contains_id(left)))
+                        .unwrap_or(true)
                 {
                     // The other_elem's origin_left must be at the left side of content's origin_left.
                     // So the content must be at the left side of other_elem.
+
+                    // debug_log::debug_log!("Break because the node's origin_left is at the left side of new_elem's origin left");
                     break;
                 }
 
@@ -154,13 +160,16 @@ impl CrdtRope {
 
                 if content.origin_left == other_origin_left {
                     if other_elem.origin_right == content.origin_right {
+                        // debug_log::debug_log!("Same right parent");
                         // Same right parent
                         if other_elem.id.peer > content.id.peer {
+                            // debug_log::debug_log!("Break on larger peer");
                             break;
                         } else {
                             scanning = false;
                         }
                     } else {
+                        // debug_log::debug_log!("Different right parent");
                         // Different right parent, we need to compare the right parents' position
 
                         let other_parent_right_idx =
@@ -178,14 +187,17 @@ impl CrdtRope {
                                 None
                             };
 
-                        match self.cmp_pos(parent_right_leaf, other_parent_right_idx) {
+                        match self.cmp_pos(other_parent_right_idx, parent_right_leaf) {
                             Ordering::Less => {
+                                // debug_log::debug_log!("Less");
                                 scanning = true;
                             }
                             Ordering::Equal if other_elem.id.peer > content.id.peer => {
+                                // debug_log::debug_log!("Break on eq");
                                 break;
                             }
                             _ => {
+                                // debug_log::debug_log!("Scanning");
                                 scanning = false;
                             }
                         }
@@ -193,15 +205,17 @@ impl CrdtRope {
                 }
 
                 if !scanning {
-                    debug_log::debug_log!("B");
                     insert_pos = Cursor {
                         leaf: *other_leaf,
                         offset: other_elem.rle_len(),
                     };
+                    // debug_log::debug_log!("updating insert pos {:?}", &insert_pos);
                 }
             }
         }
 
+        // debug_log::debug_log!("Inserting at {:?}", insert_pos);
+        // debug_log::group_end!();
         let (cursor, splitted) = self.tree.insert_by_path(insert_pos, content);
         InsertResult {
             content,

--- a/crates/loro-internal/src/dag.rs
+++ b/crates/loro-internal/src/dag.rs
@@ -12,7 +12,6 @@ use std::{
     fmt::Debug,
 };
 
-use debug_log::debug_dbg;
 use fxhash::{FxHashMap, FxHashSet};
 use loro_common::IdSpanVector;
 use rle::{HasLength, Sliceable};
@@ -350,7 +349,6 @@ where
     let mut b_count = b_ids.len();
     let mut min = None;
     while let Some((node, mut node_type)) = queue.pop() {
-        debug_dbg!(&node);
         match node_type {
             NodeType::A => a_count -= 1,
             NodeType::B => b_count -= 1,

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -476,7 +476,7 @@ pub fn test_multi_sites_refactored(site_num: u8, actions: &mut [Action]) {
     let mut sites = Vec::new();
     for i in 0..site_num {
         let loro = LoroDoc::new();
-        loro.set_peer_id(i as u64);
+        loro.set_peer_id(i as u64).unwrap();
         sites.push(loro);
     }
 

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -72,7 +72,7 @@ struct Actor {
 impl Actor {
     fn new(id: PeerID) -> Self {
         let app = LoroDoc::new();
-        app.set_peer_id(id);
+        app.set_peer_id(id).unwrap();
         let mut actor = Actor {
             peer: id,
             loro: app,

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -74,7 +74,7 @@ struct Actor {
 impl Actor {
     fn new(id: PeerID) -> Self {
         let app = LoroDoc::new();
-        app.set_peer_id(id);
+        app.set_peer_id(id).unwrap();
         let mut default_tree_tracker = FxHashMap::default();
         default_tree_tracker.insert(TreeID::delete_root().unwrap(), None);
         let mut actor = Actor {

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1087,9 +1087,9 @@ mod test {
     #[test]
     fn import() {
         let loro = LoroDoc::new();
-        loro.set_peer_id(1);
+        loro.set_peer_id(1).unwrap();
         let loro2 = LoroDoc::new();
-        loro2.set_peer_id(2);
+        loro2.set_peer_id(2).unwrap();
 
         let mut txn = loro.txn().unwrap();
         let text = txn.get_text("hello");
@@ -1113,9 +1113,9 @@ mod test {
     #[test]
     fn richtext_handler() {
         let mut loro = LoroDoc::new();
-        loro.set_peer_id(1);
+        loro.set_peer_id(1).unwrap();
         let loro2 = LoroDoc::new();
-        loro2.set_peer_id(2);
+        loro2.set_peer_id(2).unwrap();
 
         let mut txn = loro.txn().unwrap();
         let text = txn.get_text("hello");
@@ -1243,7 +1243,7 @@ mod test {
     #[test]
     fn tree_meta() {
         let loro = LoroDoc::new();
-        loro.set_peer_id(1);
+        loro.set_peer_id(1).unwrap();
         let tree = loro.get_tree("root");
         let id = loro.with_txn(|txn| tree.create(txn)).unwrap();
         loro.with_txn(|txn| {

--- a/crates/loro-internal/src/oplog/pending_changes.rs
+++ b/crates/loro-internal/src/oplog/pending_changes.rs
@@ -260,9 +260,9 @@ mod test {
     #[test]
     fn import_pending() {
         let a = LoroDoc::new();
-        a.set_peer_id(1);
+        a.set_peer_id(1).unwrap();
         let b = LoroDoc::new();
-        b.set_peer_id(2);
+        b.set_peer_id(2).unwrap();
         let text_a = a.get_text("text");
         a.with_txn(|txn| text_a.insert(txn, 0, "a")).unwrap();
 
@@ -290,9 +290,9 @@ mod test {
     #[test]
     fn pending_import_snapshot() {
         let a = LoroDoc::new();
-        a.set_peer_id(1);
+        a.set_peer_id(1).unwrap();
         let b = LoroDoc::new();
-        b.set_peer_id(2);
+        b.set_peer_id(2).unwrap();
         let text_a = a.get_text("text");
         a.with_txn(|txn| text_a.insert(txn, 0, "a")).unwrap();
         let update1 = a.export_snapshot();
@@ -312,13 +312,13 @@ mod test {
         //        \    /
         // b:       b1
         let a = LoroDoc::new();
-        a.set_peer_id(1);
+        a.set_peer_id(1).unwrap();
         let b = LoroDoc::new();
-        b.set_peer_id(2);
+        b.set_peer_id(2).unwrap();
         let c = LoroDoc::new();
-        c.set_peer_id(3);
+        c.set_peer_id(3).unwrap();
         let d = LoroDoc::new();
-        d.set_peer_id(4);
+        d.set_peer_id(4).unwrap();
         let text_a = a.get_text("text");
         let text_b = b.get_text("text");
         a.with_txn(|txn| text_a.insert(txn, 0, "a")).unwrap();
@@ -353,11 +353,11 @@ mod test {
         // In this case, c apply b's change first, then apply all the changes from a.
         // C is expected to have the same content as a, after a imported b's change
         let a = LoroDoc::new();
-        a.set_peer_id(1);
+        a.set_peer_id(1).unwrap();
         let b = LoroDoc::new();
-        b.set_peer_id(2);
+        b.set_peer_id(2).unwrap();
         let c = LoroDoc::new();
-        c.set_peer_id(3);
+        c.set_peer_id(3).unwrap();
         let text_a = a.get_text("text");
         let text_b = b.get_text("text");
         a.with_txn(|txn| text_a.insert(txn, 0, "1")).unwrap();

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -280,7 +280,6 @@ impl ContainerState for RichtextState {
             unreachable!()
         };
 
-        debug_log::debug_dbg!(&richtext);
         let mut style_starts: FxHashMap<Arc<StyleOp>, usize> = FxHashMap::default();
         let mut entity_index = 0;
         for span in richtext.vec.iter() {

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -408,6 +408,10 @@ impl Transaction {
             counter: self.next_counter,
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.local_ops.is_empty()
+    }
 }
 
 impl Drop for Transaction {

--- a/crates/loro-internal/tests/autocommit.rs
+++ b/crates/loro-internal/tests/autocommit.rs
@@ -40,7 +40,7 @@ fn auto_commit_list() {
 #[test]
 fn auto_commit_with_checkout() {
     let mut doc = LoroDoc::default();
-    doc.set_peer_id(1);
+    doc.set_peer_id(1).unwrap();
     doc.start_auto_commit();
     let map = doc.get_map("a");
     map.insert_("0", 0.into()).unwrap();

--- a/crates/loro-internal/tests/fugue.rs
+++ b/crates/loro-internal/tests/fugue.rs
@@ -1,0 +1,90 @@
+use loro_common::LoroResult;
+use loro_internal::{LoroDoc, ToJson};
+use serde_json::json;
+
+#[test]
+fn test_forward_interleaving() -> LoroResult<()> {
+    let a = LoroDoc::new_auto_commit();
+    a.set_peer_id(0)?;
+    a.get_text("text").insert_(0, "Hello")?;
+    let b = LoroDoc::new_auto_commit();
+    b.set_peer_id(1)?;
+    b.get_text("text").insert_(0, " World!")?;
+    a.merge(&b)?;
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({"text": "Hello World!"})
+    );
+    Ok(())
+}
+
+#[test]
+fn test_backward_interleaving() -> LoroResult<()> {
+    let a = LoroDoc::new_auto_commit();
+    a.set_peer_id(0)?;
+    a.get_text("text").insert_(0, "o")?;
+    a.get_text("text").insert_(0, "l")?;
+    a.get_text("text").insert_(0, "l")?;
+    a.get_text("text").insert_(0, "e")?;
+    a.get_text("text").insert_(0, "H")?;
+    dbg!(a.get_deep_value());
+    let b = LoroDoc::new_auto_commit();
+    b.set_peer_id(1)?;
+    b.get_text("text").insert_(0, "!")?;
+    b.get_text("text").insert_(0, "d")?;
+    b.get_text("text").insert_(0, "l")?;
+    b.get_text("text").insert_(0, "r")?;
+    b.get_text("text").insert_(0, "o")?;
+    b.get_text("text").insert_(0, "W")?;
+    b.get_text("text").insert_(0, " ")?;
+    dbg!(b.get_deep_value());
+    a.merge(&b)?;
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({"text": "Hello World!"})
+    );
+    Ok(())
+}
+
+#[test]
+fn test_forward_backward() -> LoroResult<()> {
+    let a = LoroDoc::new_auto_commit();
+    a.set_peer_id(0)?;
+    a.get_text("text").insert_(0, "ll")?;
+    a.get_text("text").insert_(0, "He")?;
+    a.get_text("text").insert_(4, "o")?;
+    let b = LoroDoc::new_auto_commit();
+    b.set_peer_id(1)?;
+    b.get_text("text").insert_(0, " !")?;
+    b.get_text("text").insert_(1, "W")?;
+    b.get_text("text").insert_(2, "d")?;
+    b.get_text("text").insert_(2, "l")?;
+    b.get_text("text").insert_(2, "r")?;
+    b.get_text("text").insert_(2, "o")?;
+    a.merge(&b)?;
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({"text": "Hello World!"})
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_yjs_interleave() -> LoroResult<()> {
+    // As stated in the Fugue paper, Yjs has a interleaving anomaly in the following case:
+    let a = LoroDoc::new_auto_commit();
+    a.set_peer_id(0)?;
+    let b = LoroDoc::new_auto_commit();
+    b.set_peer_id(1)?;
+    let c = LoroDoc::new_auto_commit();
+    c.set_peer_id(2)?;
+    c.get_text("text").insert_(0, "2")?;
+    a.merge(&c)?;
+    a.get_text("text").insert_(0, "1")?;
+    // b should not be between a and c
+    b.get_text("text").insert_(0, "b")?;
+    a.merge(&b)?;
+    assert_eq!(a.get_deep_value().to_json_value(), json!({"text": "b12"}));
+    Ok(())
+}

--- a/crates/loro-internal/tests/richtext.rs
+++ b/crates/loro-internal/tests/richtext.rs
@@ -6,7 +6,7 @@ use loro_internal::{container::richtext::TextStyleInfoFlag, LoroDoc, ToJson};
 
 fn init(s: &str) -> LoroDoc {
     let doc = LoroDoc::default();
-    doc.set_peer_id(1);
+    doc.set_peer_id(1).unwrap();
     let richtext = doc.get_text("r");
     doc.with_txn(|txn| richtext.insert(txn, 0, s)).unwrap();
     doc
@@ -14,7 +14,7 @@ fn init(s: &str) -> LoroDoc {
 
 fn clone(doc: &LoroDoc, peer_id: u64) -> LoroDoc {
     let doc2 = LoroDoc::default();
-    doc2.set_peer_id(peer_id);
+    doc2.set_peer_id(peer_id).unwrap();
     doc2.import(&doc.export_from(&Default::default())).unwrap();
     doc2
 }

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -27,9 +27,9 @@ fn test_pending() {
 #[test]
 fn test_checkout() {
     let mut doc_0 = LoroDoc::new();
-    doc_0.set_peer_id(0);
+    doc_0.set_peer_id(0).unwrap();
     let doc_1 = LoroDoc::new();
-    doc_1.set_peer_id(1);
+    doc_1.set_peer_id(1).unwrap();
 
     let value: Arc<Mutex<LoroValue>> = Arc::new(Mutex::new(LoroValue::Map(Default::default())));
     let root_value = value.clone();
@@ -328,7 +328,7 @@ fn map_concurrent_checkout() {
 fn tree_checkout() {
     let mut doc_a = LoroDoc::new();
     doc_a.subscribe_deep(Arc::new(|_e| {}));
-    doc_a.set_peer_id(1);
+    doc_a.set_peer_id(1).unwrap();
     let tree = doc_a.get_tree("root");
     let id1 = doc_a.with_txn(|txn| tree.create(txn)).unwrap();
     let id2 = doc_a.with_txn(|txn| tree.create_and_mov(txn, id1)).unwrap();


### PR DESCRIPTION
The original content has a reversed comparison for right parents, which causes the interleaving anomalies when inserting text in a backward order.