### PR TITLE
Refactor: use ValueOrContainer for diff event

### DIFF
--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -79,3 +79,7 @@ harness = false
 [[bench]]
 name = "pending"
 harness = false
+
+[[bench]]
+name = "event"
+harness = false

--- a/crates/loro-internal/benches/event.rs
+++ b/crates/loro-internal/benches/event.rs
@@ -1,0 +1,50 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(feature = "test_utils")]
+mod event {
+    use super::*;
+    use loro_common::ContainerType;
+    use loro_internal::{ListHandler, LoroDoc};
+    use std::sync::Arc;
+
+    fn create_sub_container(handler: ListHandler, children_num: usize) -> Vec<ListHandler> {
+        let mut ans = vec![];
+        for idx in 0..children_num {
+            let child_handler = handler
+                .insert_container(idx, ContainerType::List)
+                .unwrap()
+                .into_list()
+                .unwrap();
+            ans.push(child_handler);
+        }
+        ans
+    }
+
+    pub fn resolved_container(c: &mut Criterion) {
+        let mut b = c.benchmark_group("resolved");
+        b.sample_size(10);
+        b.bench_function("subContainer in event", |b| {
+            let children_num = 80;
+            let deep = 3;
+            b.iter(|| {
+                let mut loro = LoroDoc::default();
+                loro.start_auto_commit();
+                loro.subscribe_root(Arc::new(|_e| {}));
+                let mut handlers = vec![loro.get_list("list")];
+                for _ in 0..deep {
+                    handlers = handlers
+                        .into_iter()
+                        .flat_map(|h| create_sub_container(h, children_num))
+                        .collect();
+                }
+            })
+        });
+    }
+}
+
+pub fn dumb(_c: &mut Criterion) {}
+
+#[cfg(feature = "test_utils")]
+criterion_group!(benches, event::resolved_container);
+#[cfg(not(feature = "test_utils"))]
+criterion_group!(benches, dumb);
+criterion_main!(benches);

