### PR TITLE
Fix tracker delete error when the update is partially included

### DIFF
--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -141,6 +141,9 @@ impl Tracker {
 
     /// If `reverse` is true, the deletion happens from the end of the range to the start.
     pub(crate) fn delete(&mut self, mut op_id: ID, mut pos: usize, mut len: usize, reverse: bool) {
+        // debug_log::debug_log!("Delete");
+        // debug_log::debug_dbg!(&op_id, pos, len);
+        // debug_log::debug_dbg!(&self);
         let last_id = op_id.inc(len as Counter - 1);
         let applied_counter_end = self.applied_vv.get(&last_id.peer).copied().unwrap_or(0);
         if applied_counter_end > op_id.counter {
@@ -166,10 +169,12 @@ impl Tracker {
             if reverse {
                 pos -= start;
             } else {
-                pos += start;
+                // don't need to change the pos
             }
         }
 
+        // debug_log::debug_log!("after forwarding pos={} len={}", pos, len);
+        // debug_log::debug_dbg!(&self);
         let mut ans = Vec::new();
         let split = self.rope.delete(pos, len, |span| {
             let mut id_span = span.id_span();
@@ -197,6 +202,7 @@ impl Tracker {
         let end_id = op_id.inc(len as Counter);
         self.current_vv.extend_to_include_end_id(end_id);
         self.applied_vv.extend_to_include_end_id(end_id);
+        debug_log::debug_dbg!(&self);
     }
 
     #[inline]
@@ -299,7 +305,7 @@ impl Tracker {
         self._checkout(from, false);
         self._checkout(to, true);
         // self.id_to_cursor.diagnose();
-        // debug_log::debug_dbg!(&self);
+        debug_log::debug_dbg!(&self);
         self.rope.get_diff()
     }
 }

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -370,6 +370,7 @@ impl Actionable for Vec<Actor> {
                 let actor = &mut self[*site as usize];
                 let f = actor.history.keys().nth(*to as usize).unwrap();
                 let f = Frontiers::from(f);
+                debug_log::debug_log!("Checkout to {:?}", &f);
                 actor.loro.checkout(&f).unwrap();
             }
             Action::RichText {
@@ -744,6 +745,36 @@ mod failed_tests {
                     site: 106,
                     to: 1785358954,
                 },
+            ],
+        )
+    }
+
+    #[test]
+    fn checkout_delete() {
+        test_multi_sites(
+            5,
+            &mut [
+                RichText {
+                    site: 0,
+                    pos: 0,
+                    value: 0,
+                    action: RichTextAction::Mark(3098706341580712916),
+                },
+                RichText {
+                    site: 0,
+                    pos: 196608,
+                    value: 16558833364434944,
+                    action: RichTextAction::Delete,
+                },
+                SyncAll,
+                Checkout { site: 3, to: 0 },
+                RichText {
+                    site: 0,
+                    pos: 12080808861146021892,
+                    value: 12080808863958804391,
+                    action: RichTextAction::Delete,
+                },
+                SyncAll,
             ],
         )
     }

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -9,6 +9,7 @@ use loro_internal::{
 };
 use serde_json::json;
 
+
 #[test]
 fn issue_225() -> LoroResult<()> {
     let doc = LoroDoc::new_auto_commit();


### PR DESCRIPTION
This pull request fixes an error in the tracker code where a delete operation was not being properly handled when the update was only partially included. The code has been updated to handle this scenario correctly.