### PR TITLE
Fix encoding of oplog snapshot

### DIFF
--- a/crates/loro-internal/src/encoding/encode_snapshot.rs
+++ b/crates/loro-internal/src/encoding/encode_snapshot.rs
@@ -927,16 +927,16 @@ fn encode_oplog(oplog: &OpLog, state_ref: Option<PreEncodedState>) -> FinalPhase
                         loro_common::ContainerType::Tree => unreachable!(),
                     },
                     InnerListOp::InsertText {
-                        slice,
+                        slice: _,
                         unicode_len: len,
-                        unicode_start: _,
+                        unicode_start: start,
                         pos,
                     } => match op.container.get_type() {
                         loro_common::ContainerType::Text => {
                             encoded_ops.push(EncodedSnapshotOp::from(
                                 SnapshotOp::RichtextInsert {
                                     pos: *pos as usize,
-                                    start: slice.start(),
+                                    start: *start as usize,
                                     len: *len as usize,
                                 },
                                 op.container.to_index(),


### PR DESCRIPTION
This pull request fixes an issue with the encoding of oplog snapshots. Specifically, the `unicode_start` field was not being properly used in the `InnerListOp::InsertText` match statement, resulting in incorrect encoding. This has been resolved by properly utilizing the `unicode_start` field.