--- a/crates/loro-internal/examples/event.rs
+++ b/crates/loro-internal/examples/event.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use loro_common::ContainerType;
+use loro_internal::{
+    delta::DeltaItem,
+    event::Diff,
+    handler::{Handler, ValueOrContainer},
+    LoroDoc, ToJson,
+};
+
+fn main() {
+    let mut doc = LoroDoc::new();
+    doc.start_auto_commit();
+    let list = doc.get_list("list");
+    doc.subscribe_root(Arc::new(|e| match &e.container.diff {
+        Diff::List(list) => {
+            for item in list.iter() {
+                if let DeltaItem::Insert {
+                    insert,
+                    attributes: _,
+                } = item
+                {
+                    for v in insert {
+                        match v {
+                            ValueOrContainer::Container(h) => {
+                                // You can directly obtain the handler and perform some operations.
+                                if matches!(h, Handler::Map(_)) {
+                                    let text = h
+                                        .as_map()
+                                        .unwrap()
+                                        .insert_container("text", ContainerType::Text)
+                                        .unwrap();
+                                    text.as_text()
+                                        .unwrap()
+                                        .insert(0, "created from event")
+                                        .unwrap();
+                                }
+                            }
+                            ValueOrContainer::Value(value) => {
+                                println!("insert value {:?}", value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Diff::Map(map) => {
+            println!("map container updates {:?}", map.updated);
+        }
+        _ => {}
+    }));
+    list.insert(0, "abc").unwrap();
+    list.insert_container(1, ContainerType::List).unwrap();
+    list.insert_container(2, ContainerType::Map).unwrap();
+    list.insert_container(3, ContainerType::Text).unwrap();
+    list.insert_container(4, ContainerType::Tree).unwrap();
+    doc.commit_then_renew();
+    assert_eq!(
+        doc.get_deep_value().to_json(),
+        r#"{"list":["abc",[],{"text":"created from event"},"",[]]}"#
+    );
+}

--- a/crates/loro-internal/src/delta.rs
+++ b/crates/loro-internal/src/delta.rs
@@ -3,7 +3,7 @@ pub use seq::{Delta, DeltaItem, DeltaType, DeltaValue, Meta};
 mod map;
 pub use map::{MapDiff, ValuePair};
 mod map_delta;
-pub use map_delta::{MapDelta, MapValue};
+pub use map_delta::{MapDelta, MapValue, ResolvedMapDelta, ResolvedMapValue};
 mod text;
 pub use text::{StyleMeta, StyleMetaItem};
 mod tree;

--- a/crates/loro-internal/src/delta/map_delta.rs
+++ b/crates/loro-internal/src/delta/map_delta.rs
@@ -1,19 +1,60 @@
-use std::hash::Hash;
+use std::{
+    hash::Hash,
+    sync::{Mutex, Weak},
+};
 
 use fxhash::FxHashMap;
 use serde::{ser::SerializeStruct, Serialize};
 
 use crate::{
+    arena::SharedArena,
     change::Lamport,
     handler::ValueOrContainer,
     id::{Counter, PeerID, ID},
     span::{HasId, HasLamport},
-    InternalString, LoroValue,
+    txn::Transaction,
+    DocState, InternalString, LoroValue,
 };
 
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct MapDelta {
     pub updated: FxHashMap<InternalString, MapValue>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MapValue {
+    pub counter: Counter,
+    pub value: Option<LoroValue>,
+    pub lamport: (Lamport, PeerID),
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct ResolvedMapDelta {
+    pub updated: FxHashMap<InternalString, ResolvedMapValue>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedMapValue {
+    pub counter: Counter,
+    pub value: Option<ValueOrContainer>,
+    pub lamport: (Lamport, PeerID),
+}
+
+impl ResolvedMapValue {
+    pub(crate) fn from_map_value(
+        v: MapValue,
+        arena: &SharedArena,
+        txn: &Weak<Mutex<Option<Transaction>>>,
+        state: &Weak<Mutex<DocState>>,
+    ) -> Self {
+        ResolvedMapValue {
+            counter: v.counter,
+            lamport: v.lamport,
+            value: v
+                .value
+                .map(|v| ValueOrContainer::from_value(v, arena, txn, state)),
+        }
+    }
 }
 
 impl MapDelta {
@@ -45,23 +86,33 @@ impl MapDelta {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct MapValue {
-    pub counter: Counter,
-    pub value: Option<LoroValue>,
-    pub lamport: (Lamport, PeerID),
-}
+impl ResolvedMapDelta {
+    pub(crate) fn compose(&self, x: ResolvedMapDelta) -> ResolvedMapDelta {
+        let mut updated = self.updated.clone();
+        for (k, v) in x.updated.into_iter() {
+            if let Some(old) = updated.get_mut(&k) {
+                if v.lamport > old.lamport {
+                    *old = v;
+                }
+            } else {
+                updated.insert(k, v);
+            }
+        }
+        ResolvedMapDelta { updated }
+    }
 
-#[derive(Default, Debug, Clone)]
-pub struct ResolvedMapDelta {
-    pub updated: FxHashMap<InternalString, ResolvedMapValue>,
-}
+    #[inline]
+    pub fn new() -> Self {
+        ResolvedMapDelta {
+            updated: FxHashMap::default(),
+        }
+    }
 
-#[derive(Debug, Clone)]
-pub struct ResolvedMapValue {
-    pub counter: Counter,
-    pub value: Option<ValueOrContainer>,
-    pub lamport: (Lamport, PeerID),
+    #[inline]
+    pub fn with_entry(mut self, key: InternalString, map_value: ResolvedMapValue) -> Self {
+        self.updated.insert(key, map_value);
+        self
+    }
 }
 
 impl Hash for MapValue {

--- a/crates/loro-internal/src/delta/map_delta.rs
+++ b/crates/loro-internal/src/delta/map_delta.rs
@@ -5,6 +5,7 @@ use serde::{ser::SerializeStruct, Serialize};
 
 use crate::{
     change::Lamport,
+    handler::ValueOrContainer,
     id::{Counter, PeerID, ID},
     span::{HasId, HasLamport},
     InternalString, LoroValue,
@@ -48,6 +49,18 @@ impl MapDelta {
 pub struct MapValue {
     pub counter: Counter,
     pub value: Option<LoroValue>,
+    pub lamport: (Lamport, PeerID),
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct ResolvedMapDelta {
+    pub updated: FxHashMap<InternalString, ResolvedMapValue>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedMapValue {
+    pub counter: Counter,
+    pub value: Option<ValueOrContainer>,
     pub lamport: (Lamport, PeerID),
 }
 
@@ -100,15 +113,5 @@ impl Serialize for MapValue {
         s.serialize_field("value", &self.value)?;
         s.serialize_field("lamport", &self.lamport)?;
         s.end()
-    }
-}
-
-impl MapValue {
-    pub fn new(id: ID, lamport: Lamport, value: Option<LoroValue>) -> Self {
-        MapValue {
-            counter: id.counter,
-            value,
-            lamport: (lamport, id.peer),
-        }
     }
 }

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -220,7 +220,7 @@ pub enum UnresolvedDiff {
     /// - When feature `wasm` is enabled, it should use utf16 indexes.
     /// - When feature `wasm` is disabled, it should use unicode indexes.
     Text(Delta<StringSlice, StyleMeta>),
-    NewMap(MapDelta),
+    Map(MapDelta),
     Tree(TreeDiff),
 }
 
@@ -231,7 +231,7 @@ pub enum Diff {
     /// - When feature `wasm` is enabled, it should use utf16 indexes.
     /// - When feature `wasm` is disabled, it should use unicode indexes.
     Text(Delta<StringSlice, StyleMeta>),
-    NewMap(ResolvedMapDelta),
+    Map(ResolvedMapDelta),
     Tree(TreeDiff),
 }
 
@@ -271,8 +271,8 @@ impl UnresolvedDiff {
             (UnresolvedDiff::Text(a), UnresolvedDiff::Text(b)) => {
                 Ok(UnresolvedDiff::Text(a.compose(b)))
             }
-            (UnresolvedDiff::NewMap(a), UnresolvedDiff::NewMap(b)) => {
-                Ok(UnresolvedDiff::NewMap(a.compose(b)))
+            (UnresolvedDiff::Map(a), UnresolvedDiff::Map(b)) => {
+                Ok(UnresolvedDiff::Map(a.compose(b)))
             }
 
             (UnresolvedDiff::Tree(a), UnresolvedDiff::Tree(b)) => {
@@ -286,7 +286,7 @@ impl UnresolvedDiff {
         match self {
             UnresolvedDiff::List(s) => s.is_empty(),
             UnresolvedDiff::Text(t) => t.is_empty(),
-            UnresolvedDiff::NewMap(m) => m.updated.is_empty(),
+            UnresolvedDiff::Map(m) => m.updated.is_empty(),
             UnresolvedDiff::Tree(t) => t.diff.is_empty(),
         }
     }
@@ -299,12 +299,12 @@ impl UnresolvedDiff {
             (UnresolvedDiff::Text(a), UnresolvedDiff::Text(b)) => {
                 UnresolvedDiff::Text(a.compose(b))
             }
-            (UnresolvedDiff::NewMap(a), UnresolvedDiff::NewMap(b)) => {
+            (UnresolvedDiff::Map(a), UnresolvedDiff::Map(b)) => {
                 let mut a = a;
                 for (k, v) in b.updated {
                     a = a.with_entry(k, v);
                 }
-                UnresolvedDiff::NewMap(a)
+                UnresolvedDiff::Map(a)
             }
 
             (UnresolvedDiff::Tree(a), UnresolvedDiff::Tree(b)) => {
@@ -355,7 +355,7 @@ pub(crate) fn external_diff_to_resolved(
                 .collect();
             Diff::List(Delta { vec })
         }
-        UnresolvedDiff::NewMap(map) => {
+        UnresolvedDiff::Map(map) => {
             let mut resolved_map = FxHashMap::default();
             for (k, v) in map.updated.into_iter() {
                 let counter = v.counter;
@@ -377,7 +377,7 @@ pub(crate) fn external_diff_to_resolved(
                     },
                 );
             }
-            Diff::NewMap(ResolvedMapDelta {
+            Diff::Map(ResolvedMapDelta {
                 updated: resolved_map,
             })
         }

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -1,26 +1,20 @@
 use enum_as_inner::EnumAsInner;
-use fxhash::{FxHashMap, FxHasher64};
+use fxhash::FxHasher64;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::{
-    arena::SharedArena,
     container::richtext::richtext_state::RichtextStateChunk,
-    delta::{
-        Delta, DeltaItem, MapDelta, ResolvedMapDelta, ResolvedMapValue, StyleMeta, TreeDelta,
-        TreeDiff,
-    },
-    handler::{Handler, ValueOrContainer},
+    delta::{Delta, MapDelta, ResolvedMapDelta, StyleMeta, TreeDelta, TreeDiff},
+    handler::ValueOrContainer,
     op::SliceRanges,
-    txn::Transaction,
     utils::string_slice::StringSlice,
-    DocState, InternalString, LoroValue,
+    InternalString,
 };
 
 use std::{
     borrow::Cow,
     hash::{Hash, Hasher},
-    sync::{Mutex, Weak},
 };
 
 use loro_common::{ContainerID, TreeID};

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -76,7 +76,6 @@ pub(crate) struct InternalContainerDiff {
 pub(crate) enum DiffVariant {
     Internal(InternalDiff),
     External(Diff),
-    Resolved(ResolvedDiff),
 }
 
 /// It's used for transmitting and recording the diff internally.

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -1,20 +1,26 @@
 use enum_as_inner::EnumAsInner;
-use fxhash::FxHasher64;
+use fxhash::{FxHashMap, FxHasher64};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::{
+    arena::SharedArena,
     container::richtext::richtext_state::RichtextStateChunk,
-    delta::{Delta, MapDelta, ResolvedMapDelta, StyleMeta, TreeDelta, TreeDiff},
-    handler::ValueOrContainer,
+    delta::{
+        Delta, DeltaItem, MapDelta, ResolvedMapDelta, ResolvedMapValue, StyleMeta, TreeDelta,
+        TreeDiff,
+    },
+    handler::{Handler, ValueOrContainer},
     op::SliceRanges,
+    txn::Transaction,
     utils::string_slice::StringSlice,
-    InternalString, LoroValue,
+    DocState, InternalString, LoroValue,
 };
 
 use std::{
     borrow::Cow,
     hash::{Hash, Hasher},
+    sync::{Mutex, Weak},
 };
 
 use loro_common::{ContainerID, TreeID};
@@ -26,7 +32,15 @@ pub struct ContainerDiff {
     pub id: ContainerID,
     pub path: Vec<(ContainerID, Index)>,
     pub(crate) idx: ContainerIdx,
-    pub diff: ResolvedDiff,
+    pub diff: Diff,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnresolvedContainerDiff {
+    pub id: ContainerID,
+    pub path: Vec<(ContainerID, Index)>,
+    pub(crate) idx: ContainerIdx,
+    pub diff: UnresolvedDiff,
 }
 
 #[derive(Debug, Clone)]
@@ -35,6 +49,17 @@ pub struct DiffEvent<'a> {
     pub from_children: bool,
     pub container: &'a ContainerDiff,
     pub doc: &'a DocDiff,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnresolvedDocDiff {
+    pub from: Frontiers,
+    pub to: Frontiers,
+    pub origin: InternalString,
+    pub local: bool,
+    /// Whether the diff is created from the checkout operation.
+    pub from_checkout: bool,
+    pub diff: Vec<UnresolvedContainerDiff>,
 }
 
 /// It's the exposed event type.
@@ -61,6 +86,31 @@ impl DocDiff {
         self.to.hash(&mut hasher);
         hasher.finish()
     }
+
+    pub(crate) fn from_unsolved_diff(
+        diff: UnresolvedDocDiff,
+        state: &Weak<Mutex<DocState>>,
+        arena: &SharedArena,
+        txn: &Weak<Mutex<Option<Transaction>>>,
+    ) -> Self {
+        DocDiff {
+            from: diff.from,
+            to: diff.to,
+            origin: diff.origin,
+            local: diff.local,
+            from_checkout: diff.from_checkout,
+            diff: diff
+                .diff
+                .into_iter()
+                .map(|uc| ContainerDiff {
+                    id: uc.id,
+                    path: uc.path,
+                    idx: uc.idx,
+                    diff: external_diff_to_resolved(uc.diff, state, arena, txn),
+                })
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -75,7 +125,7 @@ pub(crate) struct InternalContainerDiff {
 #[derive(Debug, Clone, EnumAsInner)]
 pub(crate) enum DiffVariant {
     Internal(InternalDiff),
-    External(Diff),
+    External(UnresolvedDiff),
 }
 
 /// It's used for transmitting and recording the diff internally.
@@ -142,8 +192,8 @@ pub(crate) enum InternalDiff {
     Tree(TreeDelta),
 }
 
-impl From<Diff> for DiffVariant {
-    fn from(diff: Diff) -> Self {
+impl From<UnresolvedDiff> for DiffVariant {
+    fn from(diff: UnresolvedDiff) -> Self {
         DiffVariant::External(diff)
     }
 }
@@ -165,7 +215,7 @@ impl From<InternalDiff> for DiffVariant {
 /// - When `wasm` is disabled, it should use unicode indexes.
 #[non_exhaustive]
 #[derive(Clone, Debug, EnumAsInner, Serialize)]
-pub enum Diff {
+pub enum UnresolvedDiff {
     List(Delta<Vec<LoroValue>>),
     /// - When feature `wasm` is enabled, it should use utf16 indexes.
     /// - When feature `wasm` is disabled, it should use unicode indexes.
@@ -176,7 +226,7 @@ pub enum Diff {
 
 #[non_exhaustive]
 #[derive(Clone, Debug, EnumAsInner)]
-pub enum ResolvedDiff {
+pub enum Diff {
     List(Delta<Vec<ValueOrContainer>>),
     /// - When feature `wasm` is enabled, it should use utf16 indexes.
     /// - When feature `wasm` is disabled, it should use unicode indexes.
@@ -211,43 +261,128 @@ impl InternalDiff {
     }
 }
 
-impl Diff {
-    pub(crate) fn compose(self, diff: Diff) -> Result<Diff, Self> {
+impl UnresolvedDiff {
+    pub(crate) fn compose(self, diff: UnresolvedDiff) -> Result<UnresolvedDiff, Self> {
         // PERF: avoid clone
         match (self, diff) {
-            (Diff::List(a), Diff::List(b)) => Ok(Diff::List(a.compose(b))),
-            (Diff::Text(a), Diff::Text(b)) => Ok(Diff::Text(a.compose(b))),
-            (Diff::NewMap(a), Diff::NewMap(b)) => Ok(Diff::NewMap(a.compose(b))),
+            (UnresolvedDiff::List(a), UnresolvedDiff::List(b)) => {
+                Ok(UnresolvedDiff::List(a.compose(b)))
+            }
+            (UnresolvedDiff::Text(a), UnresolvedDiff::Text(b)) => {
+                Ok(UnresolvedDiff::Text(a.compose(b)))
+            }
+            (UnresolvedDiff::NewMap(a), UnresolvedDiff::NewMap(b)) => {
+                Ok(UnresolvedDiff::NewMap(a.compose(b)))
+            }
 
-            (Diff::Tree(a), Diff::Tree(b)) => Ok(Diff::Tree(a.compose(b))),
+            (UnresolvedDiff::Tree(a), UnresolvedDiff::Tree(b)) => {
+                Ok(UnresolvedDiff::Tree(a.compose(b)))
+            }
             (a, _) => Err(a),
         }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         match self {
-            Diff::List(s) => s.is_empty(),
-            Diff::Text(t) => t.is_empty(),
-            Diff::NewMap(m) => m.updated.is_empty(),
-            Diff::Tree(t) => t.diff.is_empty(),
+            UnresolvedDiff::List(s) => s.is_empty(),
+            UnresolvedDiff::Text(t) => t.is_empty(),
+            UnresolvedDiff::NewMap(m) => m.updated.is_empty(),
+            UnresolvedDiff::Tree(t) => t.diff.is_empty(),
         }
     }
 
-    pub(crate) fn concat(self, diff: Diff) -> Diff {
+    pub(crate) fn concat(self, diff: UnresolvedDiff) -> UnresolvedDiff {
         match (self, diff) {
-            (Diff::List(a), Diff::List(b)) => Diff::List(a.compose(b)),
-            (Diff::Text(a), Diff::Text(b)) => Diff::Text(a.compose(b)),
-            (Diff::NewMap(a), Diff::NewMap(b)) => {
+            (UnresolvedDiff::List(a), UnresolvedDiff::List(b)) => {
+                UnresolvedDiff::List(a.compose(b))
+            }
+            (UnresolvedDiff::Text(a), UnresolvedDiff::Text(b)) => {
+                UnresolvedDiff::Text(a.compose(b))
+            }
+            (UnresolvedDiff::NewMap(a), UnresolvedDiff::NewMap(b)) => {
                 let mut a = a;
                 for (k, v) in b.updated {
                     a = a.with_entry(k, v);
                 }
-                Diff::NewMap(a)
+                UnresolvedDiff::NewMap(a)
             }
 
-            (Diff::Tree(a), Diff::Tree(b)) => Diff::Tree(a.extend(b.diff)),
+            (UnresolvedDiff::Tree(a), UnresolvedDiff::Tree(b)) => {
+                UnresolvedDiff::Tree(a.extend(b.diff))
+            }
             _ => unreachable!(),
         }
+    }
+}
+
+pub(crate) fn external_diff_to_resolved(
+    diff: UnresolvedDiff,
+    state: &Weak<Mutex<DocState>>,
+    arena: &SharedArena,
+    txn: &Weak<Mutex<Option<Transaction>>>,
+) -> Diff {
+    match diff {
+        UnresolvedDiff::List(list) => {
+            let vec = list
+                .vec
+                .into_iter()
+                .map(|item| match item {
+                    DeltaItem::Insert { insert, attributes } => {
+                        let insert = insert
+                            .into_iter()
+                            .map(|v| {
+                                if let LoroValue::Container(c) = v {
+                                    let idx = arena.id_to_idx(&c).unwrap();
+                                    ValueOrContainer::Container(Handler::new(
+                                        txn.clone(),
+                                        idx,
+                                        state.clone(),
+                                    ))
+                                } else {
+                                    ValueOrContainer::Value(v)
+                                }
+                            })
+                            .collect();
+                        DeltaItem::Insert { insert, attributes }
+                    }
+                    DeltaItem::Delete { delete, attributes } => {
+                        DeltaItem::Delete { delete, attributes }
+                    }
+                    DeltaItem::Retain { retain, attributes } => {
+                        DeltaItem::Retain { retain, attributes }
+                    }
+                })
+                .collect();
+            Diff::List(Delta { vec })
+        }
+        UnresolvedDiff::NewMap(map) => {
+            let mut resolved_map = FxHashMap::default();
+            for (k, v) in map.updated.into_iter() {
+                let counter = v.counter;
+                let lamport = v.lamport;
+                let value = v.value.map(|v| {
+                    if let LoroValue::Container(c) = v {
+                        let idx = arena.id_to_idx(&c).unwrap();
+                        ValueOrContainer::Container(Handler::new(txn.clone(), idx, state.clone()))
+                    } else {
+                        ValueOrContainer::Value(v)
+                    }
+                });
+                resolved_map.insert(
+                    k,
+                    ResolvedMapValue {
+                        counter,
+                        value,
+                        lamport,
+                    },
+                );
+            }
+            Diff::NewMap(ResolvedMapDelta {
+                updated: resolved_map,
+            })
+        }
+        UnresolvedDiff::Text(t) => Diff::Text(t),
+        UnresolvedDiff::Tree(t) => Diff::Tree(t),
     }
 }
 

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -36,30 +36,11 @@ pub struct ContainerDiff {
 }
 
 #[derive(Debug, Clone)]
-pub struct UnresolvedContainerDiff {
-    pub id: ContainerID,
-    pub path: Vec<(ContainerID, Index)>,
-    pub(crate) idx: ContainerIdx,
-    pub diff: UnresolvedDiff,
-}
-
-#[derive(Debug, Clone)]
 pub struct DiffEvent<'a> {
     /// whether the event comes from the children of the container.
     pub from_children: bool,
     pub container: &'a ContainerDiff,
     pub doc: &'a DocDiff,
-}
-
-#[derive(Debug, Clone)]
-pub struct UnresolvedDocDiff {
-    pub from: Frontiers,
-    pub to: Frontiers,
-    pub origin: InternalString,
-    pub local: bool,
-    /// Whether the diff is created from the checkout operation.
-    pub from_checkout: bool,
-    pub diff: Vec<UnresolvedContainerDiff>,
 }
 
 /// It's the exposed event type.
@@ -86,31 +67,6 @@ impl DocDiff {
         self.to.hash(&mut hasher);
         hasher.finish()
     }
-
-    pub(crate) fn from_unsolved_diff(
-        diff: UnresolvedDocDiff,
-        state: &Weak<Mutex<DocState>>,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-    ) -> Self {
-        DocDiff {
-            from: diff.from,
-            to: diff.to,
-            origin: diff.origin,
-            local: diff.local,
-            from_checkout: diff.from_checkout,
-            diff: diff
-                .diff
-                .into_iter()
-                .map(|uc| ContainerDiff {
-                    id: uc.id,
-                    path: uc.path,
-                    idx: uc.idx,
-                    diff: external_diff_to_resolved(uc.diff, state, arena, txn),
-                })
-                .collect::<Vec<_>>(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -125,7 +81,7 @@ pub(crate) struct InternalContainerDiff {
 #[derive(Debug, Clone, EnumAsInner)]
 pub(crate) enum DiffVariant {
     Internal(InternalDiff),
-    External(UnresolvedDiff),
+    External(Diff),
 }
 
 /// It's used for transmitting and recording the diff internally.
@@ -192,12 +148,6 @@ pub(crate) enum InternalDiff {
     Tree(TreeDelta),
 }
 
-impl From<UnresolvedDiff> for DiffVariant {
-    fn from(diff: UnresolvedDiff) -> Self {
-        DiffVariant::External(diff)
-    }
-}
-
 impl From<InternalDiff> for DiffVariant {
     fn from(diff: InternalDiff) -> Self {
         DiffVariant::Internal(diff)
@@ -214,17 +164,6 @@ impl From<InternalDiff> for DiffVariant {
 /// - When `wasm` is enabled, it should use utf16 indexes.
 /// - When `wasm` is disabled, it should use unicode indexes.
 #[non_exhaustive]
-#[derive(Clone, Debug, EnumAsInner, Serialize)]
-pub enum UnresolvedDiff {
-    List(Delta<Vec<LoroValue>>),
-    /// - When feature `wasm` is enabled, it should use utf16 indexes.
-    /// - When feature `wasm` is disabled, it should use unicode indexes.
-    Text(Delta<StringSlice, StyleMeta>),
-    Map(MapDelta),
-    Tree(TreeDiff),
-}
-
-#[non_exhaustive]
 #[derive(Clone, Debug, EnumAsInner)]
 pub enum Diff {
     List(Delta<Vec<ValueOrContainer>>),
@@ -233,6 +172,12 @@ pub enum Diff {
     Text(Delta<StringSlice, StyleMeta>),
     Map(ResolvedMapDelta),
     Tree(TreeDiff),
+}
+
+impl From<Diff> for DiffVariant {
+    fn from(diff: Diff) -> Self {
+        DiffVariant::External(diff)
+    }
 }
 
 impl InternalDiff {
@@ -261,128 +206,43 @@ impl InternalDiff {
     }
 }
 
-impl UnresolvedDiff {
-    pub(crate) fn compose(self, diff: UnresolvedDiff) -> Result<UnresolvedDiff, Self> {
+impl Diff {
+    pub(crate) fn compose(self, diff: Diff) -> Result<Self, Self> {
         // PERF: avoid clone
         match (self, diff) {
-            (UnresolvedDiff::List(a), UnresolvedDiff::List(b)) => {
-                Ok(UnresolvedDiff::List(a.compose(b)))
-            }
-            (UnresolvedDiff::Text(a), UnresolvedDiff::Text(b)) => {
-                Ok(UnresolvedDiff::Text(a.compose(b)))
-            }
-            (UnresolvedDiff::Map(a), UnresolvedDiff::Map(b)) => {
-                Ok(UnresolvedDiff::Map(a.compose(b)))
-            }
+            (Diff::List(a), Diff::List(b)) => Ok(Diff::List(a.compose(b))),
+            (Diff::Text(a), Diff::Text(b)) => Ok(Diff::Text(a.compose(b))),
+            (Diff::Map(a), Diff::Map(b)) => Ok(Diff::Map(a.compose(b))),
 
-            (UnresolvedDiff::Tree(a), UnresolvedDiff::Tree(b)) => {
-                Ok(UnresolvedDiff::Tree(a.compose(b)))
-            }
+            (Diff::Tree(a), Diff::Tree(b)) => Ok(Diff::Tree(a.compose(b))),
             (a, _) => Err(a),
         }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         match self {
-            UnresolvedDiff::List(s) => s.is_empty(),
-            UnresolvedDiff::Text(t) => t.is_empty(),
-            UnresolvedDiff::Map(m) => m.updated.is_empty(),
-            UnresolvedDiff::Tree(t) => t.diff.is_empty(),
+            Diff::List(s) => s.is_empty(),
+            Diff::Text(t) => t.is_empty(),
+            Diff::Map(m) => m.updated.is_empty(),
+            Diff::Tree(t) => t.diff.is_empty(),
         }
     }
 
-    pub(crate) fn concat(self, diff: UnresolvedDiff) -> UnresolvedDiff {
+    pub(crate) fn concat(self, diff: Diff) -> Diff {
         match (self, diff) {
-            (UnresolvedDiff::List(a), UnresolvedDiff::List(b)) => {
-                UnresolvedDiff::List(a.compose(b))
-            }
-            (UnresolvedDiff::Text(a), UnresolvedDiff::Text(b)) => {
-                UnresolvedDiff::Text(a.compose(b))
-            }
-            (UnresolvedDiff::Map(a), UnresolvedDiff::Map(b)) => {
+            (Diff::List(a), Diff::List(b)) => Diff::List(a.compose(b)),
+            (Diff::Text(a), Diff::Text(b)) => Diff::Text(a.compose(b)),
+            (Diff::Map(a), Diff::Map(b)) => {
                 let mut a = a;
                 for (k, v) in b.updated {
                     a = a.with_entry(k, v);
                 }
-                UnresolvedDiff::Map(a)
+                Diff::Map(a)
             }
 
-            (UnresolvedDiff::Tree(a), UnresolvedDiff::Tree(b)) => {
-                UnresolvedDiff::Tree(a.extend(b.diff))
-            }
+            (Diff::Tree(a), Diff::Tree(b)) => Diff::Tree(a.extend(b.diff)),
             _ => unreachable!(),
         }
-    }
-}
-
-pub(crate) fn external_diff_to_resolved(
-    diff: UnresolvedDiff,
-    state: &Weak<Mutex<DocState>>,
-    arena: &SharedArena,
-    txn: &Weak<Mutex<Option<Transaction>>>,
-) -> Diff {
-    match diff {
-        UnresolvedDiff::List(list) => {
-            let vec = list
-                .vec
-                .into_iter()
-                .map(|item| match item {
-                    DeltaItem::Insert { insert, attributes } => {
-                        let insert = insert
-                            .into_iter()
-                            .map(|v| {
-                                if let LoroValue::Container(c) = v {
-                                    let idx = arena.id_to_idx(&c).unwrap();
-                                    ValueOrContainer::Container(Handler::new(
-                                        txn.clone(),
-                                        idx,
-                                        state.clone(),
-                                    ))
-                                } else {
-                                    ValueOrContainer::Value(v)
-                                }
-                            })
-                            .collect();
-                        DeltaItem::Insert { insert, attributes }
-                    }
-                    DeltaItem::Delete { delete, attributes } => {
-                        DeltaItem::Delete { delete, attributes }
-                    }
-                    DeltaItem::Retain { retain, attributes } => {
-                        DeltaItem::Retain { retain, attributes }
-                    }
-                })
-                .collect();
-            Diff::List(Delta { vec })
-        }
-        UnresolvedDiff::Map(map) => {
-            let mut resolved_map = FxHashMap::default();
-            for (k, v) in map.updated.into_iter() {
-                let counter = v.counter;
-                let lamport = v.lamport;
-                let value = v.value.map(|v| {
-                    if let LoroValue::Container(c) = v {
-                        let idx = arena.id_to_idx(&c).unwrap();
-                        ValueOrContainer::Container(Handler::new(txn.clone(), idx, state.clone()))
-                    } else {
-                        ValueOrContainer::Value(v)
-                    }
-                });
-                resolved_map.insert(
-                    k,
-                    ResolvedMapValue {
-                        counter,
-                        value,
-                        lamport,
-                    },
-                );
-            }
-            Diff::Map(ResolvedMapDelta {
-                updated: resolved_map,
-            })
-        }
-        UnresolvedDiff::Text(t) => Diff::Text(t),
-        UnresolvedDiff::Tree(t) => Diff::Tree(t),
     }
 }
 

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -5,7 +5,7 @@ use crate::{
     array_mut_ref,
     container::richtext::TextStyleInfoFlag,
     delta::{Delta, DeltaItem, StyleMeta},
-    event::ResolvedDiff,
+    event::Diff,
     loro::LoroDoc,
     state::ContainerState,
     utils::string_slice::StringSlice,
@@ -521,7 +521,7 @@ pub fn test_multi_sites(site_num: u8, actions: &mut [Action]) {
         loro.subscribe(
             &ContainerID::new_root("text", loro_common::ContainerType::Text),
             Arc::new(move |event| {
-                if let ResolvedDiff::Text(t) = &event.container.diff {
+                if let Diff::Text(t) = &event.container.diff {
                     let mut text = text_clone.lock().unwrap();
                     debug_log::debug_log!(
                         "RECEIVE site:{} event:{:#?}\nCURRENT: {:#?}",

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -5,6 +5,7 @@ use crate::{
     array_mut_ref,
     container::richtext::TextStyleInfoFlag,
     delta::{Delta, DeltaItem, StyleMeta},
+    event::ResolvedDiff,
     loro::LoroDoc,
     state::ContainerState,
     utils::string_slice::StringSlice,
@@ -520,7 +521,7 @@ pub fn test_multi_sites(site_num: u8, actions: &mut [Action]) {
         loro.subscribe(
             &ContainerID::new_root("text", loro_common::ContainerType::Text),
             Arc::new(move |event| {
-                if let crate::event::Diff::Text(t) = &event.container.diff {
+                if let ResolvedDiff::Text(t) = &event.container.diff {
                     let mut text = text_clone.lock().unwrap();
                     debug_log::debug_log!(
                         "RECEIVE site:{} event:{:#?}\nCURRENT: {:#?}",

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -570,7 +570,9 @@ pub fn test_multi_sites(site_num: u8, actions: &mut [Action]) {
     debug_log::group!("CheckTextEvent");
     for (i, (site, text)) in sites.iter().zip(texts.iter()).enumerate() {
         debug_log::group!("Check {}", i);
-        let diff = site.get_text("text").with_state_mut(|s| s.to_diff());
+        let diff = site.get_text("text").with_state_mut(|s| {
+            s.to_diff(site.arena(), &site.get_global_txn(), &site.weak_state())
+        });
         let mut diff = diff.into_text().unwrap();
         compact(&mut diff);
         let mut text = text.lock().unwrap();

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -13,8 +13,7 @@ use tabled::{TableIteratorExt, Tabled};
 
 #[allow(unused_imports)]
 use crate::{
-    array_mut_ref, container::ContainerID, delta::DeltaItem, event::UnresolvedDiff, id::PeerID,
-    ContainerType, LoroValue,
+    array_mut_ref, container::ContainerID, delta::DeltaItem, id::PeerID, ContainerType, LoroValue,
 };
 use crate::{
     container::{

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -162,7 +162,7 @@ impl Actor {
                     return;
                 }
                 let mut map = map.lock().unwrap();
-                if let Diff::NewMap(map_diff) = &event.container.diff {
+                if let Diff::Map(map_diff) = &event.container.diff {
                     for (key, value) in map_diff.updated.iter() {
                         match &value.value {
                             Some(value) => {

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -13,7 +13,7 @@ use tabled::{TableIteratorExt, Tabled};
 
 #[allow(unused_imports)]
 use crate::{
-    array_mut_ref, container::ContainerID, delta::DeltaItem, event::Diff, id::PeerID,
+    array_mut_ref, container::ContainerID, delta::DeltaItem, event::UnresolvedDiff, id::PeerID,
     ContainerType, LoroValue,
 };
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
         idx::ContainerIdx,
         richtext::richtext_state::{unicode_to_utf8_index, utf16_to_utf8_index},
     },
-    event::ResolvedDiff,
+    event::Diff,
     handler::{TextHandler, ValueOrContainer},
     loro::LoroDoc,
     value::ToJson,
@@ -107,7 +107,7 @@ impl Actor {
 
                 let mut text = text.lock().unwrap();
                 match &event.container.diff {
-                    ResolvedDiff::Text(delta) => {
+                    Diff::Text(delta) => {
                         let mut index = 0;
                         for item in delta.iter() {
                             match item {
@@ -162,7 +162,7 @@ impl Actor {
                     return;
                 }
                 let mut map = map.lock().unwrap();
-                if let ResolvedDiff::NewMap(map_diff) = &event.container.diff {
+                if let Diff::NewMap(map_diff) = &event.container.diff {
                     for (key, value) in map_diff.updated.iter() {
                         match &value.value {
                             Some(value) => {
@@ -195,7 +195,7 @@ impl Actor {
                     return;
                 }
                 let mut list = list.lock().unwrap();
-                if let ResolvedDiff::List(delta) = &event.container.diff {
+                if let Diff::List(delta) = &event.container.diff {
                     let mut index = 0;
                     for item in delta.iter() {
                         match item {

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -126,7 +126,7 @@ impl Actor {
                     let map = Arc::make_mut(map.as_map_mut().unwrap());
                     let meta = map.get_mut("meta").unwrap();
                     let meta = Arc::make_mut(meta.as_map_mut().unwrap());
-                    if let Diff::NewMap(update) = &event.container.diff {
+                    if let Diff::Map(update) = &event.container.diff {
                         for (key, value) in update.updated.iter() {
                             match &value.value {
                                 Some(value) => {

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use crate::{
     delta::TreeValue,
-    event::Index,
+    event::{Index, ResolvedDiff},
     handler::TreeHandler,
     loro::LoroDoc,
     value::{unresolved_to_collection, ToJson},
@@ -126,7 +126,7 @@ impl Actor {
                     let map = Arc::make_mut(map.as_map_mut().unwrap());
                     let meta = map.get_mut("meta").unwrap();
                     let meta = Arc::make_mut(meta.as_map_mut().unwrap());
-                    if let Diff::NewMap(update) = &event.container.diff {
+                    if let ResolvedDiff::NewMap(update) = &event.container.diff {
                         for (key, value) in update.updated.iter() {
                             match &value.value {
                                 Some(value) => {
@@ -142,7 +142,7 @@ impl Actor {
                     return;
                 }
                 let mut tree = tree.lock().unwrap();
-                if let Diff::Tree(tree_diff) = &event.container.diff {
+                if let ResolvedDiff::Tree(tree_diff) = &event.container.diff {
                     let mut v = TreeValue(&mut tree);
                     v.apply_diff(tree_diff);
                 } else {

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -13,12 +13,12 @@ use tabled::{TableIteratorExt, Tabled};
 
 #[allow(unused_imports)]
 use crate::{
-    array_mut_ref, container::ContainerID, delta::DeltaItem, event::Diff, id::PeerID,
+    array_mut_ref, container::ContainerID, delta::DeltaItem, event::UnresolvedDiff, id::PeerID,
     ContainerType, LoroValue,
 };
 use crate::{
     delta::TreeValue,
-    event::{Index, ResolvedDiff},
+    event::{Diff, Index},
     handler::TreeHandler,
     loro::LoroDoc,
     value::{unresolved_to_collection, ToJson},
@@ -126,7 +126,7 @@ impl Actor {
                     let map = Arc::make_mut(map.as_map_mut().unwrap());
                     let meta = map.get_mut("meta").unwrap();
                     let meta = Arc::make_mut(meta.as_map_mut().unwrap());
-                    if let ResolvedDiff::NewMap(update) = &event.container.diff {
+                    if let Diff::NewMap(update) = &event.container.diff {
                         for (key, value) in update.updated.iter() {
                             match &value.value {
                                 Some(value) => {
@@ -142,7 +142,7 @@ impl Actor {
                     return;
                 }
                 let mut tree = tree.lock().unwrap();
-                if let ResolvedDiff::Tree(tree_diff) = &event.container.diff {
+                if let Diff::Tree(tree_diff) = &event.container.diff {
                     let mut v = TreeValue(&mut tree);
                     v.apply_diff(tree_diff);
                 } else {

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -13,8 +13,7 @@ use tabled::{TableIteratorExt, Tabled};
 
 #[allow(unused_imports)]
 use crate::{
-    array_mut_ref, container::ContainerID, delta::DeltaItem, event::UnresolvedDiff, id::PeerID,
-    ContainerType, LoroValue,
+    array_mut_ref, container::ContainerID, delta::DeltaItem, id::PeerID, ContainerType, LoroValue,
 };
 use crate::{
     delta::TreeValue,

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -122,7 +122,7 @@ impl Handler {
 }
 
 impl Handler {
-    fn new(
+    pub(crate) fn new(
         txn: Weak<Mutex<Option<Transaction>>>,
         idx: ContainerIdx,
         state: Weak<Mutex<DocState>>,

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -20,8 +20,7 @@ use crate::{
     handler::TextHandler,
     handler::TreeHandler,
     id::PeerID,
-    version::Frontiers,
-    DocDiff, InternalString, LoroError, VersionVector,
+    version::Frontiers, InternalString, LoroError, VersionVector,
 };
 
 use super::{
@@ -329,9 +328,9 @@ impl LoroDoc {
         );
 
         let obs = self.observer.clone();
-        let weak_state = Arc::downgrade(&self.state);
-        let arena = self.arena.clone();
-        let weak_txn = Arc::downgrade(&self.txn);
+        let _weak_state = Arc::downgrade(&self.state);
+        let _arena = self.arena.clone();
+        let _weak_txn = Arc::downgrade(&self.txn);
         txn.set_on_commit(Box::new(move |state| {
             let mut state = state.try_lock().unwrap();
             let events = state.take_events();

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -68,8 +68,12 @@ impl LoroDoc {
     pub fn new() -> Self {
         let oplog = OpLog::new();
         let arena = oplog.arena.clone();
+        let txn = Arc::new(Mutex::new(None));
         // share arena
-        let state = Arc::new(Mutex::new(DocState::new(arena.clone())));
+        let state = Arc::new(Mutex::new(DocState::new(
+            arena.clone(),
+            Arc::downgrade(&txn),
+        )));
         Self {
             oplog: Arc::new(Mutex::new(oplog)),
             state,
@@ -77,7 +81,7 @@ impl LoroDoc {
             auto_commit: false,
             observer: Arc::new(Observer::new(arena.clone())),
             diff_calculator: Arc::new(Mutex::new(DiffCalculator::new())),
-            txn: Arc::new(Mutex::new(None)),
+            txn,
             arena,
         }
     }

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -447,6 +447,9 @@ impl LoroDoc {
 
     fn emit_events(&self, state: &mut DocState) {
         let events = state.take_events();
+        {
+            println!("txn {:?}", self.txn.lock().unwrap().is_some());
+        }
         for event in events {
             self.observer.emit(DocDiff::from_unsolved_diff(
                 event,

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -20,7 +20,8 @@ use crate::{
     handler::TextHandler,
     handler::TreeHandler,
     id::PeerID,
-    version::Frontiers, InternalString, LoroError, VersionVector,
+    version::Frontiers,
+    InternalString, LoroError, VersionVector,
 };
 
 use super::{
@@ -328,9 +329,6 @@ impl LoroDoc {
         );
 
         let obs = self.observer.clone();
-        let _weak_state = Arc::downgrade(&self.state);
-        let _arena = self.arena.clone();
-        let _weak_txn = Arc::downgrade(&self.txn);
         txn.set_on_commit(Box::new(move |state| {
             let mut state = state.try_lock().unwrap();
             let events = state.take_events();
@@ -442,9 +440,6 @@ impl LoroDoc {
 
     fn emit_events(&self, state: &mut DocState) {
         let events = state.take_events();
-        {
-            println!("txn {:?}", self.txn.lock().unwrap().is_some());
-        }
         for event in events {
             self.observer.emit(event);
         }

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -800,6 +800,7 @@ impl DocState {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn bring_back_sub_container(
     state_diff: &Diff,
     queue: &mut Vec<InternalContainerDiff>,

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -802,7 +802,7 @@ fn bring_back_sub_container(
                 }
             }
         }
-        UnresolvedDiff::NewMap(map) => {
+        UnresolvedDiff::Map(map) => {
             for (_, v) in map.updated.iter() {
                 if let Some(LoroValue::Container(id)) = &v.value {
                     let idx = arena.id_to_idx(id).unwrap();

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -5,7 +5,7 @@ use crate::{
     arena::SharedArena,
     container::{idx::ContainerIdx, ContainerID},
     delta::Delta,
-    event::{Diff, Index, InternalDiff},
+    event::{Index, InternalDiff, UnresolvedDiff},
     op::{ListSlice, Op, RawOp, RawOpContent},
     LoroValue,
 };
@@ -289,7 +289,11 @@ impl ListState {
 }
 
 impl ContainerState for ListState {
-    fn apply_diff_and_convert(&mut self, diff: InternalDiff, arena: &SharedArena) -> Diff {
+    fn apply_diff_and_convert(
+        &mut self,
+        diff: InternalDiff,
+        arena: &SharedArena,
+    ) -> UnresolvedDiff {
         let InternalDiff::SeqRaw(delta) = diff else {
             unreachable!()
         };
@@ -326,7 +330,7 @@ impl ContainerState for ListState {
             }
         }
 
-        Diff::List(ans)
+        UnresolvedDiff::List(ans)
     }
 
     fn apply_diff(&mut self, diff: InternalDiff, arena: &SharedArena) {
@@ -438,8 +442,8 @@ impl ContainerState for ListState {
 
     #[doc = " Convert a state to a diff that when apply this diff on a empty state,"]
     #[doc = " the state will be the same as this state."]
-    fn to_diff(&mut self) -> Diff {
-        Diff::List(Delta::new().insert(self.to_vec()))
+    fn to_diff(&mut self) -> UnresolvedDiff {
+        UnresolvedDiff::List(Delta::new().insert(self.to_vec()))
     }
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -348,8 +348,8 @@ impl ContainerState for ListState {
         &mut self,
         diff: InternalDiff,
         arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        _txn: &Weak<Mutex<Option<Transaction>>>,
+        _state: &Weak<Mutex<DocState>>,
     ) {
         match diff {
             InternalDiff::SeqRaw(delta) => {

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -7,7 +7,7 @@ use crate::{
     arena::SharedArena,
     container::{idx::ContainerIdx, map::MapSet},
     delta::MapValue,
-    event::{Diff, Index, InternalDiff},
+    event::{Index, InternalDiff, UnresolvedDiff},
     op::{Op, RawOp, RawOpContent},
     InternalString, LoroValue,
 };
@@ -23,7 +23,11 @@ pub struct MapState {
 }
 
 impl ContainerState for MapState {
-    fn apply_diff_and_convert(&mut self, diff: InternalDiff, arena: &SharedArena) -> Diff {
+    fn apply_diff_and_convert(
+        &mut self,
+        diff: InternalDiff,
+        arena: &SharedArena,
+    ) -> UnresolvedDiff {
         let InternalDiff::Map(delta) = diff else {
             unreachable!()
         };
@@ -38,7 +42,7 @@ impl ContainerState for MapState {
             self.store_txn_snapshot(key.clone(), old);
         }
 
-        Diff::NewMap(delta)
+        UnresolvedDiff::NewMap(delta)
     }
 
     fn apply_op(&mut self, op: &RawOp, _: &Op, arena: &SharedArena) -> LoroResult<()> {
@@ -104,8 +108,8 @@ impl ContainerState for MapState {
 
     #[doc = " Convert a state to a diff that when apply this diff on a empty state,"]
     #[doc = " the state will be the same as this state."]
-    fn to_diff(&mut self) -> Diff {
-        Diff::NewMap(crate::delta::MapDelta {
+    fn to_diff(&mut self) -> UnresolvedDiff {
+        UnresolvedDiff::NewMap(crate::delta::MapDelta {
             updated: self.map.clone(),
         })
     }

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -1,4 +1,7 @@
-use std::{mem, sync::Arc};
+use std::{
+    mem,
+    sync::{Arc, Mutex, Weak},
+};
 
 use fxhash::FxHashMap;
 use loro_common::{ContainerID, LoroResult};
@@ -6,10 +9,12 @@ use loro_common::{ContainerID, LoroResult};
 use crate::{
     arena::SharedArena,
     container::{idx::ContainerIdx, map::MapSet},
-    delta::MapValue,
-    event::{Index, InternalDiff, UnresolvedDiff},
+    delta::{MapValue, ResolvedMapDelta, ResolvedMapValue},
+    event::{Diff, Index, InternalDiff},
+    handler::ValueOrContainer,
     op::{Op, RawOp, RawOpContent},
-    InternalString, LoroValue,
+    txn::Transaction,
+    DocState, InternalString, LoroValue,
 };
 
 use super::ContainerState;
@@ -27,12 +32,14 @@ impl ContainerState for MapState {
         &mut self,
         diff: InternalDiff,
         arena: &SharedArena,
-    ) -> UnresolvedDiff {
+        txn: &Weak<Mutex<Option<Transaction>>>,
+        state: &Weak<Mutex<DocState>>,
+    ) -> Diff {
         let InternalDiff::Map(delta) = diff else {
             unreachable!()
         };
-
-        for (key, value) in delta.updated.iter() {
+        let mut resolved_delta = ResolvedMapDelta::new();
+        for (key, value) in delta.updated.into_iter() {
             if let Some(LoroValue::Container(c)) = &value.value {
                 let idx = arena.register_container(c);
                 arena.set_parent(idx, Some(self.idx));
@@ -40,9 +47,19 @@ impl ContainerState for MapState {
 
             let old = self.map.insert(key.clone(), value.clone());
             self.store_txn_snapshot(key.clone(), old);
+            resolved_delta = resolved_delta.with_entry(
+                key,
+                ResolvedMapValue {
+                    counter: value.counter,
+                    lamport: value.lamport,
+                    value: value
+                        .value
+                        .map(|v| ValueOrContainer::from_value(v, arena, txn, state)),
+                },
+            )
         }
 
-        UnresolvedDiff::Map(delta)
+        Diff::Map(resolved_delta)
     }
 
     fn apply_op(&mut self, op: &RawOp, _: &Op, arena: &SharedArena) -> LoroResult<()> {
@@ -108,9 +125,19 @@ impl ContainerState for MapState {
 
     #[doc = " Convert a state to a diff that when apply this diff on a empty state,"]
     #[doc = " the state will be the same as this state."]
-    fn to_diff(&mut self) -> UnresolvedDiff {
-        UnresolvedDiff::Map(crate::delta::MapDelta {
-            updated: self.map.clone(),
+    fn to_diff(
+        &mut self,
+        arena: &SharedArena,
+        txn: &Weak<Mutex<Option<Transaction>>>,
+        state: &Weak<Mutex<DocState>>,
+    ) -> Diff {
+        Diff::Map(ResolvedMapDelta {
+            updated: self
+                .map
+                .clone()
+                .into_iter()
+                .map(|(k, v)| (k, ResolvedMapValue::from_map_value(v, arena, txn, state)))
+                .collect::<FxHashMap<_, _>>(),
         })
     }
 

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -42,7 +42,7 @@ impl ContainerState for MapState {
             self.store_txn_snapshot(key.clone(), old);
         }
 
-        UnresolvedDiff::NewMap(delta)
+        UnresolvedDiff::Map(delta)
     }
 
     fn apply_op(&mut self, op: &RawOp, _: &Op, arena: &SharedArena) -> LoroResult<()> {
@@ -109,7 +109,7 @@ impl ContainerState for MapState {
     #[doc = " Convert a state to a diff that when apply this diff on a empty state,"]
     #[doc = " the state will be the same as this state."]
     fn to_diff(&mut self) -> UnresolvedDiff {
-        UnresolvedDiff::NewMap(crate::delta::MapDelta {
+        UnresolvedDiff::Map(crate::delta::MapDelta {
             updated: self.map.clone(),
         })
     }

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -143,8 +143,8 @@ impl ContainerState for RichtextState {
         &mut self,
         diff: InternalDiff,
         _arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        _txn: &Weak<Mutex<Option<Transaction>>>,
+        _state: &Weak<Mutex<DocState>>,
     ) -> Diff {
         let InternalDiff::RichtextRaw(richtext) = diff else {
             unreachable!()
@@ -273,8 +273,8 @@ impl ContainerState for RichtextState {
         &mut self,
         diff: InternalDiff,
         _arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        _txn: &Weak<Mutex<Option<Transaction>>>,
+        _state: &Weak<Mutex<DocState>>,
     ) {
         let InternalDiff::RichtextRaw(richtext) = diff else {
             unreachable!()
@@ -410,9 +410,9 @@ impl ContainerState for RichtextState {
 
     fn to_diff(
         &mut self,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        _arena: &SharedArena,
+        _txn: &Weak<Mutex<Option<Transaction>>>,
+        _state: &Weak<Mutex<DocState>>,
     ) -> Diff {
         let mut delta = crate::delta::Delta::new();
         for span in self.state.get_mut().iter() {

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -13,7 +13,7 @@ use crate::{
     arena::SharedArena,
     container::tree::tree_op::TreeOp,
     delta::TreeInternalDiff,
-    event::{Diff, Index},
+    event::{Index, UnresolvedDiff},
     op::RawOp,
 };
 
@@ -166,7 +166,7 @@ impl ContainerState for TreeState {
         &mut self,
         diff: crate::event::InternalDiff,
         _arena: &SharedArena,
-    ) -> Diff {
+    ) -> UnresolvedDiff {
         if let InternalDiff::Tree(tree) = &diff {
             // assert never cause cycle move
             for diff in tree.diff.iter() {
@@ -201,7 +201,7 @@ impl ContainerState for TreeState {
             .into_iter()
             .flat_map(TreeDiffItem::from_delta_item)
             .collect_vec();
-        Diff::Tree(TreeDiff { diff: ans })
+        UnresolvedDiff::Tree(TreeDiff { diff: ans })
     }
 
     fn apply_op(
@@ -219,7 +219,7 @@ impl ContainerState for TreeState {
         }
     }
 
-    fn to_diff(&mut self) -> Diff {
+    fn to_diff(&mut self) -> UnresolvedDiff {
         let mut diffs = vec![];
         // TODO: perf
         let forest = Forest::from_tree_state(&self.trees);
@@ -242,7 +242,7 @@ impl ContainerState for TreeState {
             q.extend(node.children);
         }
 
-        Diff::Tree(TreeDiff { diff: diffs })
+        UnresolvedDiff::Tree(TreeDiff { diff: diffs })
     }
 
     fn start_txn(&mut self) {

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -167,8 +167,8 @@ impl ContainerState for TreeState {
         &mut self,
         diff: crate::event::InternalDiff,
         _arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        _txn: &Weak<Mutex<Option<Transaction>>>,
+        _state: &Weak<Mutex<DocState>>,
     ) -> Diff {
         if let InternalDiff::Tree(tree) = &diff {
             // assert never cause cycle move
@@ -224,9 +224,9 @@ impl ContainerState for TreeState {
 
     fn to_diff(
         &mut self,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        _arena: &SharedArena,
+        _txn: &Weak<Mutex<Option<Transaction>>>,
+        _state: &Weak<Mutex<DocState>>,
     ) -> Diff {
         let mut diffs = vec![];
         // TODO: perf

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -597,7 +597,7 @@ fn change_to_diff(
                 }
                 EventHint::Map { key, value } => ans.push(TxnContainerDiff {
                     idx: op.container,
-                    diff: UnresolvedDiff::NewMap(crate::delta::MapDelta::new().with_entry(
+                    diff: UnresolvedDiff::Map(crate::delta::MapDelta::new().with_entry(
                         key,
                         MapValue {
                             counter: op.counter,

--- a/crates/loro-internal/src/value.rs
+++ b/crates/loro-internal/src/value.rs
@@ -215,7 +215,7 @@ impl ApplyDiff for LoroValue {
             LoroValue::Map(map) => {
                 for item in diff.iter() {
                     match item {
-                        Diff::NewMap(diff) => {
+                        Diff::Map(diff) => {
                             let map = Arc::make_mut(map);
                             for (key, value) in diff.updated.iter() {
                                 match &value.value {
@@ -247,7 +247,7 @@ impl ApplyDiff for LoroValue {
         let hint = match diff[0] {
             Diff::List(_) => TypeHint::List,
             Diff::Text(_) => TypeHint::Text,
-            Diff::NewMap(_) => TypeHint::Map,
+            Diff::Map(_) => TypeHint::Map,
             Diff::Tree(_) => TypeHint::Tree,
         };
         let value = {

--- a/crates/loro-internal/src/value.rs
+++ b/crates/loro-internal/src/value.rs
@@ -313,16 +313,14 @@ pub(crate) fn unresolved_to_collection(v: &ValueOrContainer) -> LoroValue {
 
 #[cfg(feature = "wasm")]
 pub mod wasm {
-    use std::sync::Arc;
 
-    use js_sys::{Array, Object, Uint8Array};
+    use js_sys::{Array, Object};
     use wasm_bindgen::{JsValue, __rt::IntoJsResult};
 
     use crate::{
-        delta::{Delta, DeltaItem, MapDelta, MapDiff, Meta, StyleMeta, TreeDiff, TreeExternalDiff},
-        event::{Diff, Index, ResolvedDiff},
+        delta::{Delta, DeltaItem, Meta, StyleMeta, TreeDiff, TreeExternalDiff},
+        event::Index,
         utils::string_slice::StringSlice,
-        LoroValue,
     };
 
     impl From<Index> for JsValue {

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -261,7 +261,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::Diff::Text(_)
+                loro_internal::event::ResolvedDiff::Text(_)
             ))
         }),
     );
@@ -270,7 +270,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::Diff::NewMap(_)
+                loro_internal::event::ResolvedDiff::NewMap(_)
             ))
         }),
     );
@@ -279,7 +279,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::Diff::List(_)
+                loro_internal::event::ResolvedDiff::List(_)
             ))
         }),
     );

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -2,7 +2,10 @@ use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
 use loro_common::{ContainerID, ContainerType, LoroValue, ID};
 use loro_internal::{
-    container::richtext::TextStyleInfoFlag, version::Frontiers, ApplyDiff, LoroDoc, ToJson,
+    container::richtext::TextStyleInfoFlag,
+    handler::{Handler, ValueOrContainer},
+    version::Frontiers,
+    ApplyDiff, LoroDoc, ToJson,
 };
 use serde_json::json;
 
@@ -26,6 +29,34 @@ fn event_from_checkout() {
     }));
     a.checkout(&version).unwrap();
     assert!(ran_cloned.load(std::sync::atomic::Ordering::Relaxed));
+}
+
+#[test]
+fn handler_in_event() {
+    let doc = LoroDoc::new_auto_commit();
+    doc.subscribe_root(Arc::new(|e| {
+        let value = e
+            .container
+            .diff
+            .as_list()
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .as_insert()
+            .unwrap()
+            .0
+            .iter()
+            .next()
+            .unwrap();
+        assert!(matches!(
+            value,
+            ValueOrContainer::Container(Handler::Text(_))
+        ));
+    }));
+    let list = doc.get_list("list");
+    list.insert_container(0, ContainerType::Text).unwrap();
+    doc.commit_then_renew();
 }
 
 #[test]

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -270,7 +270,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::Diff::NewMap(_)
+                loro_internal::event::Diff::Map(_)
             ))
         }),
     );

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -261,7 +261,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::ResolvedDiff::Text(_)
+                loro_internal::event::Diff::Text(_)
             ))
         }),
     );
@@ -270,7 +270,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::ResolvedDiff::NewMap(_)
+                loro_internal::event::Diff::NewMap(_)
             ))
         }),
     );
@@ -279,7 +279,7 @@ fn import_after_init_handlers() {
         Arc::new(|event| {
             assert!(matches!(
                 event.container.diff,
-                loro_internal::event::ResolvedDiff::List(_)
+                loro_internal::event::Diff::List(_)
             ))
         }),
     );

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use loro_internal::delta::{DeltaItem, ResolvedMapDelta};
@@ -88,7 +88,7 @@ impl TryFrom<JsValue> for LoroMap {
     }
 }
 
-pub(crate) fn resolved_diff_to_js(value: Diff, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+pub(crate) fn resolved_diff_to_js(value: Diff, doc: Arc<LoroDoc>) -> JsValue {
     // create a obj
     let obj = Object::new();
     match value {
@@ -139,10 +139,7 @@ pub(crate) fn resolved_diff_to_js(value: Diff, doc: Arc<Mutex<LoroDoc>>) -> JsVa
     obj.into_js_result().unwrap()
 }
 
-fn delta_item_to_js(
-    item: DeltaItem<Vec<ValueOrContainer>, ()>,
-    doc: Arc<Mutex<LoroDoc>>,
-) -> JsValue {
+fn delta_item_to_js(item: DeltaItem<Vec<ValueOrContainer>, ()>, doc: Arc<LoroDoc>) -> JsValue {
     let obj = Object::new();
     match item {
         DeltaItem::Retain { retain: len, .. } => {
@@ -220,7 +217,7 @@ pub fn convert(value: LoroValue) -> JsValue {
     }
 }
 
-fn map_delta_to_js(value: ResolvedMapDelta, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+fn map_delta_to_js(value: ResolvedMapDelta, doc: Arc<LoroDoc>) -> JsValue {
     let obj = Object::new();
     for (key, value) in value.updated.iter() {
         let value = if let Some(value) = value.value.clone() {
@@ -238,7 +235,7 @@ fn map_delta_to_js(value: ResolvedMapDelta, doc: Arc<Mutex<LoroDoc>>) -> JsValue
     obj.into_js_result().unwrap()
 }
 
-pub(crate) fn handler_to_js_value(handler: Handler, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+pub(crate) fn handler_to_js_value(handler: Handler, doc: Arc<LoroDoc>) -> JsValue {
     match handler {
         Handler::Text(t) => LoroText {
             handler: t,

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use loro_internal::delta::{DeltaItem, ResolvedMapDelta};
-use loro_internal::event::ResolvedDiff;
+use loro_internal::event::Diff;
 use loro_internal::handler::{Handler, ValueOrContainer};
 use loro_internal::{LoroDoc, LoroValue};
 use wasm_bindgen::JsValue;
@@ -88,17 +88,17 @@ impl TryFrom<JsValue> for LoroMap {
     }
 }
 
-pub(crate) fn resolved_diff_to_js(value: ResolvedDiff, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+pub(crate) fn resolved_diff_to_js(value: Diff, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
     // create a obj
     let obj = Object::new();
     match value {
-        ResolvedDiff::Tree(tree) => {
+        Diff::Tree(tree) => {
             js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("tree"))
                 .unwrap();
 
             js_sys::Reflect::set(&obj, &JsValue::from_str("diff"), &tree.into()).unwrap();
         }
-        ResolvedDiff::List(list) => {
+        Diff::List(list) => {
             // set type as "list"
             js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("list"))
                 .unwrap();
@@ -114,14 +114,14 @@ pub(crate) fn resolved_diff_to_js(value: ResolvedDiff, doc: Arc<Mutex<LoroDoc>>)
             )
             .unwrap();
         }
-        ResolvedDiff::Text(text) => {
+        Diff::Text(text) => {
             // set type as "text"
             js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("text"))
                 .unwrap();
             // set diff as array
             js_sys::Reflect::set(&obj, &JsValue::from_str("diff"), &JsValue::from(text)).unwrap();
         }
-        ResolvedDiff::NewMap(map) => {
+        Diff::NewMap(map) => {
             js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("map"))
                 .unwrap();
 

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -1,7 +1,14 @@
-use js_sys::{Object, Reflect};
+use std::sync::{Arc, Mutex};
+
+use js_sys::{Array, Object, Reflect, Uint8Array};
+use loro_internal::delta::{DeltaItem, ResolvedMapDelta};
+use loro_internal::event::ResolvedDiff;
+use loro_internal::handler::{Handler, ValueOrContainer};
+use loro_internal::{LoroDoc, LoroValue};
 use wasm_bindgen::JsValue;
 
-use crate::{LoroList, LoroMap, LoroText, PrelimList, PrelimMap, PrelimText};
+use crate::{LoroList, LoroMap, LoroText, LoroTree, PrelimList, PrelimMap, PrelimText};
+use wasm_bindgen::__rt::IntoJsResult;
 use wasm_bindgen::convert::FromWasmAbi;
 
 /// Convert a `JsValue` to `T` by constructor's name.
@@ -78,5 +85,168 @@ impl TryFrom<JsValue> for LoroMap {
 
     fn try_from(value: JsValue) -> Result<Self, Self::Error> {
         js_to_any(value, "LoroMap")
+    }
+}
+
+pub(crate) fn resolved_diff_to_js(value: ResolvedDiff, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+    // create a obj
+    let obj = Object::new();
+    match value {
+        ResolvedDiff::Tree(tree) => {
+            js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("tree"))
+                .unwrap();
+
+            js_sys::Reflect::set(&obj, &JsValue::from_str("diff"), &tree.into()).unwrap();
+        }
+        ResolvedDiff::List(list) => {
+            // set type as "list"
+            js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("list"))
+                .unwrap();
+            // set diff as array
+            let arr = Array::new_with_length(list.len() as u32);
+            for (i, v) in list.iter().enumerate() {
+                arr.set(i as u32, delta_item_to_js(v.clone(), doc.clone()));
+            }
+            js_sys::Reflect::set(
+                &obj,
+                &JsValue::from_str("diff"),
+                &arr.into_js_result().unwrap(),
+            )
+            .unwrap();
+        }
+        ResolvedDiff::Text(text) => {
+            // set type as "text"
+            js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("text"))
+                .unwrap();
+            // set diff as array
+            js_sys::Reflect::set(&obj, &JsValue::from_str("diff"), &JsValue::from(text)).unwrap();
+        }
+        ResolvedDiff::NewMap(map) => {
+            js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("map"))
+                .unwrap();
+
+            js_sys::Reflect::set(
+                &obj,
+                &JsValue::from_str("updated"),
+                &map_delta_to_js(map, doc),
+            )
+            .unwrap();
+        }
+        _ => unreachable!(),
+    };
+
+    // convert object to js value
+    obj.into_js_result().unwrap()
+}
+
+fn delta_item_to_js(
+    item: DeltaItem<Vec<ValueOrContainer>, ()>,
+    doc: Arc<Mutex<LoroDoc>>,
+) -> JsValue {
+    let obj = Object::new();
+    match item {
+        DeltaItem::Retain { retain: len, .. } => {
+            js_sys::Reflect::set(
+                &obj,
+                &JsValue::from_str("retain"),
+                &JsValue::from_f64(len as f64),
+            )
+            .unwrap();
+        }
+        DeltaItem::Insert { insert: value, .. } => {
+            let arr = Array::new_with_length(value.len() as u32);
+            for (i, v) in value.into_iter().enumerate() {
+                let value = match v {
+                    ValueOrContainer::Value(v) => convert(v),
+                    ValueOrContainer::Container(h) => handler_to_js_value(h, doc.clone()),
+                };
+                arr.set(i as u32, value);
+            }
+
+            js_sys::Reflect::set(
+                &obj,
+                &JsValue::from_str("insert"),
+                &arr.into_js_result().unwrap(),
+            )
+            .unwrap();
+        }
+        DeltaItem::Delete { delete: len, .. } => {
+            js_sys::Reflect::set(
+                &obj,
+                &JsValue::from_str("delete"),
+                &JsValue::from_f64(len as f64),
+            )
+            .unwrap();
+        }
+    }
+
+    obj.into_js_result().unwrap()
+}
+
+pub fn convert(value: LoroValue) -> JsValue {
+    match value {
+        LoroValue::Null => JsValue::NULL,
+        LoroValue::Bool(b) => JsValue::from_bool(b),
+        LoroValue::Double(f) => JsValue::from_f64(f),
+        LoroValue::I32(i) => JsValue::from_f64(i as f64),
+        LoroValue::String(s) => JsValue::from_str(&s),
+        LoroValue::List(list) => {
+            let list = Arc::try_unwrap(list).unwrap_or_else(|m| (*m).clone());
+            let arr = Array::new_with_length(list.len() as u32);
+            for (i, v) in list.into_iter().enumerate() {
+                arr.set(i as u32, convert(v));
+            }
+            arr.into_js_result().unwrap()
+        }
+        LoroValue::Map(m) => {
+            let m = Arc::try_unwrap(m).unwrap_or_else(|m| (*m).clone());
+            let map = Object::new();
+            for (k, v) in m.into_iter() {
+                let str: &str = &k;
+                js_sys::Reflect::set(&map, &JsValue::from_str(str), &convert(v)).unwrap();
+            }
+
+            map.into_js_result().unwrap()
+        }
+        LoroValue::Container(container_id) => JsValue::from(container_id),
+        LoroValue::Binary(binary) => {
+            let binary = Arc::try_unwrap(binary).unwrap_or_else(|m| (*m).clone());
+            let arr = Uint8Array::new_with_length(binary.len() as u32);
+            for (i, v) in binary.into_iter().enumerate() {
+                arr.set_index(i as u32, v);
+            }
+            arr.into_js_result().unwrap()
+        }
+    }
+}
+
+fn map_delta_to_js(value: ResolvedMapDelta, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+    let obj = Object::new();
+    for (key, value) in value.updated.iter() {
+        let value = if let Some(value) = value.value.clone() {
+            match value {
+                ValueOrContainer::Value(v) => convert(v),
+                ValueOrContainer::Container(h) => handler_to_js_value(h, doc.clone()),
+            }
+        } else {
+            JsValue::null()
+        };
+
+        js_sys::Reflect::set(&obj, &JsValue::from_str(key), &value).unwrap();
+    }
+
+    obj.into_js_result().unwrap()
+}
+
+pub(crate) fn handler_to_js_value(handler: Handler, doc: Arc<Mutex<LoroDoc>>) -> JsValue {
+    match handler {
+        Handler::Text(t) => LoroText {
+            handler: t,
+            _doc: doc,
+        }
+        .into(),
+        Handler::Map(m) => LoroMap { handler: m, doc }.into(),
+        Handler::List(l) => LoroList { handler: l, doc }.into(),
+        Handler::Tree(t) => LoroTree { handler: t, doc }.into(),
     }
 }

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -121,7 +121,7 @@ pub(crate) fn resolved_diff_to_js(value: Diff, doc: Arc<Mutex<LoroDoc>>) -> JsVa
             // set diff as array
             js_sys::Reflect::set(&obj, &JsValue::from_str("diff"), &JsValue::from(text)).unwrap();
         }
-        Diff::NewMap(map) => {
+        Diff::Map(map) => {
             js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("map"))
                 .unwrap();
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -6,10 +6,8 @@ use loro_internal::{
         richtext::{ExpandType, TextStyleInfoFlag},
         ContainerID,
     },
-    event::{Diff, Index, ResolvedDiff},
-    handler::{
-        Handler, ListHandler, MapHandler, TextDelta, TextHandler, TreeHandler, ValueOrContainer,
-    },
+    event::{Index, ResolvedDiff},
+    handler::{ListHandler, MapHandler, TextDelta, TextHandler, TreeHandler, ValueOrContainer},
     id::{Counter, PeerID, TreeID, ID},
     obs::SubID,
     version::Frontiers,

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -6,7 +6,7 @@ use loro_internal::{
         richtext::{ExpandType, TextStyleInfoFlag},
         ContainerID,
     },
-    event::{Index, ResolvedDiff},
+    event::{Diff, Index},
     handler::{ListHandler, MapHandler, TextDelta, TextHandler, TreeHandler, ValueOrContainer},
     id::{Counter, PeerID, TreeID, ID},
     obs::SubID,
@@ -999,7 +999,7 @@ pub struct Event {
     origin: String,
     target: ContainerID,
     from_checkout: bool,
-    diff: ResolvedDiff,
+    diff: Diff,
     path: JsValue,
 }
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -16,13 +16,7 @@ use loro_internal::{
 };
 use rle::HasLength;
 use serde::{Deserialize, Serialize};
-use std::{
-    cell::RefCell,
-    cmp::Ordering,
-    panic,
-    rc::Rc,
-    sync::{Arc, Mutex},
-};
+use std::{cell::RefCell, cmp::Ordering, panic, rc::Rc, sync::Arc};
 use wasm_bindgen::{__rt::IntoJsResult, prelude::*};
 mod log;
 mod prelim;
@@ -1194,11 +1188,11 @@ impl LoroText {
     /// returns a subscription id, which can be used to unsubscribe.
     pub fn subscribe(&self, loro: &Loro, f: js_sys::Function) -> JsResult<u32> {
         let observer = observer::Observer::new(f);
-        let doc = self.0.clone();
+        let doc = loro.0.clone();
         let ans = loro.0.subscribe(
             &self.handler.id(),
             Arc::new(move |e| {
-                call_after_micro_task(observer.clone(), e,doc);
+                call_after_micro_task(observer.clone(), e, doc.clone());
             }),
         );
 

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -1,13 +1,7 @@
 export * from "loro-wasm";
 import { Container, ContainerType, Delta, OpId, Value } from "loro-wasm";
 import { PrelimText, PrelimList, PrelimMap } from "loro-wasm";
-import {
-  ContainerID,
-  Loro,
-  LoroList,
-  LoroMap,
-  TreeID,
-} from "loro-wasm";
+import { ContainerID, Loro, LoroList, LoroMap, TreeID } from "loro-wasm";
 
 Loro.prototype.getTypedMap = function (...args) {
   return this.getMap(...args);
@@ -79,7 +73,7 @@ export interface LoroEvent {
 
 export type ListDiff = {
   type: "list";
-  diff: Delta<Value[]>[];
+  diff: Delta<(Value | Container)[]>[];
 };
 
 export type TextDiff = {
@@ -89,14 +83,14 @@ export type TextDiff = {
 
 export type MapDiff = {
   type: "map";
-  updated: Record<string, Value | undefined>;
+  updated: Record<string, Value | Container | undefined>;
 };
 
 export type TreeDiff = {
   type: "tree";
   diff:
-  | { target: TreeID; action: "create" | "delete" }
-  | { target: TreeID; action: "move"; parent: TreeID };
+    | { target: TreeID; action: "create" | "delete" }
+    | { target: TreeID; action: "move"; parent: TreeID };
 };
 
 export type Diff = ListDiff | TextDiff | MapDiff | TreeDiff;
@@ -137,10 +131,10 @@ declare module "loro-wasm" {
 
   interface Loro<T extends Record<string, any> = Record<string, any>> {
     getTypedMap<Key extends keyof T & string>(
-      name: Key,
+      name: Key
     ): T[Key] extends LoroMap ? T[Key] : never;
     getTypedList<Key extends keyof T & string>(
-      name: Key,
+      name: Key
     ): T[Key] extends LoroList ? T[Key] : never;
   }
 
@@ -180,7 +174,7 @@ declare module "loro-wasm" {
     subscribe(txn: Loro, listener: Listener): number;
   }
 
-  interface LoroTree{
+  interface LoroTree {
     create(parent: TreeID | undefined): TreeID;
     mov(target: TreeID, parent: TreeID | undefined): void;
     delete(target: TreeID): void;

--- a/loro-js/tests/event.test.ts
+++ b/loro-js/tests/event.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   Delta,
   ListDiff,
   Loro,
+  LoroText,
   LoroEvent,
-  MapDiff as MapDiff,
+  MapDiff,
   TextDiff,
   setPanicHook,
 } from "../src";
@@ -292,6 +293,26 @@ describe("event", () => {
       loro.commit();
       await oneMs();
       expect(text.toString()).toBe(string);
+    });
+  });
+
+  describe("handler in event", () => {
+    it("test", async () => {
+      const loro = new Loro();
+      const list = loro.getList("list");
+      let first = true;
+      loro.subscribe((e) => {
+        if(first){
+          const diff = e.diff.diff;
+          const text = diff[0].insert[0] as LoroText;
+          text.insert(0, "abc");
+          first = false;
+        }
+      });
+      list.insertContainer(0, "Text");
+      loro.commit();
+      await oneMs();
+      expect(loro.toJson().list[0]).toBe('abc');
     });
   });
 });

--- a/loro-js/vite.config.ts
+++ b/loro-js/vite.config.ts
@@ -4,5 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [wasm()],
-  // test: {},
+  // test: {
+  //   reporters:['hanging-process']
+  // },
 });


### PR DESCRIPTION
return `ValueOrContainer` in diff event for a better developer experience.

@zxch3n I found that `vitest` sometimes times out and cannot exit. Do you know why? The main branch also has this problem.