### PR TITLE
Refactor container value retrieval in handlers

### DIFF
--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -38,6 +38,8 @@ pub enum LoroError {
     ArgErr(Box<str>),
     #[error("Auto commit has not started. The doc is readonly when detached. You should ensure autocommit is on and the doc and the state is attached.")]
     AutoCommitNotStarted,
+    #[error("The doc is already dropped")]
+    DocDropError,
     // #[error("the data for key `{0}` is not available")]
     // Redaction(String),
     // #[error("invalid header (expected {expected:?}, found {found:?})")]

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -53,6 +53,7 @@ export type Value =
   | Uint8Array
   | Value[];
 
+export type Container = LoroList | LoroMap | LoroText | LoroTree;
 export type Prelim = PrelimList | PrelimMap | PrelimText;
 
 /**
@@ -109,8 +110,8 @@ export type MapDiff = {
 export type TreeDiff = {
   type: "tree";
   diff:
-  | { target: TreeID; action: "create" | "delete" }
-  | { target: TreeID; action: "move"; parent: TreeID };
+    | { target: TreeID; action: "create" | "delete" }
+    | { target: TreeID; action: "move"; parent: TreeID };
 };
 
 export type Diff = ListDiff | TextDiff | MapDiff | TreeDiff;
@@ -148,7 +149,7 @@ declare module "loro-wasm" {
     insertContainer(pos: number, container: "Tree"): LoroTree;
     insertContainer(pos: number, container: string): never;
 
-    get(index: number): Value;
+    get(index: number): undefined | Value | Container;
     getTyped<Key extends keyof T & number>(loro: Loro, index: Key): T[Key];
     insertTyped<Key extends keyof T & number>(pos: Key, value: T[Key]): void;
     insert(pos: number, value: Value | Prelim): void;
@@ -163,7 +164,7 @@ declare module "loro-wasm" {
     setContainer(key: string, container_type: "Tree"): LoroTree;
     setContainer(key: string, container_type: string): never;
 
-    get(key: string): Value;
+    get(key: string): undefined | Value | Container;
     getTyped<Key extends keyof T & string>(txn: Loro, key: Key): T[Key];
     set(key: string, value: Value | Prelim): void;
     setTyped<Key extends keyof T & string>(key: Key, value: T[Key]): void;

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -84,12 +84,22 @@ describe("list", () => {
     map.set("key", "value");
     const v = list.get(0);
     console.log(v);
-    expect(typeof v).toBe("string");
-    const m = doc.getMap(v as ContainerID);
-    expect(m.getDeepValue()).toStrictEqual({ key: "value" });
+    expect(v instanceof LoroMap).toBeTruthy();
+    expect(v.getDeepValue()).toStrictEqual({ key: "value" });
   });
 
   it.todo("iterate");
+});
+
+describe("map", () => {
+  it("get child container", () => {
+    const doc = new Loro();
+    const map = doc.getMap("map");
+    const list = map.setContainer("key", "List");
+    list.insert(0, 1);
+    expect(map.get("key") instanceof LoroList).toBeTruthy();
+    expect(map.get("key").getDeepValue()).toStrictEqual([1]);
+  });
 });
 
 describe("import", () => {


### PR DESCRIPTION
This PR refactors the `get` methods in `ListHandler` and `MapHandler` to return a `ValueOrContainer` enum, which can hold either a `LoroValue` or a `Handler` to a container. This allows for easier handling of nested containers in the codebase.

feat: get sub container directly when getting value

Fixes #174 