### PR TITLE
Refactor LoroDoc shared reference

### DIFF
--- a/crates/loro-internal/benches/encode.rs
+++ b/crates/loro-internal/benches/encode.rs
@@ -88,7 +88,7 @@ mod run {
             let buf = loro.export_from(&Default::default());
 
             b.iter(|| {
-                let mut store2 = LoroDoc::default();
+                let store2 = LoroDoc::default();
                 store2.detach();
                 store2.import(&buf).unwrap();
             })

--- a/crates/loro-internal/benches/pending.rs
+++ b/crates/loro-internal/benches/pending.rs
@@ -26,7 +26,7 @@ mod pending {
             }
             updates.reverse();
             b.iter(|| {
-                let mut store2 = LoroDoc::default();
+                let store2 = LoroDoc::default();
                 store2.detach();
                 for update in updates.iter() {
                     store2.import(update).unwrap();

--- a/crates/loro-internal/benches/tree.rs
+++ b/crates/loro-internal/benches/tree.rs
@@ -34,7 +34,7 @@ mod tree {
         });
 
         b.bench_function("1000 node checkout 10^3", |b| {
-            let mut loro = LoroDoc::default();
+            let loro = LoroDoc::default();
             let tree = loro.get_tree("tree");
             let mut ids = vec![];
             let mut versions = vec![];
@@ -69,7 +69,7 @@ mod tree {
 
         b.bench_function("300 deep node random checkout 10^3", |b| {
             let depth = 300;
-            let mut loro = LoroDoc::default();
+            let loro = LoroDoc::default();
             let tree = loro.get_tree("tree");
             let mut ids = vec![];
             let mut versions = vec![];

--- a/crates/loro-internal/examples/automerge_x100.rs
+++ b/crates/loro-internal/examples/automerge_x100.rs
@@ -6,7 +6,7 @@ fn main() {
     use std::time::Instant;
 
     let actions = bench_utils::get_automerge_actions();
-    let mut loro = LoroDoc::default();
+    let loro = LoroDoc::default();
     let start = Instant::now();
     // loro.subscribe_deep(Box::new(|_| ()));
     let text = loro.get_text("text");

--- a/crates/loro-internal/examples/pending.rs
+++ b/crates/loro-internal/examples/pending.rs
@@ -21,7 +21,7 @@ pub fn main() {
     println!("done encoding");
     updates.reverse();
     let start = std::time::Instant::now();
-    let mut store2 = LoroDoc::default();
+    let store2 = LoroDoc::default();
     store2.detach();
     for update in updates.iter() {
         store2.import(update).unwrap();

--- a/crates/loro-internal/examples/tree.rs
+++ b/crates/loro-internal/examples/tree.rs
@@ -5,7 +5,7 @@ use rand::{rngs::StdRng, Rng};
 
 fn checkout() {
     let depth = 300;
-    let mut loro = LoroDoc::default();
+    let loro = LoroDoc::default();
     let tree = loro.get_tree("tree");
     let mut ids = vec![];
     let mut versions = vec![];

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1332,7 +1332,7 @@ mod test {
 
     #[test]
     fn richtext_handler() {
-        let mut loro = LoroDoc::new();
+        let loro = LoroDoc::new();
         loro.set_peer_id(1).unwrap();
         let loro2 = LoroDoc::new();
         loro2.set_peer_id(2).unwrap();

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1,7 +1,13 @@
 use std::{
     borrow::Cow,
     cmp::Ordering,
-    sync::{Arc, Mutex, Weak},
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering::{Acquire, Release},
+        },
+        Arc, Mutex, Weak,
+    },
 };
 
 use loro_common::{ContainerID, ContainerType, LoroResult, LoroValue};
@@ -54,8 +60,8 @@ pub struct LoroDoc {
     diff_calculator: Arc<Mutex<DiffCalculator>>,
     // when dropping the doc, the txn will be commited
     txn: Arc<Mutex<Option<Transaction>>>,
-    auto_commit: bool,
-    detached: bool,
+    auto_commit: AtomicBool,
+    detached: AtomicBool,
 }
 
 impl Default for LoroDoc {
@@ -73,8 +79,8 @@ impl LoroDoc {
         Self {
             oplog: Arc::new(Mutex::new(oplog)),
             state,
-            detached: false,
-            auto_commit: false,
+            detached: AtomicBool::new(false),
+            auto_commit: AtomicBool::new(false),
             observer: Arc::new(Observer::new(arena.clone())),
             diff_calculator: Arc::new(Mutex::new(DiffCalculator::new())),
             txn: Arc::new(Mutex::new(None)),
@@ -113,7 +119,7 @@ impl LoroDoc {
     /// Whether [OpLog] ans [DocState] are detached.
     #[inline(always)]
     pub fn is_detached(&self) -> bool {
-        self.detached
+        self.detached.load(Acquire)
     }
 
     #[allow(unused)]
@@ -122,12 +128,12 @@ impl LoroDoc {
         Self {
             arena: oplog.arena.clone(),
             observer: Arc::new(obs),
-            auto_commit: false,
+            auto_commit: AtomicBool::new(false),
             oplog: Arc::new(Mutex::new(oplog)),
             state: Arc::new(Mutex::new(state)),
             diff_calculator: Arc::new(Mutex::new(DiffCalculator::new())),
             txn: Arc::new(Mutex::new(None)),
-            detached: false,
+            detached: AtomicBool::new(false),
         }
     }
 
@@ -138,7 +144,7 @@ impl LoroDoc {
 
     #[inline(always)]
     pub fn set_peer_id(&self, peer: PeerID) -> LoroResult<()> {
-        if self.auto_commit {
+        if self.auto_commit.load(Acquire) {
             let mut doc_state = self.state.lock().unwrap();
             doc_state.peer = peer;
             drop(doc_state);
@@ -171,12 +177,12 @@ impl LoroDoc {
     }
 
     #[inline(always)]
-    pub fn detach(&mut self) {
-        self.detached = true;
+    pub fn detach(&self) {
+        self.detached.store(true, Release);
     }
 
     #[inline(always)]
-    pub fn attach(&mut self) {
+    pub fn attach(&self) {
         self.checkout_to_latest()
     }
 
@@ -209,9 +215,9 @@ impl LoroDoc {
     }
 
     pub fn start_auto_commit(&mut self) {
-        self.auto_commit = true;
+        self.auto_commit.store(true, Release);
         let mut self_txn = self.txn.try_lock().unwrap();
-        if self_txn.is_some() || self.detached {
+        if self_txn.is_some() || self.detached.load(Acquire) {
             return;
         }
 
@@ -244,7 +250,7 @@ impl LoroDoc {
         timestamp: Option<Timestamp>,
         immediate_renew: bool,
     ) {
-        if !self.auto_commit {
+        if !self.auto_commit.load(Acquire) {
             return;
         }
 
@@ -267,7 +273,7 @@ impl LoroDoc {
         txn.commit().unwrap();
         if immediate_renew {
             let mut txn_guard = self.txn.try_lock().unwrap();
-            assert!(!self.detached);
+            assert!(!self.detached.load(std::sync::atomic::Ordering::Acquire));
             *txn_guard = Some(self.txn().unwrap());
         }
 
@@ -288,7 +294,7 @@ impl LoroDoc {
     }
 
     pub fn renew_txn_if_auto_commit(&self) {
-        if self.auto_commit && !self.detached {
+        if self.auto_commit.load(Acquire) && !self.detached.load(Acquire) {
             let mut self_txn = self.txn.try_lock().unwrap();
             if self_txn.is_some() {
                 return;
@@ -390,7 +396,7 @@ impl LoroDoc {
                 let old_vv = oplog.vv().clone();
                 let old_frontiers = oplog.frontiers().clone();
                 oplog.decode(bytes)?;
-                if !self.detached {
+                if !self.detached.load(Acquire) {
                     let mut diff = DiffCalculator::default();
                     let diff = diff.calc_diff_internal(
                         &oplog,
@@ -413,7 +419,7 @@ impl LoroDoc {
             }
             EncodeMode::Snapshot => {
                 if self.can_reset_with_snapshot() {
-                    decode_app_snapshot(self, input, !self.detached)?;
+                    decode_app_snapshot(self, input, !self.detached.load(Acquire))?;
                 } else {
                     let app = LoroDoc::new();
                     decode_app_snapshot(&app, input, false)?;
@@ -550,7 +556,7 @@ impl LoroDoc {
     }
 
     // PERF: opt
-    pub fn import_batch(&mut self, bytes: &[Vec<u8>]) -> LoroResult<()> {
+    pub fn import_batch(&self, bytes: &[Vec<u8>]) -> LoroResult<()> {
         self.commit_then_stop();
         let is_detached = self.is_detached();
         self.detach();
@@ -594,10 +600,10 @@ impl LoroDoc {
         self.state.lock().unwrap().get_deep_value_with_id()
     }
 
-    pub fn checkout_to_latest(&mut self) {
+    pub fn checkout_to_latest(&self) {
         let f = self.oplog_frontiers();
         self.checkout(&f).unwrap();
-        self.detached = false;
+        self.detached.store(false, Release);
         self.renew_txn_if_auto_commit();
     }
 
@@ -605,11 +611,11 @@ impl LoroDoc {
     ///
     /// This will make the current [DocState] detached from the latest version of [OpLog].
     /// Any further import will not be reflected on the [DocState], until user call [LoroDoc::attach()]
-    pub fn checkout(&mut self, frontiers: &Frontiers) -> LoroResult<()> {
+    pub fn checkout(&self, frontiers: &Frontiers) -> LoroResult<()> {
         self.commit_then_stop();
         let oplog = self.oplog.lock().unwrap();
         let mut state = self.state.lock().unwrap();
-        self.detached = true;
+        self.detached.store(true, Release);
         let mut calc = self.diff_calculator.lock().unwrap();
         let before = &oplog.dag.frontiers_to_vv(&state.frontiers).unwrap();
         let Some(after) = &oplog.dag.frontiers_to_vv(frontiers) else {
@@ -688,7 +694,7 @@ mod test {
 
     #[test]
     fn test_checkout() {
-        let mut loro = LoroDoc::new();
+        let loro = LoroDoc::new();
         loro.set_peer_id(1).unwrap();
         let text = loro.get_text("text");
         let map = loro.get_map("map");
@@ -700,7 +706,7 @@ mod test {
             list.insert_with_txn(&mut txn, 0, i.into()).unwrap();
         }
         txn.commit().unwrap();
-        let mut b = LoroDoc::new();
+        let b = LoroDoc::new();
         b.import(&loro.export_snapshot()).unwrap();
         loro.checkout(&Frontiers::default()).unwrap();
         {
@@ -734,7 +740,7 @@ mod test {
     fn import_batch_err_181() {
         let a = LoroDoc::new_auto_commit();
         let update_a = a.export_snapshot();
-        let mut b = LoroDoc::new_auto_commit();
+        let b = LoroDoc::new_auto_commit();
         b.import_batch(&[update_a]).unwrap();
         b.get_text("text").insert(0, "hello").unwrap();
         b.commit_then_renew();

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 
 #[test]
 fn event_from_checkout() {
-    let mut a = LoroDoc::new_auto_commit();
+    let a = LoroDoc::new_auto_commit();
     let sub_id = a.subscribe_root(Arc::new(|event| {
         assert!(!event.doc.from_checkout);
     }));
@@ -336,7 +336,7 @@ fn test_pending() {
 
 #[test]
 fn test_checkout() {
-    let mut doc_0 = LoroDoc::new();
+    let doc_0 = LoroDoc::new();
     doc_0.set_peer_id(0).unwrap();
     let doc_1 = LoroDoc::new();
     doc_1.set_peer_id(1).unwrap();
@@ -411,7 +411,7 @@ fn test_timestamp() {
 
 #[test]
 fn test_text_checkout() {
-    let mut doc = LoroDoc::new();
+    let doc = LoroDoc::new();
     doc.set_peer_id(1).unwrap();
     let text = doc.get_text("text");
     let mut txn = doc.txn().unwrap();
@@ -480,7 +480,7 @@ fn test_text_checkout() {
 
 #[test]
 fn map_checkout() {
-    let mut doc = LoroDoc::new();
+    let doc = LoroDoc::new();
     let meta = doc.get_map("meta");
     let v_empty = doc.oplog_frontiers();
     doc.with_txn(|txn| {
@@ -506,7 +506,7 @@ fn map_checkout() {
 
 #[test]
 fn a_list_of_map_checkout() {
-    let mut doc = LoroDoc::new();
+    let doc = LoroDoc::new();
     let entry = doc.get_map("entry");
     let (list, sub) = doc
         .with_txn(|txn| {
@@ -589,7 +589,7 @@ fn a_list_of_map_checkout() {
 
 #[test]
 fn map_concurrent_checkout() {
-    let mut doc_a = LoroDoc::new();
+    let doc_a = LoroDoc::new();
     let meta_a = doc_a.get_map("meta");
     let doc_b = LoroDoc::new();
     let meta_b = doc_b.get_map("meta");
@@ -637,7 +637,7 @@ fn map_concurrent_checkout() {
 
 #[test]
 fn tree_checkout() {
-    let mut doc_a = LoroDoc::new();
+    let doc_a = LoroDoc::new();
     doc_a.subscribe_root(Arc::new(|_e| {}));
     doc_a.set_peer_id(1).unwrap();
     let tree = doc_a.get_tree("root");

--- a/loro-js/tests/event.test.ts
+++ b/loro-js/tests/event.test.ts
@@ -236,6 +236,7 @@ describe("event", () => {
       text.insert(0, "123");
       await oneMs();
       loro.commit();
+      await oneMs();
       expect(times).toBe(2);
 
       // unsubscribe

--- a/loro-js/tests/richtext.test.ts
+++ b/loro-js/tests/richtext.test.ts
@@ -1,10 +1,5 @@
-
 import { describe, expect, it } from "vitest";
-import {
-  Delta,
-  Loro,
-  setPanicHook,
-} from "../src";
+import { Delta, Loro, setPanicHook } from "../src";
 import { setDebug } from "loro-wasm";
 
 setPanicHook();
@@ -20,66 +15,62 @@ describe("richtext", () => {
         insert: "Hello",
         attributes: {
           bold: true,
-        }
+        },
       },
       {
-        insert: " World!"
-      }
-    ] as Delta<string>[])
-  })
+        insert: " World!",
+      },
+    ] as Delta<string>[]);
+  });
 
   it("insert after emoji", () => {
     const doc = new Loro();
     const text = doc.getText("text");
     text.insert(0, "👨‍👩‍👦");
     text.insert(8, "a");
-    expect(text.toString()).toBe("👨‍👩‍👦a")
-  })
+    expect(text.toString()).toBe("👨‍👩‍👦a");
+  });
 
   it("emit event correctly", () => {
     const doc = new Loro();
     const text = doc.getText("text");
     text.subscribe(doc, (event) => {
       if (event.diff.type == "text") {
-        expect(event.diff.diff).toStrictEqual(
-          [
-            {
-              insert: "Hello",
-              attributes: {
-                bold: true,
-              }
+        expect(event.diff.diff).toStrictEqual([
+          {
+            insert: "Hello",
+            attributes: {
+              bold: true,
             },
-            {
-              insert: " World!"
-            }
-          ] as Delta<string>[]
-        )
+          },
+          {
+            insert: " World!",
+          },
+        ] as Delta<string>[]);
       }
     });
     text.insert(0, "Hello World!");
     text.mark({ start: 0, end: 5 }, "bold", true);
-  })
+  });
 
-  it("emit event from merging doc correctly", () => {
+  it("emit event from merging doc correctly", async () => {
     const doc = new Loro();
     const text = doc.getText("text");
     let called = false;
     text.subscribe(doc, (event) => {
       if (event.diff.type == "text") {
         called = true;
-        expect(event.diff.diff).toStrictEqual(
-          [
-            {
-              insert: "Hello",
-              attributes: {
-                bold: true,
-              }
+        expect(event.diff.diff).toStrictEqual([
+          {
+            insert: "Hello",
+            attributes: {
+              bold: true,
             },
-            {
-              insert: " World!"
-            }
-          ] as Delta<string>[]
-        )
+          },
+          {
+            insert: " World!",
+          },
+        ] as Delta<string>[]);
       }
     });
 
@@ -88,8 +79,9 @@ describe("richtext", () => {
     textB.insert(0, "Hello World!");
     textB.mark({ start: 0, end: 5 }, "bold", true);
     doc.import(docB.exportFrom());
+    await new Promise((r) => setTimeout(r, 1));
     expect(called).toBeTruthy();
-  })
+  });
 
   it("Delete emoji", async () => {
     const doc = new Loro();
@@ -98,16 +90,19 @@ describe("richtext", () => {
     doc.commit();
     text.mark({ start: 0, end: 18 }, "bold", true);
     doc.commit();
-    expect(text.toDelta()).toStrictEqual([{
-      insert: "012345👨‍👩‍👦6789",
-      attributes: { bold: true }
-    }]);
+    expect(text.toDelta()).toStrictEqual([
+      {
+        insert: "012345👨‍👩‍👦6789",
+        attributes: { bold: true },
+      },
+    ]);
     text.delete(6, 8);
     doc.commit();
-    expect(text.toDelta()).toStrictEqual([{
-      insert: "0123456789",
-      attributes: { bold: true }
-    }]);
+    expect(text.toDelta()).toStrictEqual([
+      {
+        insert: "0123456789",
+        attributes: { bold: true },
+      },
+    ]);
   });
-
-})
+});


### PR DESCRIPTION
This pull request refactors the LoroDoc code to only require a shared reference in the loro doc now. 

This makes WASM faster and make `BorrowMutError` on `LoroDoc` in loro-wasm impossible.