### PR TITLE
(WASM )Refactor wasm interfaces on List and Map

### DIFF
--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1295,7 +1295,8 @@ impl LoroMap {
         Ok(())
     }
 
-    /// Get the value of the key. If the value is a container, the corresponding handler will be returned.
+    /// Get the value of the key. If the value is a child container, the corresponding
+    /// `Container` will be returned.
     ///
     /// @example
     /// ```ts
@@ -1336,7 +1337,8 @@ impl LoroMap {
         ans
     }
 
-    /// Get the values of the map.
+    /// Get the values of the map. If the value is a child container, the corresponding
+    /// `Container` will be returned.
     ///
     /// @example
     /// ```ts
@@ -1346,7 +1348,7 @@ impl LoroMap {
     /// const map = doc.getMap("map");
     /// map.set("foo", "bar");
     /// map.set("baz", "bar");
-    /// const values = map.values(); // [{ type: "Value", value: "bar" }, { type: "Value", value: "bar" }]
+    /// const values = map.values(); // ["bar", "bar"]
     /// ```
     pub fn values(&self) -> Vec<JsValue> {
         let mut ans: Vec<JsValue> = Vec::with_capacity(self.handler.len());
@@ -1356,7 +1358,8 @@ impl LoroMap {
         ans
     }
 
-    /// Get the entries of the map.
+    /// Get the entries of the map. If the value is a child container, the corresponding
+    /// `Container` will be returned.
     ///
     /// @example
     /// ```ts
@@ -1366,7 +1369,7 @@ impl LoroMap {
     /// const map = doc.getMap("map");
     /// map.set("foo", "bar");
     /// map.set("baz", "bar");
-    /// const entries = map.entries(); // [["foo", { type: "Value", value: "bar" }], ["baz", { type: "Value", value: "bar" }]]
+    /// const entries = map.entries(); // [["foo", "bar"], ["baz", "bar"]]
     /// ```
     pub fn entries(&self) -> Vec<MapEntry> {
         let mut ans: Vec<MapEntry> = Vec::with_capacity(self.handler.len());
@@ -1387,8 +1390,8 @@ impl LoroMap {
         value.into()
     }
 
-    /// Get the keys and the values. If the type of value is a container, it will be
-    /// resolved recursively.
+    /// Get the keys and the values. If the type of value is a child container,
+    /// it will be resolved recursively.
     ///
     /// @example
     /// ```ts
@@ -1616,7 +1619,8 @@ impl LoroList {
         value.into()
     }
 
-    /// Get elements of the list.
+    /// Get elements of the list. If the value is a child container, the corresponding
+    /// `Container` will be returned.
     ///
     /// @example
     /// ```ts
@@ -1627,7 +1631,8 @@ impl LoroList {
     /// list.insert(0, 100);
     /// list.insert(1, "foo");
     /// list.insert(2, true);
-    /// console.log(list.value);  // [100, "foo", true];
+    /// list.insertContainer(3, "Text");
+    /// console.log(list.value);  // [100, "foo", true, LoroText];
     /// ```
     #[wasm_bindgen(js_name = "toArray", method)]
     pub fn to_array(&mut self) -> Vec<JsValueOrContainer> {

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -1,13 +1,11 @@
 export * from "loro-wasm";
-import { Delta, OpId } from "loro-wasm";
+import { Container, ContainerType, Delta, OpId, Value } from "loro-wasm";
 import { PrelimText, PrelimList, PrelimMap } from "loro-wasm";
 import {
   ContainerID,
   Loro,
   LoroList,
   LoroMap,
-  LoroText,
-  LoroTree,
   TreeID,
 } from "loro-wasm";
 
@@ -40,20 +38,6 @@ LoroMap.prototype.setTyped = function (...args) {
   return this.set(...args);
 };
 
-/**
- * Data types supported by loro
- */
-export type Value =
-  | ContainerID
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Value }
-  | Uint8Array
-  | Value[];
-
-export type Container = LoroList | LoroMap | LoroText | LoroTree;
 export type Prelim = PrelimList | PrelimMap | PrelimText;
 export type Frontiers = OpId[];
 
@@ -128,6 +112,23 @@ export function isContainerId(s: string): s is ContainerID {
 }
 
 export { Loro };
+
+export function isContainer(value: any): value is Container {
+  if (typeof value !== "object" || value == null) {
+    return false;
+  }
+
+  const p = value.__proto__;
+  return p.hasOwnProperty("kind") && CONTAINER_TYPES.includes(value.kind());
+}
+
+export function valueType(value: any): "Json" | ContainerType {
+  if (isContainer(value)) {
+    return value.kind();
+  }
+
+  return "Json";
+}
 
 declare module "loro-wasm" {
   interface Loro {

--- a/loro-js/tests/misc.test.ts
+++ b/loro-js/tests/misc.test.ts
@@ -218,7 +218,7 @@ describe("prelim", () => {
       map.set("list", prelim_list);
       loro.commit();
 
-      assertEquals(map.getDeepValue(), {
+      assertEquals(map.toJson(), {
         text: "hello everyone",
         map: { a: 1, ab: 123 },
         list: [0, { a: 4 }],
@@ -234,7 +234,7 @@ describe("prelim", () => {
       list.insert(2, prelim_list);
       loro.commit();
 
-      assertEquals(list.getDeepValue(), [
+      assertEquals(list.toJson(), [
         "ttt",
         { a: 1, b: 2 },
         [
@@ -270,17 +270,17 @@ describe("wasm", () => {
 
   it("getValueDeep", () => {
     bText.insert(0, "hello world Text");
-    assertEquals(b.getDeepValue(), { ab: 123, hh: "hello world Text" });
+    assertEquals(b.toJson(), { ab: 123, hh: "hello world Text" });
   });
 
   it("get container by id", () => {
     const id = b.id;
     const b2 = loro.getContainerById(id) as LoroMap;
-    assertEquals(b2.value, b.value);
+    assertEquals(b2.toJson(), b.toJson());
     assertEquals(b2.id, id);
     b2.set("0", 12);
 
-    assertEquals(b2.value, b.value);
+    assertEquals(b2.toJson(), b.toJson());
   });
 });
 


### PR DESCRIPTION
- LoroMap.entries() now returns `Container` instead of `ContainerId` when the child is a container
- Replace `LoroList.value` with `LoroList.toArray()`
- Replace `*.getDeepValue()` with `*.toJson()`
- `LoroList.toArray()` returns `Container`  instead of `ContainerId` when the child is a container
- Add `kind()` function to all `Container`
- Add `valueType()` function and `isContainer()` function to get the type of the value quickly

It includes changes to the ListHandler and MapHandler classes, as well as updates to the for_each method to handle both values and containers. These changes make the code more maintainable and easier to understand.
