### PR TITLE
Fix partial inclusion bug in Tracker

### DIFF
--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -295,7 +295,6 @@ impl Tracker {
     ) -> impl Iterator<Item = CrdtRopeDelta> + '_ {
         self._checkout(from, false);
         self._checkout(to, true);
-        dbg!(&self.rope);
         // self.id_to_cursor.diagnose();
         self.rope.get_diff()
     }

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -72,8 +72,7 @@ impl Tracker {
     pub(crate) fn insert(&mut self, mut op_id: ID, mut pos: usize, mut content: RichtextChunk) {
         let last_id = op_id.inc(content.len() as Counter - 1);
         let applied_counter_end = self.applied_vv.get(&last_id.peer).copied().unwrap_or(0);
-        if applied_counter_end > last_id.counter {
-            // the op is included in the applied vv
+        if applied_counter_end > op_id.counter {
             if !self.current_vv.includes_id(last_id) {
                 // PERF: may be slow
                 let mut updates = Default::default();
@@ -87,9 +86,13 @@ impl Tracker {
                 );
                 self.batch_update(updates, false);
             }
-            return;
-        } else if applied_counter_end > op_id.counter {
-            // need to slice the content
+
+            if applied_counter_end > last_id.counter {
+                // the op is included in the applied vv
+                return;
+            }
+
+            // the op is partially included, need to slice the content
             let start = (applied_counter_end - op_id.counter) as usize;
             op_id.counter = applied_counter_end;
             pos += start;
@@ -137,8 +140,7 @@ impl Tracker {
     pub(crate) fn delete(&mut self, mut op_id: ID, mut pos: usize, mut len: usize, reverse: bool) {
         let last_id = op_id.inc(len as Counter - 1);
         let applied_counter_end = self.applied_vv.get(&last_id.peer).copied().unwrap_or(0);
-        if applied_counter_end > last_id.counter {
-            // the op is included in the applied_vv
+        if applied_counter_end > op_id.counter {
             if !self.current_vv.includes_id(last_id) {
                 // PERF: may be slow
                 let mut updates = Default::default();
@@ -148,9 +150,12 @@ impl Tracker {
                 );
                 self.batch_update(updates, false);
             }
-            return;
-        } else if applied_counter_end > op_id.counter {
-            // need to slice the op
+
+            if applied_counter_end > last_id.counter {
+                return;
+            }
+
+            // the op is partially included, need to slice the op
             let start = (applied_counter_end - op_id.counter) as usize;
             op_id.counter = applied_counter_end;
             len -= start;
@@ -176,7 +181,6 @@ impl Tracker {
 
         let mut cur_id = op_id;
         for id_span in ans {
-            debug_log::debug_dbg!(&cur_id, id_span, reverse);
             let len = id_span.atom_len();
             self.id_to_cursor
                 .push(cur_id, id_to_cursor::Cursor::Delete(id_span));
@@ -291,6 +295,7 @@ impl Tracker {
     ) -> impl Iterator<Item = CrdtRopeDelta> + '_ {
         self._checkout(from, false);
         self._checkout(to, true);
+        dbg!(&self.rope);
         // self.id_to_cursor.diagnose();
         self.rope.get_diff()
     }

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -76,7 +76,7 @@ impl DiffCalculator {
         after: &crate::VersionVector,
         after_frontiers: Option<&Frontiers>,
     ) -> Vec<InternalContainerDiff> {
-        debug_dbg!(&before, &after, &oplog);
+        debug_dbg!(&before, &after);
         if self.has_all {
             let include_before = self.last_vv.includes_vv(before);
             let include_after = self.last_vv.includes_vv(after);
@@ -724,7 +724,7 @@ impl DiffCalculatorTrait for RichtextDiffCalculator {
 
         // FIXME: handle new containers when inserting richtext style like comments
 
-        // debug_log::debug_dbg!(&delta, from, to);
+        debug_log::debug_dbg!(&delta);
         // debug_log::debug_dbg!(&self.tracker);
         InternalDiff::RichtextRaw(delta)
     }

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 pub(super) mod tree;
-use debug_log::debug_dbg;
 use itertools::Itertools;
 pub(crate) use tree::TreeDeletedSetTrait;
 pub(super) use tree::TreeDiffCache;
@@ -76,7 +75,6 @@ impl DiffCalculator {
         after: &crate::VersionVector,
         after_frontiers: Option<&Frontiers>,
     ) -> Vec<InternalContainerDiff> {
-        debug_dbg!(&before, &after);
         if self.has_all {
             let include_before = self.last_vv.includes_vv(before);
             let include_after = self.last_vv.includes_vv(after);
@@ -724,7 +722,6 @@ impl DiffCalculatorTrait for RichtextDiffCalculator {
 
         // FIXME: handle new containers when inserting richtext style like comments
 
-        debug_log::debug_dbg!(&delta);
         // debug_log::debug_dbg!(&self.tracker);
         InternalDiff::RichtextRaw(delta)
     }


### PR DESCRIPTION
This pull request fixes a bug in the `Tracker` implementation where partial inclusions were not handled correctly. The bug caused incorrect slicing of content and operations when the applied counter end was greater than the last ID's counter.

This fix ensures that partial inclusions are handled correctly in the `Tracker` implementation.