### PR TITLE
Make InternalString a newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "static_assertions",
- "string_cache",
  "tabled 0.10.0",
  "thiserror",
  "wasm-bindgen",

--- a/crates/loro-common/Cargo.toml
+++ b/crates/loro-common/Cargo.toml
@@ -14,7 +14,7 @@ rle = { path = "../rle", version = "0.1.0", package = "loro-rle" }
 wasm-bindgen = { version = "=0.2.86", optional = true }
 fxhash = "0.2.1"
 enum-as-inner = "0.6.0"
-string_cache = "0.8.7"
+string_cache = "0.8"
 arbitrary = { version = "1.3.0", features = ["derive"] }
 js-sys = { version = "0.3.60", optional = true }
 serde_columnar = "0.3.3"

--- a/crates/loro-common/src/internal_string.rs
+++ b/crates/loro-common/src/internal_string.rs
@@ -1,0 +1,42 @@
+use std::{fmt::Display, ops::Deref};
+
+use serde::{Deserialize, Serialize};
+
+#[repr(transparent)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InternalString(string_cache::DefaultAtom);
+
+impl<T: Into<string_cache::DefaultAtom>> From<T> for InternalString {
+    #[inline(always)]
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&InternalString> for String {
+    #[inline(always)]
+    fn from(value: &InternalString) -> Self {
+        value.0.to_string()
+    }
+}
+
+impl From<&InternalString> for InternalString {
+    #[inline(always)]
+    fn from(value: &InternalString) -> Self {
+        value.clone()
+    }
+}
+
+impl Display for InternalString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for InternalString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -6,6 +6,7 @@ use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 mod error;
 mod id;
+mod internal_string;
 mod macros;
 mod span;
 mod value;
@@ -13,6 +14,7 @@ mod value;
 pub use error::{LoroError, LoroResult, LoroTreeError};
 #[doc(hidden)]
 pub use fxhash::FxHashMap;
+pub use internal_string::InternalString;
 pub use span::*;
 pub use value::{to_value, LoroValue};
 
@@ -52,7 +54,6 @@ pub enum ContainerID {
     },
 }
 
-pub type InternalString = string_cache::DefaultAtom;
 // TODO: add non_exausted
 // Note: It will be encoded into binary format, so the order of its fields should not be changed.
 #[derive(

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -8,7 +8,6 @@ description = "Loro internal library. Do not use it directly as it's not stable.
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-string_cache = "0.8.7"
 rle = { path = "../rle", version = "0.1.0", package = "loro-rle" }
 loro-preload = { path = "../loro-preload", version = "0.1.0" }
 loro-common = { path = "../loro-common", version = "0.1.0" }

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -732,7 +732,7 @@ mod encode {
         ops: Vec<TempOp<'_>>,
         arena: &crate::arena::SharedArena,
         value_writer: &mut ValueWriter,
-        key_register: &mut ValueRegister<string_cache::Atom<string_cache::EmptyStaticAtomSet>>,
+        key_register: &mut ValueRegister<InternalString>,
         cid_register: &mut ValueRegister<ContainerID>,
         peer_register: &mut ValueRegister<u64>,
     ) -> Vec<EncodedOp> {
@@ -770,7 +770,7 @@ mod encode {
         dep_arena: &mut super::arena::DepsArena,
         peer_register: &mut ValueRegister<u64>,
         push_op: &mut impl FnMut(TempOp<'a>),
-        key_register: &mut ValueRegister<string_cache::Atom<string_cache::EmptyStaticAtomSet>>,
+        key_register: &mut ValueRegister<InternalString>,
         container_idx2index: &FxHashMap<ContainerIdx, usize>,
     ) -> Vec<EncodedChange> {
         let mut changes: Vec<EncodedChange> = Vec::with_capacity(diff_changes.len());

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -48,11 +48,9 @@ pub(crate) use change::Timestamp;
 pub(crate) use id::{PeerID, ID};
 
 // TODO: rename as Key?
-pub(crate) type InternalString = DefaultAtom;
+pub(crate) use loro_common::InternalString;
 
 pub use container::ContainerType;
 pub use loro_common::{loro_value, to_value};
 pub use value::{ApplyDiff, LoroValue, ToJson};
 pub use version::VersionVector;
-
-use string_cache::DefaultAtom;

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -376,11 +376,7 @@ impl LoroDoc {
         ans
     }
 
-    fn _import_with(
-        &self,
-        bytes: &[u8],
-        origin: string_cache::Atom<string_cache::EmptyStaticAtomSet>,
-    ) -> Result<(), LoroError> {
+    fn _import_with(&self, bytes: &[u8], origin: InternalString) -> Result<(), LoroError> {
         let parsed = parse_header_and_body(bytes)?;
         match parsed.mode.is_snapshot() {
             false => {

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -233,13 +233,7 @@ impl MapState {
         }
     }
 
-    pub fn iter(
-        &self,
-    ) -> std::collections::hash_map::Iter<
-        '_,
-        string_cache::Atom<string_cache::EmptyStaticAtomSet>,
-        MapValue,
-    > {
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, InternalString, MapValue> {
         self.map.iter()
     }
 


### PR DESCRIPTION
This pull request refactors the InternalString type to use the InternalString type from the loro-common crate. This change improves code consistency and removes the dependency on the string_cache crate.