### PR TITLE
Fix list get method

### DIFF
--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -273,7 +273,7 @@ impl ListState {
     pub fn get(&self, index: usize) -> Option<&LoroValue> {
         let result = self.list.query::<LengthFinder>(&index)?;
         if result.found {
-            Some(&result.elem(&self.list).unwrap().v[result.offset()])
+            Some(&result.elem(&self.list).unwrap().v)
         } else {
             None
         }
@@ -404,6 +404,7 @@ impl ContainerState for ListState {
                 crate::container::list::list_op::ListOp::StyleEnd { .. } => unreachable!(),
             },
         }
+        debug_log::debug_dbg!(&self);
         Ok(())
     }
 

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -7,6 +7,23 @@ use loro_internal::{
 use serde_json::json;
 
 #[test]
+fn list() {
+    let a = LoroDoc::new_auto_commit();
+    a.get_list("list").insert_(0, "Hello".into()).unwrap();
+    assert_eq!(a.get_list("list").get(0).unwrap(), LoroValue::from("Hello"));
+    let map = a
+        .get_list("list")
+        .insert_container_(1, ContainerType::Map)
+        .unwrap()
+        .into_map()
+        .unwrap();
+    map.insert_("Hello", LoroValue::from("u")).unwrap();
+    let cid = map.id();
+    let id = a.get_list("list").get(1);
+    assert_eq!(id.unwrap().as_container().unwrap(), &cid);
+}
+
+#[test]
 fn richtext_mark_event() {
     let a = LoroDoc::new_auto_commit();
     a.subscribe(

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -902,7 +902,11 @@ impl LoroList {
     }
 
     pub fn get(&self, index: usize) -> JsValue {
-        self.0.get(index).into()
+        let Some(v) = self.0.get(index) else {
+            return JsValue::UNDEFINED;
+        };
+
+        JsValue::from(v)
     }
 
     #[wasm_bindgen(js_name = "id", method, getter)]

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  ContainerID,
+  Loro,
+  setPanicHook,
+} from "../src";
+
+setPanicHook();
+
+describe("list", () => {
+  it("insert containers", () => {
+    const doc = new Loro();
+    const list = doc.getList("list");
+    const map = list.insertContainer(0, "Map");
+    map.set("key", "value");
+    const v = list.get(0);
+    console.log(v);
+    expect(typeof v).toBe("string");
+    const m = doc.getMap(v as ContainerID);
+    expect(m.getDeepValue()).toStrictEqual({ key: "value" });
+  })
+
+  it.todo("iterate");
+})


### PR DESCRIPTION
This pull request fixes an issue with the `get` method in the `ListState` module. Previously, the method would return null because refactoring is not done fully.