### PR TITLE
Refactor: Extract text chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,15 +529,9 @@ dependencies = [
 
 [[package]]
 name = "debug-log"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364ff57c5031fee39b026dcdfdc9c7dc1d1d79451bfdacba90f040524b766254"
-
-[[package]]
-name = "debug-log"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d13e7dd03f70e6b332a2b42a9cdfa5b04f1015098c9656e77995c09772c947"
+checksum = "b90f9d9c0c144c4aa35a874e362392ec6aef3b9291c882484235069540b26c73"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -943,7 +937,7 @@ dependencies = [
  "crdt-list",
  "criterion 0.4.0",
  "ctor",
- "debug-log 0.2.1",
+ "debug-log",
  "dhat",
  "enum-as-inner 0.5.1",
  "enum_dispatch",
@@ -1009,7 +1003,7 @@ name = "loro-wasm"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "debug-log 0.2.1",
+ "debug-log",
  "getrandom",
  "js-sys",
  "loro-internal",
@@ -1653,7 +1647,7 @@ dependencies = [
  "color-backtrace",
  "crdt-list",
  "ctor",
- "debug-log 0.1.4",
+ "debug-log",
  "enum-as-inner 0.5.1",
  "fxhash",
  "heapless",

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -26,7 +26,7 @@ serde-wasm-bindgen = { version = "0.5.0", optional = true }
 js-sys = { version = "0.3.60", optional = true }
 serde_json = { version = "1" }
 arref = "0.1.0"
-debug-log = { version = "0.2.1", features = [] }
+debug-log = { version = "0.2.2", features = [] }
 serde_columnar = { version = "0.3.2" }
 tracing = { version = "0.1.37" }
 append-only-bytes = { version = "0.1.12", features = ["u32_range"] }

--- a/crates/loro-internal/fuzz/Cargo.lock
+++ b/crates/loro-internal/fuzz/Cargo.lock
@@ -170,15 +170,9 @@ dependencies = [
 
 [[package]]
 name = "debug-log"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364ff57c5031fee39b026dcdfdc9c7dc1d1d79451bfdacba90f040524b766254"
-
-[[package]]
-name = "debug-log"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d13e7dd03f70e6b332a2b42a9cdfa5b04f1015098c9656e77995c09772c947"
+checksum = "b90f9d9c0c144c4aa35a874e362392ec6aef3b9291c882484235069540b26c73"
 dependencies = [
  "once_cell",
 ]
@@ -397,7 +391,7 @@ dependencies = [
  "arbitrary",
  "arref",
  "crdt-list",
- "debug-log 0.2.1",
+ "debug-log",
  "enum-as-inner 0.5.1",
  "enum_dispatch",
  "fxhash",
@@ -739,7 +733,7 @@ dependencies = [
  "arref",
  "bumpalo",
  "crdt-list",
- "debug-log 0.1.4",
+ "debug-log",
  "enum-as-inner 0.5.1",
  "fxhash",
  "heapless",

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -18,7 +18,6 @@ use crate::{
         EntityIndexQueryWithEventIndex, IndexQueryWithEntityIndex,
     },
     delta::{DeltaValue, Meta, StyleMeta},
-    utils::{string_slice::unicode_range_to_byte_range, utf16::count_utf16_chars},
 };
 
 // FIXME: Check splice and other things are using unicode index
@@ -50,8 +49,8 @@ impl Display for RichtextState {
         for span in self.tree.iter() {
             match span {
                 RichtextStateChunk::Style { .. } => {}
-                RichtextStateChunk::Text { text, .. } => {
-                    f.write_str(std::str::from_utf8(text).unwrap())?;
+                RichtextStateChunk::Text(s) => {
+                    f.write_str(s.as_str())?;
                 }
             }
         }
@@ -60,13 +59,256 @@ impl Display for RichtextState {
     }
 }
 
+pub(crate) use text_chunk::TextChunk;
+mod text_chunk {
+    use std::ops::Range;
+
+    use append_only_bytes::BytesSlice;
+
+    #[derive(Clone, Debug)]
+    pub(crate) struct TextChunk {
+        unicode_len: i32,
+        bytes: BytesSlice,
+        // TODO: make this field only available in wasm mode
+        utf16_len: i32,
+    }
+
+    impl TextChunk {
+        pub fn from_bytes(bytes: BytesSlice) -> Self {
+            let mut utf16_len = 0;
+            let mut unicode_len = 0;
+            for c in std::str::from_utf8(&bytes).unwrap().chars() {
+                utf16_len += c.len_utf16();
+                unicode_len += 1;
+            }
+
+            Self {
+                unicode_len,
+                bytes,
+                utf16_len: utf16_len as i32,
+            }
+        }
+
+        pub fn bytes(&self) -> &BytesSlice {
+            &self.bytes
+        }
+
+        pub fn as_str(&self) -> &str {
+            // SAFETY: We know that the text is valid UTF-8
+            unsafe { std::str::from_utf8_unchecked(&self.bytes) }
+        }
+
+        pub fn len(&self) -> i32 {
+            self.unicode_len
+        }
+
+        pub fn unicode_len(&self) -> i32 {
+            self.unicode_len
+        }
+
+        pub fn utf16_len(&self) -> i32 {
+            self.utf16_len
+        }
+
+        pub fn event_len(&self) -> i32 {
+            if cfg!(feature = "wasm") {
+                self.utf16_len
+            } else {
+                self.unicode_len
+            }
+        }
+
+        /// Convert a unicode index on this text to an event index
+        pub fn convert_unicode_offset_to_event_offset(&self, offset: usize) -> usize {
+            if cfg!(feature = "wasm") {
+                let mut event_offset = 0;
+                for (i, c) in self.as_str().chars().enumerate() {
+                    if i == offset {
+                        return event_offset;
+                    }
+                    event_offset += c.len_utf16();
+                }
+                event_offset
+            } else {
+                offset
+            }
+        }
+
+        pub fn new_empty() -> Self {
+            Self {
+                unicode_len: 0,
+                bytes: BytesSlice::empty(),
+                utf16_len: 0,
+            }
+        }
+
+        pub(crate) fn delete_by_entity_index(
+            &mut self,
+            unicode_offset: usize,
+            unicode_len: usize,
+        ) -> (Option<Self>, usize) {
+            let s = self.as_str();
+            let mut start_byte = 0;
+            let mut end_byte = self.bytes().len();
+            let start_unicode_index = unicode_offset;
+            let end_unicode_index = unicode_offset + unicode_len;
+            let mut start_utf16_index = 0;
+            let mut current_utf16_index = 0;
+            let mut current_utf8_index = 0;
+            for (current_unicode_index, c) in s.chars().enumerate() {
+                if current_unicode_index == start_unicode_index {
+                    start_utf16_index = current_utf16_index;
+                    start_byte = current_utf8_index;
+                }
+
+                if current_unicode_index == end_unicode_index {
+                    end_byte = current_utf8_index;
+                    break;
+                }
+
+                current_utf16_index += c.len_utf16();
+                current_utf8_index += c.len_utf8();
+            }
+
+            self.utf16_len -= (current_utf16_index - start_utf16_index) as i32;
+
+            let event_len = if cfg!(feature = "wasm") {
+                current_utf16_index - start_utf16_index
+            } else {
+                unicode_len
+            };
+
+            self.unicode_len -= unicode_len as i32;
+            let next = match (start_byte == 0, end_byte == self.bytes.len()) {
+                (true, true) => {
+                    self.bytes = BytesSlice::empty();
+                    None
+                }
+                (true, false) => {
+                    self.bytes.slice_(end_byte..);
+                    None
+                }
+                (false, true) => {
+                    self.bytes.slice_(..start_byte);
+                    None
+                }
+                (false, false) => {
+                    let next = self.bytes.slice_clone(end_byte..);
+                    let next = Self::from_bytes(next);
+                    self.unicode_len -= next.unicode_len;
+                    self.utf16_len -= next.utf16_len;
+                    self.bytes.slice_(..start_byte);
+                    Some(next)
+                }
+            };
+
+            self.check();
+            if let Some(next) = next.as_ref() {
+                next.check();
+            }
+            (next, event_len)
+        }
+
+        fn check(&self) {
+            if cfg!(debug_assertions) {
+                assert_eq!(self.unicode_len, self.as_str().chars().count() as i32);
+                assert_eq!(
+                    self.utf16_len,
+                    self.as_str().chars().map(|c| c.len_utf16()).sum::<usize>() as i32
+                );
+            }
+        }
+    }
+
+    impl generic_btree::rle::HasLength for TextChunk {
+        fn rle_len(&self) -> usize {
+            self.unicode_len as usize
+        }
+    }
+
+    impl generic_btree::rle::Sliceable for TextChunk {
+        fn _slice(&self, range: Range<usize>) -> Self {
+            assert!(range.start < range.end);
+            let mut utf16_len = 0;
+            let mut start = 0;
+            let mut end = 0;
+            let mut started = false;
+            for (unicode_index, (i, c)) in self.as_str().char_indices().enumerate() {
+                if unicode_index == range.start {
+                    start = i;
+                    started = true;
+                }
+                if unicode_index == range.end {
+                    end = i;
+                    break;
+                }
+                if started {
+                    utf16_len += c.len_utf16();
+                }
+            }
+
+            let ans = Self {
+                unicode_len: range.len() as i32,
+                bytes: self.bytes.slice_clone(start..end),
+                utf16_len: utf16_len as i32,
+            };
+            ans.check();
+            ans
+        }
+
+        fn split(&mut self, pos: usize) -> Self {
+            let mut utf16_len = 0;
+            let mut byte_offset = 0;
+            for (unicode_index, (i, c)) in self.as_str().char_indices().enumerate() {
+                if unicode_index == pos {
+                    byte_offset = i;
+                    break;
+                }
+
+                utf16_len += c.len_utf16();
+            }
+            let right = Self {
+                unicode_len: self.unicode_len - pos as i32,
+                bytes: self.bytes.slice_clone(byte_offset..),
+                utf16_len: self.utf16_len - utf16_len as i32,
+            };
+
+            self.unicode_len = pos as i32;
+            self.utf16_len = utf16_len as i32;
+            self.bytes.slice_(..byte_offset);
+            right.check();
+            self.check();
+            right
+        }
+    }
+
+    impl generic_btree::rle::Mergeable for TextChunk {
+        fn can_merge(&self, rhs: &Self) -> bool {
+            self.bytes.can_merge(&rhs.bytes)
+        }
+
+        fn merge_right(&mut self, rhs: &Self) {
+            self.bytes.try_merge(&rhs.bytes).unwrap();
+            self.utf16_len += rhs.utf16_len;
+            self.unicode_len += rhs.unicode_len;
+            self.check();
+        }
+
+        fn merge_left(&mut self, left: &Self) {
+            let mut new = left.bytes.clone();
+            new.try_merge(&self.bytes).unwrap();
+            self.bytes = new;
+            self.utf16_len += left.utf16_len;
+            self.unicode_len += left.unicode_len;
+            self.check();
+        }
+    }
+}
+
 // TODO: change visibility back to crate after #116 is done
 #[derive(Clone, Debug)]
-pub enum RichtextStateChunk {
-    Text {
-        unicode_len: i32,
-        text: BytesSlice,
-    },
+pub(crate) enum RichtextStateChunk {
+    Text(TextChunk),
     Style {
         style: Arc<StyleOp>,
         anchor_type: AnchorType,
@@ -75,10 +317,7 @@ pub enum RichtextStateChunk {
 
 impl RichtextStateChunk {
     pub fn new_text(s: BytesSlice) -> Self {
-        Self::Text {
-            unicode_len: std::str::from_utf8(&s).unwrap().chars().count() as i32,
-            text: s,
-        }
+        Self::Text(TextChunk::from_bytes(s))
     }
 
     pub fn new_style(style: Arc<StyleOp>, anchor_type: AnchorType) -> Self {
@@ -108,11 +347,11 @@ impl Serialize for RichtextStateChunk {
         S: serde::Serializer,
     {
         match self {
-            RichtextStateChunk::Text { unicode_len, .. } => {
+            RichtextStateChunk::Text(text) => {
                 let mut state = serializer.serialize_struct("RichtextStateChunk", 3)?;
                 state.serialize_field("type", "Text")?;
-                state.serialize_field("unicode_len", unicode_len)?;
-                state.serialize_field("text", self.as_str().unwrap())?;
+                state.serialize_field("unicode_len", &text.unicode_len())?;
+                state.serialize_field("text", text.as_str())?;
                 state.end()
             }
             RichtextStateChunk::Style { style, anchor_type } => {
@@ -128,10 +367,8 @@ impl Serialize for RichtextStateChunk {
 
 impl RichtextStateChunk {
     pub fn try_from_bytes(s: BytesSlice) -> Result<Self, Utf8Error> {
-        Ok(RichtextStateChunk::Text {
-            unicode_len: std::str::from_utf8(&s)?.chars().count() as i32,
-            text: s,
-        })
+        std::str::from_utf8(&s)?;
+        Ok(RichtextStateChunk::Text(TextChunk::from_bytes(s)))
     }
 
     pub fn from_style(style: Arc<StyleOp>, anchor_type: AnchorType) -> Self {
@@ -140,10 +377,7 @@ impl RichtextStateChunk {
 
     pub fn as_str(&self) -> Option<&str> {
         match self {
-            RichtextStateChunk::Text { text, .. } => {
-                // SAFETY: We know that the text is valid UTF-8
-                Some(unsafe { std::str::from_utf8_unchecked(text) })
-            }
+            RichtextStateChunk::Text(text) => Some(text.as_str()),
             _ => None,
         }
     }
@@ -152,7 +386,7 @@ impl RichtextStateChunk {
 impl HasLength for RichtextStateChunk {
     fn rle_len(&self) -> usize {
         match self {
-            RichtextStateChunk::Text { unicode_len, .. } => *unicode_len as usize,
+            RichtextStateChunk::Text(s) => s.rle_len(),
             RichtextStateChunk::Style { .. } => 1,
         }
     }
@@ -161,44 +395,22 @@ impl HasLength for RichtextStateChunk {
 impl Mergeable for RichtextStateChunk {
     fn can_merge(&self, rhs: &Self) -> bool {
         match (self, rhs) {
-            (
-                RichtextStateChunk::Text { text: l, .. },
-                RichtextStateChunk::Text { text: r, .. },
-            ) => l.can_merge(r),
+            (RichtextStateChunk::Text(l), RichtextStateChunk::Text(r)) => l.can_merge(r),
             _ => false,
         }
     }
 
     fn merge_right(&mut self, rhs: &Self) {
         match (self, rhs) {
-            (
-                RichtextStateChunk::Text { unicode_len, text },
-                RichtextStateChunk::Text {
-                    unicode_len: rhs_len,
-                    text: rhs_text,
-                },
-            ) => {
-                *unicode_len += *rhs_len;
-                text.try_merge(rhs_text).unwrap();
-            }
+            (RichtextStateChunk::Text(l), RichtextStateChunk::Text(r)) => l.merge_right(r),
             _ => unreachable!(),
         }
     }
 
     fn merge_left(&mut self, left: &Self) {
         match (self, left) {
-            (
-                RichtextStateChunk::Text { unicode_len, text },
-                RichtextStateChunk::Text {
-                    unicode_len: left_len,
-                    text: left_text,
-                },
-            ) => {
-                *unicode_len += *left_len;
-                // TODO: small PERF improvement
-                let mut new_text = left_text.clone();
-                new_text.try_merge(text).unwrap();
-                *text = new_text;
+            (RichtextStateChunk::Text(this), RichtextStateChunk::Text(left)) => {
+                this.merge_left(left)
             }
             _ => unreachable!(),
         }
@@ -207,48 +419,22 @@ impl Mergeable for RichtextStateChunk {
 
 impl Sliceable for RichtextStateChunk {
     fn _slice(&self, range: Range<usize>) -> Self {
-        let start_index = range.start;
-        let end_index = range.end;
-
-        let text = match self {
-            RichtextStateChunk::Text {
-                unicode_len: _,
-                text,
-            } => text,
+        match self {
+            RichtextStateChunk::Text(s) => RichtextStateChunk::Text(s._slice(range)),
             RichtextStateChunk::Style { style, anchor_type } => {
-                assert_eq!(start_index, 0);
-                assert_eq!(end_index, 1);
-                return RichtextStateChunk::Style {
+                assert_eq!(range.start, 0);
+                assert_eq!(range.end, 1);
+                RichtextStateChunk::Style {
                     style: style.clone(),
                     anchor_type: *anchor_type,
-                };
+                }
             }
-        };
-
-        let s = std::str::from_utf8(text).unwrap();
-        let from = unicode_to_utf8_index(s, start_index).unwrap();
-        let len = unicode_to_utf8_index(&s[from..], end_index - start_index).unwrap();
-        let to = from + len;
-        RichtextStateChunk::Text {
-            unicode_len: (end_index - start_index) as i32,
-            text: text.slice_clone(from..to),
         }
     }
 
     fn split(&mut self, pos: usize) -> Self {
         match self {
-            RichtextStateChunk::Text { unicode_len, text } => {
-                let s = std::str::from_utf8(text).unwrap();
-                let byte_pos = unicode_to_utf8_index(s, pos).unwrap();
-                let right = text.slice_clone(byte_pos..);
-                let ans = RichtextStateChunk::Text {
-                    unicode_len: *unicode_len - pos as i32,
-                    text: right,
-                };
-                *text = text.slice_clone(..byte_pos);
-                *unicode_len = pos as i32;
-                ans
-            }
+            RichtextStateChunk::Text(s) => RichtextStateChunk::Text(s.split(pos)),
             RichtextStateChunk::Style { .. } => {
                 unreachable!()
             }
@@ -330,11 +516,13 @@ pub(crate) fn utf16_to_unicode_index(s: &str, utf16_index: usize) -> Result<usiz
             return Ok(i + 1);
         }
         if current_utf16_index > utf16_index {
+            debug_log::debug_log!("WARNING: UTF16 MISMATCHED!");
             return Err(i);
         }
         current_unicode_index = i + 1;
     }
 
+    debug_log::debug_log!("WARNING: UTF16 MISMATCHED!");
     Err(current_unicode_index)
 }
 
@@ -454,11 +642,11 @@ impl BTreeTrait for RichtextTreeTrait {
     #[inline]
     fn get_elem_cache(elem: &Self::Elem) -> Self::Cache {
         match elem {
-            RichtextStateChunk::Text { unicode_len, text } => PosCache {
-                bytes: text.len() as i32,
-                unicode_len: *unicode_len,
-                utf16_len: count_utf16_chars(text) as i32,
-                entity_len: *unicode_len,
+            RichtextStateChunk::Text(s) => PosCache {
+                bytes: s.bytes().len() as i32,
+                unicode_len: s.unicode_len(),
+                utf16_len: s.utf16_len(),
+                entity_len: s.unicode_len(),
             },
             RichtextStateChunk::Style { .. } => PosCache {
                 bytes: 0,
@@ -521,10 +709,7 @@ mod query {
 
         fn get_elem_len(elem: &<RichtextTreeTrait as BTreeTrait>::Elem) -> usize {
             match elem {
-                RichtextStateChunk::Text {
-                    unicode_len,
-                    text: _,
-                } => *unicode_len as usize,
+                RichtextStateChunk::Text(s) => s.rle_len(),
                 RichtextStateChunk::Style { .. } => 0,
             }
         }
@@ -534,11 +719,8 @@ mod query {
             elem: &<RichtextTreeTrait as BTreeTrait>::Elem,
         ) -> (usize, bool) {
             match elem {
-                RichtextStateChunk::Text {
-                    unicode_len,
-                    text: _,
-                } => {
-                    if *unicode_len as usize >= left {
+                RichtextStateChunk::Text(s) => {
+                    if s.rle_len() >= left {
                         return (left, true);
                     }
 
@@ -563,10 +745,7 @@ mod query {
 
         fn get_elem_len(elem: &<RichtextTreeTrait as BTreeTrait>::Elem) -> usize {
             match elem {
-                RichtextStateChunk::Text {
-                    unicode_len: _,
-                    text,
-                } => count_utf16_chars(text),
+                RichtextStateChunk::Text(s) => s.utf16_len() as usize,
                 RichtextStateChunk::Style { .. } => 0,
             }
         }
@@ -576,20 +755,14 @@ mod query {
             elem: &<RichtextTreeTrait as BTreeTrait>::Elem,
         ) -> (usize, bool) {
             match elem {
-                RichtextStateChunk::Text {
-                    unicode_len: _,
-                    text,
-                } => {
+                RichtextStateChunk::Text(s) => {
                     if left == 0 {
                         return (0, true);
                     }
 
-                    // TODO: extract this behavior to a dedicated type
-                    // SAFETY: we know that `text` is valid utf8
-                    let s = unsafe { std::str::from_utf8_unchecked(text) };
                     // Allow left to not at the correct utf16 boundary. If so fallback to the last position.
                     // TODO: if we remove the use of query(pos-1), we won't need this fallback behaviro
-                    let offset = utf16_to_unicode_index(s, left).unwrap_or_else(|e| e);
+                    let offset = utf16_to_unicode_index(s.as_str(), left).unwrap_or_else(|e| e);
                     (offset, true)
                 }
                 RichtextStateChunk::Style { .. } => (1, false),
@@ -611,10 +784,7 @@ mod query {
 
         fn get_elem_len(elem: &<RichtextTreeTrait as BTreeTrait>::Elem) -> usize {
             match elem {
-                RichtextStateChunk::Text {
-                    unicode_len,
-                    text: _,
-                } => *unicode_len as usize,
+                RichtextStateChunk::Text(s) => s.rle_len(),
                 RichtextStateChunk::Style { .. } => 1,
             }
         }
@@ -624,11 +794,8 @@ mod query {
             elem: &<RichtextTreeTrait as BTreeTrait>::Elem,
         ) -> (usize, bool) {
             match elem {
-                RichtextStateChunk::Text {
-                    unicode_len,
-                    text: _,
-                } => {
-                    if *unicode_len as usize >= left {
+                RichtextStateChunk::Text(s) => {
+                    if s.rle_len() >= left {
                         return (left, true);
                     }
 
@@ -1035,26 +1202,18 @@ impl RichtextState {
             self.tree
                 .visit_previous_caches(cursor, |cache| match cache {
                     generic_btree::PreviousCache::NodeCache(c) => {
-                        ans += c.unicode_len as usize;
+                        ans += c.utf16_len as usize;
                     }
                     generic_btree::PreviousCache::PrevSiblingElem(c) => match c {
-                        RichtextStateChunk::Text { text, .. } => {
-                            ans += count_utf16_chars(text);
+                        RichtextStateChunk::Text(s) => {
+                            ans += s.utf16_len() as usize;
                         }
                         RichtextStateChunk::Style { .. } => {}
                     },
                     generic_btree::PreviousCache::ThisElemAndOffset { elem, offset } => {
                         match elem {
-                            RichtextStateChunk::Text {
-                                unicode_len: _,
-                                text,
-                            } => {
-                                ans += unicode_to_utf16_index(
-                                    // SAFETY: we're sure that the text is valid utf8
-                                    unsafe { std::str::from_utf8_unchecked(text) },
-                                    offset,
-                                )
-                                .unwrap();
+                            RichtextStateChunk::Text(s) => {
+                                ans += s.convert_unicode_offset_to_event_offset(offset);
                             }
                             RichtextStateChunk::Style { .. } => {}
                         }
@@ -1070,8 +1229,8 @@ impl RichtextState {
                         ans += c.unicode_len;
                     }
                     generic_btree::PreviousCache::PrevSiblingElem(c) => match c {
-                        RichtextStateChunk::Text { unicode_len, .. } => {
-                            ans += *unicode_len;
+                        RichtextStateChunk::Text(s) => {
+                            ans += s.unicode_len();
                         }
                         RichtextStateChunk::Style { .. } => {}
                     },
@@ -1290,6 +1449,7 @@ impl RichtextState {
                     .cursor,
             ),
         };
+
         // TODO: assert end cursor is valid
         let mut entity_index = self.get_entity_index_from_path(start);
         for span in self.tree.iter_range(start..end) {
@@ -1351,77 +1511,13 @@ impl RichtextState {
             // drop in place
             let mut event_len = 0;
             self.tree.update_leaf(start_cursor.leaf, |elem| match elem {
-                RichtextStateChunk::Text { unicode_len, text } => {
-                    // SAFETY: we're sure this is a valid utf8 string
-                    let s = unsafe { std::str::from_utf8_unchecked(text.as_ref()) };
-                    let mut start_byte = 0;
-                    let mut end_byte = text.len();
-                    if cfg!(feature = "wasm") {
-                        event_len = len;
-                        let (s, e) = unicode_range_to_byte_range(
-                            text,
-                            start_cursor.offset,
-                            start_cursor.offset + len,
-                        );
-                        start_byte = s;
-                        end_byte = e;
-                    } else {
-                        event_len = 'e: {
-                            let start_unicode_index = start_cursor.offset;
-                            let end_unicode_index = start_cursor.offset + len;
-                            let mut start_utf16_index = 0;
-                            let mut current_utf16_index = 0;
-                            let mut current_utf8_index = 0;
-                            for (current_unicode_index, c) in s.chars().enumerate() {
-                                if current_unicode_index == start_unicode_index {
-                                    start_utf16_index = current_utf16_index;
-                                    start_byte = current_utf8_index;
-                                }
-
-                                if current_unicode_index == end_unicode_index {
-                                    end_byte = current_utf8_index;
-                                    break 'e current_utf16_index - start_utf16_index;
-                                }
-
-                                current_utf16_index += c.len_utf16();
-                                current_utf8_index += c.len_utf8();
-                            }
-
-                            current_utf16_index - start_utf16_index
-                        }
-                    }
-
-                    *unicode_len -= len as i32;
-                    let next = match (start_byte == 0, end_byte == text.len()) {
-                        (true, true) => {
-                            *text = BytesSlice::empty();
-                            None
-                        }
-                        (true, false) => {
-                            *text = text.slice_clone(end_byte..);
-                            None
-                        }
-                        (false, true) => {
-                            *text = text.slice_clone(..start_byte);
-                            None
-                        }
-                        (false, false) => {
-                            let next = text.slice_clone(end_byte..);
-                            let next = RichtextStateChunk::new_text(next);
-                            *unicode_len -= next.rle_len() as i32;
-                            *text = text.slice_clone(..start_byte);
-                            Some(next)
-                        }
-                    };
-
-                    (true, next, None)
+                RichtextStateChunk::Text(text) => {
+                    let (next, event_len_) = text.delete_by_entity_index(start_cursor.offset, len);
+                    event_len = event_len_;
+                    (true, next.map(RichtextStateChunk::Text), None)
                 }
                 RichtextStateChunk::Style { .. } => {
-                    *elem = RichtextStateChunk::Text {
-                        unicode_len: 0,
-                        text: BytesSlice::empty(),
-                    };
-
+                    *elem = RichtextStateChunk::Text(TextChunk::new_empty());
                     (true, None, None)
                 }
             });
@@ -1469,7 +1565,7 @@ impl RichtextState {
             cur_style_range.as_ref().map(|x| x.1.clone().into());
 
         self.tree.iter().filter_map(move |x| match x {
-            RichtextStateChunk::Text { unicode_len, text } => {
+            RichtextStateChunk::Text(s) => {
                 let mut styles = Default::default();
                 while let Some((inner_cur_range, _)) = cur_style_range.as_ref() {
                     if entity_index < inner_cur_range.start {
@@ -1485,9 +1581,9 @@ impl RichtextState {
                     }
                 }
 
-                entity_index += *unicode_len as usize;
+                entity_index += s.rle_len();
                 Some(RichtextSpan {
-                    text: text.clone().into(),
+                    text: s.bytes().clone().into(),
                     attributes: styles,
                 })
             }

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -70,7 +70,6 @@ impl Tracker {
     }
 
     pub(crate) fn insert(&mut self, op_id: ID, pos: usize, content: RichtextChunk) {
-        debug_log::debug_dbg!(&self, op_id, pos, &content);
         if self.applied_vv.includes_id(op_id) {
             let last_id = op_id.inc(content.len() as Counter - 1);
             assert!(self.applied_vv.includes_id(last_id));
@@ -129,7 +128,6 @@ impl Tracker {
 
     /// If `reverse` is true, the deletion happens from the end of the range to the start.
     pub(crate) fn delete(&mut self, op_id: ID, pos: usize, len: usize, reverse: bool) {
-        debug_log::debug_dbg!(&self, op_id, pos, len);
         if self.applied_vv.includes_id(op_id) {
             let last_id = op_id.inc(len as Counter - 1);
             assert!(self.applied_vv.includes_id(last_id));
@@ -275,7 +273,6 @@ impl Tracker {
     ) -> impl Iterator<Item = CrdtRopeDelta> + '_ {
         self._checkout(from, false);
         self._checkout(to, true);
-        debug_log::debug_dbg!(from, to, &self);
         // self.id_to_cursor.diagnose();
         self.rope.get_diff()
     }

--- a/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
+++ b/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
@@ -352,7 +352,6 @@ impl CrdtRope {
             while let Some((index, elem)) = iter.next() {
                 // The elements will not be changed by this method.
                 // This index is current index of the elem (calculated by `status` field rather than `diff_status` field)
-                debug_log::debug_dbg!(&index, &elem);
                 match elem.diff() {
                     DiffStatus::NotChanged => {}
                     DiffStatus::Created => {

--- a/crates/loro-internal/src/encoding/encode_enhanced.rs
+++ b/crates/loro-internal/src/encoding/encode_enhanced.rs
@@ -4,7 +4,7 @@ use fxhash::{FxHashMap, FxHashSet};
 use loro_common::{HasCounterSpan, HasIdSpan, HasLamportSpan, TreeID};
 use rle::{HasLength, RleVec, Sliceable};
 use serde_columnar::{columnar, iter_from_bytes, to_vec};
-use std::{borrow::Cow, cmp::Ordering, ops::Deref, sync::Arc};
+use std::{borrow::Cow, ops::Deref, sync::Arc};
 use zerovec::{vecs::Index32, VarZeroVec};
 
 use crate::{

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -138,7 +138,7 @@ impl DiffVariant {
 
 #[non_exhaustive]
 #[derive(Clone, Debug, EnumAsInner, Serialize)]
-pub enum InternalDiff {
+pub(crate) enum InternalDiff {
     SeqRaw(Delta<SliceRanges>),
     /// This always uses entity indexes.
     RichtextRaw(Delta<RichtextStateChunk>),

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -121,15 +121,29 @@ impl Actor {
                                     attributes: _,
                                 } => {
                                     let utf8_index = if cfg!(feature = "wasm") {
+                                        let ans = utf16_to_utf8_index(&text, index).unwrap();
+                                        index += value.len_utf16();
+                                        ans
+                                    } else {
+                                        let ans = unicode_to_utf8_index(&text, index).unwrap();
+                                        index += value.len_unicode();
+                                        ans
+                                    };
+                                    text.insert_str(utf8_index, value.as_str());
+                                }
+                                DeltaItem::Delete { delete: len, .. } => {
+                                    let utf8_index = if cfg!(feature = "wasm") {
                                         utf16_to_utf8_index(&text, index).unwrap()
                                     } else {
                                         unicode_to_utf8_index(&text, index).unwrap()
                                     };
-                                    text.insert_str(utf8_index, value.as_str());
-                                    index += value.len_unicode();
-                                }
-                                DeltaItem::Delete { delete: len, .. } => {
-                                    text.drain(index..index + *len);
+
+                                    let utf8_end = if cfg!(feature = "wasm") {
+                                        utf16_to_utf8_index(&text, index + *len).unwrap()
+                                    } else {
+                                        unicode_to_utf8_index(&text, index + *len).unwrap()
+                                    };
+                                    text.drain(utf8_index..utf8_end);
                                 }
                             }
                         }
@@ -3967,6 +3981,29 @@ mod failed_tests {
                     pos: 116,
                     value: 116,
                     is_del: false,
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn fuzz_14() {
+        test_multi_sites(
+            5,
+            &mut [
+                Text {
+                    site: 111,
+                    container_idx: 238,
+                    pos: 110,
+                    value: 28270,
+                    is_del: false,
+                },
+                Text {
+                    site: 191,
+                    container_idx: 42,
+                    pos: 191,
+                    value: 37186,
+                    is_del: true,
                 },
             ],
         )

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -10,7 +10,7 @@ use crate::{
     op::ListSlice,
     state::RichtextState,
     txn::EventHint,
-    utils::utf16::count_utf16_chars,
+    utils::utf16::count_utf16_len,
 };
 use enum_as_inner::EnumAsInner;
 use fxhash::FxHashMap;
@@ -350,10 +350,8 @@ impl TextHandler {
             .lock()
             .unwrap()
             .with_state_mut(self.container_idx, |state| {
-                state
-                    .as_richtext_state_mut()
-                    .unwrap()
-                    .get_text_entity_ranges_in_event_index_range(pos, len)
+                let richtext_state = state.as_richtext_state_mut().unwrap();
+                richtext_state.get_text_entity_ranges_in_event_index_range(pos, len)
             });
 
         debug_assert_eq!(ranges.iter().map(|x| x.len()).sum::<usize>(), len);
@@ -520,7 +518,7 @@ impl TextHandler {
 
 fn event_len(s: &str) -> usize {
     if cfg!(feature = "wasm") {
-        count_utf16_chars(s.as_bytes())
+        count_utf16_len(s.as_bytes())
     } else {
         s.chars().count()
     }

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -50,7 +50,7 @@ pub struct DocState {
 }
 
 #[enum_dispatch]
-pub trait ContainerState: Clone {
+pub(crate) trait ContainerState: Clone {
     fn apply_diff_and_convert(&mut self, diff: InternalDiff, arena: &SharedArena) -> Diff;
 
     fn apply_diff(&mut self, diff: InternalDiff, arena: &SharedArena) {

--- a/crates/loro-internal/src/utils/string_slice.rs
+++ b/crates/loro-internal/src/utils/string_slice.rs
@@ -8,7 +8,7 @@ use crate::{
     delta::DeltaValue,
 };
 
-use super::utf16::{count_unicode_chars, count_utf16_chars};
+use super::utf16::{count_unicode_chars, count_utf16_len};
 
 #[derive(Clone)]
 pub struct StringSlice {
@@ -91,6 +91,10 @@ impl StringSlice {
 
     pub fn len_unicode(&self) -> usize {
         count_unicode_chars(self.bytes())
+    }
+
+    pub fn len_utf16(&self) -> usize {
+        count_utf16_len(self.bytes())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -181,7 +185,7 @@ impl DeltaValue for StringSlice {
     /// Utf16 length when in WASM
     fn length(&self) -> usize {
         if cfg!(feature = "wasm") {
-            count_utf16_chars(self.bytes())
+            count_utf16_len(self.bytes())
         } else {
             count_unicode_chars(self.bytes())
         }

--- a/crates/loro-internal/src/utils/utf16.rs
+++ b/crates/loro-internal/src/utils/utf16.rs
@@ -1,4 +1,4 @@
-pub fn count_utf16_chars(utf8_str: &[u8]) -> usize {
+pub fn count_utf16_len(utf8_str: &[u8]) -> usize {
     let mut utf16_count = 0;
 
     let mut iter = utf8_str.iter();
@@ -48,69 +48,69 @@ mod tests {
     fn test_ascii() {
         let input = "Hello, world!";
         let expected = 13;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_2_byte() {
         let input = "Привет, мир!";
         let expected = 12;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_3_byte() {
         let input = "こんにちは世界";
         let expected = 7;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_4_byte() {
         let input = "👋🌍";
         let expected = 4;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_crazy_emoji_bytes() {
         let input = "👩‍👩‍👧‍👧👨‍👨‍👧";
         let expected = 19;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_empty_string() {
         let input = "";
         let expected = 0;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_single_char() {
         let input = "a";
         let expected = 1;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_utf8_with_bom() {
         let input = "\u{FEFF}Hello, world!"; // UTF-8 with BOM
         let expected = 14;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_long_string() {
         let input = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
         let expected = 52;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 
     #[test]
     fn test_utf8_with_null_char() {
         let input = "Hello\u{0000}world!";
         let expected = 12;
-        assert_eq!(count_utf16_chars(input.as_bytes()), expected);
+        assert_eq!(count_utf16_len(input.as_bytes()), expected);
     }
 }

--- a/crates/loro-wasm/Cargo.toml
+++ b/crates/loro-wasm/Cargo.toml
@@ -13,7 +13,7 @@ wasm-bindgen = "=0.2.86"
 serde-wasm-bindgen = { version = "0.5.0" }
 console_error_panic_hook = { version = "0.1.6", optional = true }
 getrandom = { version = "0.2.10", features = ["js"] }
-debug-log = { version = "0.2.1", features = ["wasm"] }
+debug-log = { version = "0.2.2", features = ["wasm"] }
 serde = { version = "1", features = ["derive"] }
 
 [features]

--- a/crates/rle/Cargo.toml
+++ b/crates/rle/Cargo.toml
@@ -15,7 +15,7 @@ arref = "0.1.0"
 crdt-list = { version = "0.4.0" }
 fxhash = "0.2.1"
 heapless = "0.7.16"
-debug-log = "0.1.4"
+debug-log = "0.2.2"
 append-only-bytes = { version = "0.1.11", features = ["u32_range"] }
 
 [dev-dependencies]

--- a/examples/loro-quill/src/main.ts
+++ b/examples/loro-quill/src/main.ts
@@ -1,5 +1,5 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
+import { createApp } from "vue";
+import "./style.css";
+import App from "./App.vue";
 
-createApp(App).mount('#app')
+createApp(App).mount("#app");


### PR DESCRIPTION
This pull request extracts the `Text` variant of the `RichtextStateChunk` enum into its own module. This improves code organization and makes it easier to work with text-specific functionality.

No issues are fixed in this pull request.