### PR TITLE
Add `from_checkout` mark to event

### DIFF
--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -404,6 +404,7 @@ impl LoroDoc {
                         origin,
                         local: false,
                         diff: (diff).into(),
+                        from_checkout: false,
                         new_version: Cow::Owned(oplog.frontiers().clone()),
                     });
                 }
@@ -627,6 +628,7 @@ impl LoroDoc {
             origin: "checkout".into(),
             local: true,
             diff: Cow::Owned(diff),
+            from_checkout: true,
             new_version: Cow::Owned(frontiers.clone()),
         });
         let events = state.take_events();

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -429,6 +429,7 @@ impl DocState {
             self.record_diff(InternalDocDiff {
                 origin: Default::default(),
                 local: false,
+                from_checkout: false,
                 diff,
                 new_version: Cow::Borrowed(&frontiers),
             });
@@ -664,6 +665,7 @@ impl DocState {
         let to = (*diffs.last().unwrap().new_version).to_owned();
         let origin = diffs[0].origin.clone();
         let local = diffs[0].local;
+        let from_checkout = diffs[0].from_checkout;
         for diff in diffs {
             #[allow(clippy::unnecessary_to_owned)]
             for container_diff in diff.diff.into_owned() {
@@ -714,6 +716,7 @@ impl DocState {
             from,
             to,
             origin,
+            from_checkout,
             local,
             diff,
         }

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -321,6 +321,7 @@ impl Transaction {
                         })
                         .collect(),
                 ),
+                from_checkout: false,
                 new_version: Cow::Borrowed(oplog.frontiers()),
             }),
         );


### PR DESCRIPTION
This pull request adds a new field to the `DocDiff` and `InternalDocDiff` structs called `from_checkout`. This field indicates whether the diff was created from a checkout operation. The `DocState` and `Transaction` structs have also been updated to include this field when recording diffs. Additionally, a new test has been added to ensure that events are correctly marked as not being from a checkout operation. 