### PR TITLE
Update loro_value! macro and add binary support

### DIFF
--- a/crates/loro-common/src/macros.rs
+++ b/crates/loro-common/src/macros.rs
@@ -1,3 +1,24 @@
+/// A macro for creating `LoroValue`. It works just like the `json!` macro in
+/// `serde_json`.
+///
+/// # Example
+///
+/// ```
+/// use loro_common::loro_value;
+/// loro_value({
+///     "name": "John",
+///     "age": 12,
+///     "collections": [
+///         {
+///             "binary-data": b"1,2,3"
+///         }
+///     ],
+///     "float": 1.2,
+///     "null": null,
+///     "bool": true,
+/// });
+/// ```
+///
 #[macro_export(local_inner_macros)]
 macro_rules! loro_value {
     // Hide distracting implementation details from the generated rustdoc.
@@ -262,11 +283,12 @@ mod test {
             "float": 123.123,
             "map": {
                 "a": "1"
-            }
+            },
+            "binary": b"123",
         });
 
         let map = map.into_map().unwrap();
-        assert_eq!(map.len(), 7);
+        assert_eq!(map.len(), 8);
         assert!(*map.get("hi").unwrap().as_bool().unwrap());
         assert!(!(*map.get("false").unwrap().as_bool().unwrap()));
         assert!(map.get("null").unwrap().is_null());
@@ -285,6 +307,10 @@ mod test {
                 .as_string()
                 .unwrap(),
             "1"
+        );
+        assert_eq!(
+            &**map.get("binary").unwrap().as_binary().unwrap(),
+            &b"123".to_vec()
         );
     }
 }

--- a/crates/loro-common/src/macros.rs
+++ b/crates/loro-common/src/macros.rs
@@ -5,7 +5,7 @@
 ///
 /// ```
 /// use loro_common::loro_value;
-/// loro_value({
+/// loro_value!({
 ///     "name": "John",
 ///     "age": 12,
 ///     "collections": [

--- a/crates/loro-common/src/value.rs
+++ b/crates/loro-common/src/value.rs
@@ -88,7 +88,7 @@ impl LoroValue {
         max_depth
     }
 
-    // TODO: add checks for too deep value, and return err if users 
+    // TODO: add checks for too deep value, and return err if users
     // try to insert such value into a container
     pub fn is_too_deep(&self) -> bool {
         self.get_depth() > MAX_DEPTH
@@ -258,6 +258,24 @@ impl<S: Into<String>, M> From<HashMap<S, LoroValue, M>> for LoroValue {
 impl From<Vec<LoroValue>> for LoroValue {
     fn from(vec: Vec<LoroValue>) -> Self {
         LoroValue::List(Arc::new(vec))
+    }
+}
+
+impl From<Vec<u8>> for LoroValue {
+    fn from(vec: Vec<u8>) -> Self {
+        LoroValue::Binary(Arc::new(vec))
+    }
+}
+
+impl From<&'_ [u8]> for LoroValue {
+    fn from(vec: &[u8]) -> Self {
+        LoroValue::Binary(Arc::new(vec.to_vec()))
+    }
+}
+
+impl<const N: usize> From<&'_ [u8; N]> for LoroValue {
+    fn from(vec: &[u8; N]) -> Self {
+        LoroValue::Binary(Arc::new(vec.to_vec()))
     }
 }
 

--- a/crates/loro-common/src/value.rs
+++ b/crates/loro-common/src/value.rs
@@ -255,12 +255,6 @@ impl<S: Into<String>, M> From<HashMap<S, LoroValue, M>> for LoroValue {
     }
 }
 
-impl From<Vec<LoroValue>> for LoroValue {
-    fn from(vec: Vec<LoroValue>) -> Self {
-        LoroValue::List(Arc::new(vec))
-    }
-}
-
 impl From<Vec<u8>> for LoroValue {
     fn from(vec: Vec<u8>) -> Self {
         LoroValue::Binary(Arc::new(vec))
@@ -285,12 +279,6 @@ impl From<i32> for LoroValue {
     }
 }
 
-impl From<u8> for LoroValue {
-    fn from(v: u8) -> Self {
-        LoroValue::I32(v as i32)
-    }
-}
-
 impl From<u16> for LoroValue {
     fn from(v: u16) -> Self {
         LoroValue::I32(v as i32)
@@ -312,6 +300,13 @@ impl From<f64> for LoroValue {
 impl From<bool> for LoroValue {
     fn from(v: bool) -> Self {
         LoroValue::Bool(v)
+    }
+}
+
+impl<T: Into<LoroValue>> From<Vec<T>> for LoroValue {
+    fn from(value: Vec<T>) -> Self {
+        let vec: Vec<LoroValue> = value.into_iter().map(|x| x.into()).collect();
+        Self::List(Arc::new(vec))
     }
 }
 

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -2354,11 +2354,11 @@ mod test {
             ID::new(u64::MAX, 123),
             ContainerType::Tree,
         )));
-        test_loro_value_read_write(vec![1.into(), 2.into(), 3.into()]);
+        test_loro_value_read_write(vec![1i32, 2, 3]);
         test_loro_value_read_write(LoroValue::Map(Arc::new(fx_map![
             "1".into() => 123.into(),
             "2".into() => "123".into(),
-            "3".into() => vec![true.into()].into()
+            "3".into() => vec![true].into()
         ])));
     }
 }

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -377,7 +377,7 @@ impl ContainerState for TreeState {
     }
 
     fn get_value(&mut self) -> LoroValue {
-        let mut ans = vec![];
+        let mut ans: Vec<LoroValue> = vec![];
         #[cfg(feature = "test_utils")]
         // The order keep consistent
         let iter = self.trees.iter().sorted();


### PR DESCRIPTION
This pull request updates the `loro_value!` macro to support binary data and adds new conversion implementations for `LoroValue` from `Vec<u8>`, `&[u8]`, and `[u8; N]`. This allows users to easily create `LoroValue` instances from binary data.