### PR TITLE
refactor: use better repr for container id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,16 +854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jumprope"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829c74fe88dda0d2a5425b022b44921574a65c4eb78e6e39a61b40eb416a4ef8"
-dependencies = [
- "rand",
- "str_indices",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,7 +954,6 @@ dependencies = [
  "im",
  "itertools 0.11.0",
  "js-sys",
- "jumprope",
  "loro-common",
  "loro-preload",
  "miniz_oxide 0.7.1",
@@ -1874,12 +1863,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "str_indices"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
 
 [[package]]
 name = "string_cache"

--- a/crates/loro-common/src/id.rs
+++ b/crates/loro-common/src/id.rs
@@ -9,13 +9,13 @@ use std::{
 
 impl Debug for ID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(format!("c{}:{}", self.peer, self.counter).as_str())
+        f.write_str(format!("{}@{}", self.counter, self.peer).as_str())
     }
 }
 
 impl Display for ID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(format!("{}@{}", self.counter, self.peer).as_str())
+        f.write_str(format!("{}@{:X}", self.counter, self.peer).as_str())
     }
 }
 
@@ -23,16 +23,17 @@ impl TryFrom<&str> for ID {
     type Error = LoroError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let splitted: Vec<_> = value.split('@').collect();
-        if splitted.len() != 2 {
+        if value.split('@').count() != 2 {
             return Err(LoroError::DecodeError("Invalid ID format".into()));
         }
 
-        let counter = splitted[0]
+        let mut iter = value.split('@');
+        let counter = iter
+            .next()
+            .unwrap()
             .parse::<Counter>()
             .map_err(|_| LoroError::DecodeError("Invalid ID format".into()))?;
-        let client_id = splitted[1]
-            .parse::<PeerID>()
+        let client_id = u64::from_str_radix(iter.next().unwrap(), 16)
             .map_err(|_| LoroError::DecodeError("Invalid ID format".into()))?;
         Ok(ID {
             peer: client_id,

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -33,7 +33,6 @@ append-only-bytes = { version = "0.1.12", features = ["u32_range"] }
 itertools = "0.11.0"
 enum_dispatch = "0.3.11"
 im = "15.1.0"
-jumprope = { version = "1.1.2", features = ["wchar_conversion"] }
 generic-btree = { version = "0.8.2" }
 miniz_oxide = "0.7.1"
 getrandom = "0.2.10"

--- a/crates/loro-internal/src/container.rs
+++ b/crates/loro-internal/src/container.rs
@@ -67,9 +67,9 @@ pub mod idx {
 
 pub mod list;
 pub mod map;
-pub mod tree;
 pub mod richtext;
 pub(crate) mod text;
+pub mod tree;
 
 use idx::ContainerIdx;
 
@@ -183,19 +183,19 @@ mod test {
     fn container_id_convert() {
         let container_id = ContainerID::new_normal(ID::new(12, 12), ContainerType::List);
         let s = container_id.to_string();
-        assert_eq!(s, "12@12:List");
+        assert_eq!(s, "cid:12@C:List");
         let actual = ContainerID::try_from(s.as_str()).unwrap();
         assert_eq!(actual, container_id);
 
         let container_id = ContainerID::new_root("123", ContainerType::Map);
         let s = container_id.to_string();
-        assert_eq!(s, "/123:Map");
+        assert_eq!(s, "cid:root-123:Map");
         let actual = ContainerID::try_from(s.as_str()).unwrap();
         assert_eq!(actual, container_id);
 
         let container_id = ContainerID::new_root("kkk", ContainerType::Text);
         let s = container_id.to_string();
-        assert_eq!(s, "/kkk:Text");
+        assert_eq!(s, "cid:root-kkk:Text");
         let actual = ContainerID::try_from(s.as_str()).unwrap();
         assert_eq!(actual, container_id);
     }

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -164,6 +164,12 @@ impl Loro {
         self.0.peer_id()
     }
 
+    /// Get peer id in hex string.
+    #[wasm_bindgen(js_name = "peerIdStr", method, getter)]
+    pub fn peer_id_str(&self) -> String {
+        format!("{:X}", self.0.peer_id())
+    }
+
     #[wasm_bindgen(js_name = "getText")]
     pub fn get_text(&self, name: &str) -> JsResult<LoroText> {
         let text = self.0.get_text(name);
@@ -699,7 +705,7 @@ impl LoroTree {
     pub fn create(&mut self, parent: Option<JsTreeID>) -> JsResult<JsTreeID> {
         let id = if let Some(p) = parent {
             let parent: JsValue = p.into();
-            self.0.create_and_mov_(parent.try_into().unwrap())?
+            self.0.create_and_mov_(parent.try_into().unwrap_throw())?
         } else {
             self.0.create_()?
         };
@@ -797,9 +803,9 @@ impl LoroTree {
 const TYPES: &'static str = r#"
 export type ContainerType = "Text" | "Map" | "List"| "Tree";
 export type ContainerID =
-  | `/${string}:${ContainerType}`
-  | `${number}@${number}:${ContainerType}`;
-export type TreeID = `${number}@${number}`;
+  | `cid:root-${string}:${ContainerType}`
+  | `cid:${number}@${string}:${ContainerType}`;
+export type TreeID = `${number}@${string}`;
 
 interface Loro {
     exportFrom(version?: Uint8Array): Uint8Array;

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -11,13 +11,7 @@ export {
 import { Delta, PrelimMap } from "loro-wasm";
 import { PrelimText } from "loro-wasm";
 import { PrelimList } from "loro-wasm";
-import {
-  ContainerID,
-  Loro,
-  LoroList,
-  LoroMap,
-  LoroText,
-} from "loro-wasm";
+import { ContainerID, Loro, LoroList, LoroMap, LoroText } from "loro-wasm";
 
 export type { ContainerID, ContainerType } from "loro-wasm";
 
@@ -95,27 +89,7 @@ interface Listener {
 const CONTAINER_TYPES = ["Map", "Text", "List"];
 
 export function isContainerId(s: string): s is ContainerID {
-  try {
-    if (s.startsWith("/")) {
-      const [_, type] = s.slice(1).split(":");
-      if (!CONTAINER_TYPES.includes(type)) {
-        return false;
-      }
-    } else {
-      const [id, type] = s.split(":");
-      if (!CONTAINER_TYPES.includes(type)) {
-        return false;
-      }
-
-      const [counter, client] = id.split("@");
-      Number.parseInt(counter);
-      Number.parseInt(client);
-    }
-
-    return true;
-  } catch (e) {
-    return false;
-  }
+  return s.startsWith("cid:");
 }
 
 export { Loro };
@@ -142,40 +116,22 @@ declare module "loro-wasm" {
 
     get(index: number): Value;
     getTyped<Key extends keyof T & number>(loro: Loro, index: Key): T[Key];
-    insertTyped<Key extends keyof T & number>(
-      pos: Key,
-      value: T[Key],
-    ): void;
+    insertTyped<Key extends keyof T & number>(pos: Key, value: T[Key]): void;
     insert(pos: number, value: Value | Prelim): void;
     delete(pos: number, len: number): void;
     subscribe(txn: Loro, listener: Listener): number;
   }
 
   interface LoroMap<T extends Record<string, any> = Record<string, any>> {
-    insertContainer(
-      key: string,
-      container_type: "Map",
-    ): LoroMap;
-    insertContainer(
-      key: string,
-      container_type: "List",
-    ): LoroList;
-    insertContainer(
-      key: string,
-      container_type: "Text",
-    ): LoroText;
-    insertContainer(
-      key: string,
-      container_type: string,
-    ): never;
+    insertContainer(key: string, container_type: "Map"): LoroMap;
+    insertContainer(key: string, container_type: "List"): LoroList;
+    insertContainer(key: string, container_type: "Text"): LoroText;
+    insertContainer(key: string, container_type: string): never;
 
     get(key: string): Value;
     getTyped<Key extends keyof T & string>(txn: Loro, key: Key): T[Key];
     set(key: string, value: Value | Prelim): void;
-    setTyped<Key extends keyof T & string>(
-      key: Key,
-      value: T[Key],
-    ): void;
+    setTyped<Key extends keyof T & string>(key: Key, value: T[Key]): void;
     delete(key: string): void;
     subscribe(txn: Loro, listener: Listener): number;
   }

--- a/loro-js/tests/misc.test.ts
+++ b/loro-js/tests/misc.test.ts
@@ -167,7 +167,6 @@ describe("sync", () => {
     assertEquals(text.toString(), "a hello world");
     const map = loro.getMap("map");
     map.set("key", "value");
-
   });
 });
 
@@ -224,9 +223,17 @@ describe("prelim", () => {
       list.insert(2, prelim_list);
       loro.commit();
 
-      assertEquals(list.getDeepValue(), ["ttt", { a: 1, b: 2 }, [1, "2", {
-        a: 4,
-      }]]);
+      assertEquals(list.getDeepValue(), [
+        "ttt",
+        { a: 1, b: 2 },
+        [
+          1,
+          "2",
+          {
+            a: 4,
+          },
+        ],
+      ]);
     });
   });
 });
@@ -315,16 +322,15 @@ describe("tree", () => {
     const childID = tree.create(id);
     console.log(typeof id);
     assertEquals(tree.parent(childID), id);
-  })
+  });
 
   it("meta", () => {
-    const id = tree.create()
+    const id = tree.create();
     const meta = tree.getMeta(id);
     meta.set("a", 123);
     assertEquals(meta.get("a"), 123);
-
-  })
-})
+  });
+});
 
 function one_ms(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 1));


### PR DESCRIPTION
ContainerID's string representation has been modified as follows:

- `cid:root-name:Map` represents a root container named "name" with the type "Map."
- `cid:10@FF:Text` represents a standard container with an `OpID` consisting of a peerId equal to 255 and a counter of 10, and the container's type is Text.