### PR TITLE
Remove txn abort and reduce mem usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.35",
  "syn 1.0.107",
 ]
 
@@ -382,8 +382,8 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
 dependencies = [
- "quote 1.0.29",
- "syn 2.0.41",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -404,10 +404,10 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "strsim",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -417,8 +417,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
- "quote 1.0.29",
- "syn 2.0.41",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -437,9 +437,9 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -471,8 +471,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.107",
 ]
 
@@ -483,9 +483,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -495,8 +495,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.107",
 ]
 
@@ -510,6 +510,7 @@ dependencies = [
  "ctor 0.2.6",
  "debug-log",
  "loro",
+ "serde_json",
  "tabled 0.15.0",
 ]
 
@@ -557,7 +558,7 @@ dependencies = [
  "heapless",
  "itertools 0.11.0",
  "loro-thunderdome",
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.75",
 ]
 
 [[package]]
@@ -966,8 +967,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.107",
 ]
 
@@ -1162,8 +1163,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.107",
  "version_check",
 ]
@@ -1174,8 +1175,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "version_check",
 ]
 
@@ -1190,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
@@ -1251,11 +1252,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.75",
 ]
 
 [[package]]
@@ -1423,9 +1424,9 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
@@ -1461,27 +1462,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46d50a130ce1b4cf3b1585342ee0bf71e7589845ec23283e85fc875606018520"
 dependencies = [
  "darling",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1582,19 +1583,19 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
@@ -1638,8 +1639,8 @@ checksum = "beca1b4eaceb4f2755df858b88d9b9315b7ccfd1ffd0d7a48a52602301f01a57"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.107",
 ]
 
@@ -1651,8 +1652,8 @@ checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.107",
 ]
 
@@ -1700,9 +1701,9 @@ version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1796,9 +1797,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -1808,7 +1809,7 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.35",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1818,9 +1819,9 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.29",
- "syn 2.0.41",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -11,6 +11,7 @@ loro = { path = "../loro" }
 tabled = "0.15.0"
 arbitrary = { version = "1.3.0", features = ["derive"] }
 debug-log = { version = "0.3.1", features = [] }
+serde_json = "1.0.111"
 
 [dev-dependencies]
 color-backtrace = { version = "0.6" }

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run_async_workflow<T: ActorTrait>(
     action_num: usize,
     actions_before_sync: usize,
     seed: u64,
+    preprocess: impl FnMut(&mut Action<T::ActionKind>),
 ) -> (ActorGroup<T>, Instant)
 where
     for<'a> T::ActionKind: arbitrary::Arbitrary<'a>,
@@ -103,7 +104,7 @@ where
         peer_num,
         &seed,
         actions_before_sync,
-        |_| {},
+        preprocess,
     )
     .unwrap();
     let mut actors = ActorGroup::<T>::new(peer_num);
@@ -119,13 +120,14 @@ pub fn run_realtime_collab_workflow<T: ActorTrait>(
     peer_num: usize,
     action_num: usize,
     seed: u64,
+    preprocess: impl FnMut(&mut Action<T::ActionKind>),
 ) -> (ActorGroup<T>, Instant)
 where
     for<'a> T::ActionKind: arbitrary::Arbitrary<'a>,
 {
     let seed = create_seed(seed, action_num * 32);
     let mut actions =
-        gen_realtime_actions::<T::ActionKind>(action_num, peer_num, &seed, |_| {}).unwrap();
+        gen_realtime_actions::<T::ActionKind>(action_num, peer_num, &seed, preprocess).unwrap();
     let mut actors = ActorGroup::<T>::new(peer_num);
     let start = Instant::now();
     for action in actions.iter_mut() {

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -1909,6 +1909,12 @@ impl RichtextState {
             &start_ops
         );
     }
+
+    pub(crate) fn estimate_size(&self) -> usize {
+        // TODO: this is inaccurate
+        self.tree.node_len() * std::mem::size_of::<RichtextStateChunk>()
+            + self.style_ranges.estimate_size()
+    }
 }
 
 #[cfg(test)]

--- a/crates/loro-internal/src/container/richtext/style_range_map.rs
+++ b/crates/loro-internal/src/container/richtext/style_range_map.rs
@@ -394,6 +394,11 @@ impl StyleRangeMap {
     pub(crate) fn has_style(&self) -> bool {
         self.has_style
     }
+
+    pub(crate) fn estimate_size(&self) -> usize {
+        // TODO: this is inaccurate
+        self.tree.node_len() * std::mem::size_of::<Elem>()
+    }
 }
 
 pub(super) struct IterAnchorItem {

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -418,13 +418,15 @@ impl DiffCalculatorTrait for MapDiffCalculator {
                     MapValue {
                         counter: v.counter,
                         value,
-                        lamport: (v.lamport, v.peer),
+                        lamp: v.lamport,
+                        peer: v.peer,
                     }
                 })
                 .unwrap_or_else(|| MapValue {
                     counter: 0,
                     value: None,
-                    lamport: (0, 0),
+                    lamp: 0,
+                    peer: 0,
                 });
 
             updated.insert(key, value);

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1363,23 +1363,6 @@ mod test {
     use super::TextDelta;
 
     #[test]
-    fn test() {
-        let loro = LoroDoc::new();
-        let mut txn = loro.txn().unwrap();
-        let text = txn.get_text("hello");
-        text.insert_with_txn(&mut txn, 0, "hello").unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello");
-        text.insert_with_txn(&mut txn, 2, " kk ").unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "he kk llo");
-        txn.abort();
-        let mut txn = loro.txn().unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "");
-        text.insert_with_txn(&mut txn, 0, "hi").unwrap();
-        txn.commit().unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hi");
-    }
-
-    #[test]
     fn import() {
         let loro = LoroDoc::new();
         loro.set_peer_id(1).unwrap();

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -989,8 +989,10 @@ impl DocState {
         }
 
         eprintln!(
-            "Estimated state size: \nEntries: {} \nSum: {}",
-            state_entries_size, state_size_sum
+            "ContainerNum: {}\nEstimated state size: \nEntries: {} \nSum: {}",
+            self.states.len(),
+            state_entries_size,
+            state_size_sum
         );
     }
 }

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -26,7 +26,6 @@ use loro_common::{IdSpan, LoroResult, ID};
 
 #[derive(Debug)]
 pub struct ListState {
-    id: ContainerID,
     idx: ContainerIdx,
     list: BTree<ListImpl>,
     child_container_to_leaf: FxHashMap<ContainerID, LeafIndex>,
@@ -35,7 +34,6 @@ pub struct ListState {
 impl Clone for ListState {
     fn clone(&self) -> Self {
         Self {
-            id: self.id.clone(),
             idx: self.idx,
             list: self.list.clone(),
             child_container_to_leaf: Default::default(),
@@ -136,10 +134,9 @@ impl UseLengthFinder<ListImpl> for ListImpl {
 
 // FIXME: update child_container_to_leaf
 impl ListState {
-    pub fn new(id: ContainerID, idx: ContainerIdx) -> Self {
+    pub fn new(idx: ContainerIdx) -> Self {
         let tree = BTree::new();
         Self {
-            id,
             idx,
             list: tree,
             child_container_to_leaf: Default::default(),
@@ -285,10 +282,6 @@ impl ListState {
 impl ContainerState for ListState {
     fn container_idx(&self) -> ContainerIdx {
         self.idx
-    }
-
-    fn container_id(&self) -> &ContainerID {
-        &self.id
     }
 
     fn estimate_size(&self) -> usize {
@@ -506,10 +499,10 @@ mod test {
 
     #[test]
     fn test() {
-        let mut list = ListState::new(
-            id("abc"),
-            ContainerIdx::from_index_and_type(0, loro_common::ContainerType::List),
-        );
+        let mut list = ListState::new(ContainerIdx::from_index_and_type(
+            0,
+            loro_common::ContainerType::List,
+        ));
         fn id(name: &str) -> ContainerID {
             ContainerID::new_root(name, crate::ContainerType::List)
         }

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -24,7 +24,6 @@ use super::ContainerState;
 
 #[derive(Debug, Clone)]
 pub struct MapState {
-    id: ContainerID,
     idx: ContainerIdx,
     map: FxHashMap<InternalString, MapValue>,
 }
@@ -32,10 +31,6 @@ pub struct MapState {
 impl ContainerState for MapState {
     fn container_idx(&self) -> ContainerIdx {
         self.idx
-    }
-
-    fn container_id(&self) -> &ContainerID {
-        &self.id
     }
 
     fn estimate_size(&self) -> usize {
@@ -211,9 +206,8 @@ impl ContainerState for MapState {
 }
 
 impl MapState {
-    pub fn new(id: ContainerID, idx: ContainerIdx) -> Self {
+    pub fn new(idx: ContainerIdx) -> Self {
         Self {
-            id,
             idx,
             map: FxHashMap::default(),
         }

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -27,8 +27,6 @@ pub struct MapState {
     id: ContainerID,
     idx: ContainerIdx,
     map: FxHashMap<InternalString, MapValue>,
-    in_txn: bool,
-    map_when_txn_start: FxHashMap<InternalString, Option<MapValue>>,
 }
 
 impl ContainerState for MapState {
@@ -38,6 +36,10 @@ impl ContainerState for MapState {
 
     fn container_id(&self) -> &ContainerID {
         &self.id
+    }
+
+    fn estimate_size(&self) -> usize {
+        self.map.capacity() * (mem::size_of::<MapValue>() + mem::size_of::<InternalString>())
     }
 
     fn is_state_empty(&self) -> bool {
@@ -61,8 +63,7 @@ impl ContainerState for MapState {
                 arena.set_parent(idx, Some(self.idx));
             }
 
-            let old = self.map.insert(key.clone(), value.clone());
-            self.store_txn_snapshot(key.clone(), old);
+            self.map.insert(key.clone(), value.clone());
             resolved_delta = resolved_delta.with_entry(
                 key,
                 ResolvedMapValue {
@@ -76,6 +77,16 @@ impl ContainerState for MapState {
         }
 
         Diff::Map(resolved_delta)
+    }
+
+    fn apply_diff(
+        &mut self,
+        diff: InternalDiff,
+        arena: &SharedArena,
+        txn: &Weak<Mutex<Option<Transaction>>>,
+        state: &Weak<Mutex<DocState>>,
+    ) {
+        self.apply_diff_and_convert(diff, arena, txn, state);
     }
 
     fn apply_op(&mut self, op: &RawOp, _: &Op, arena: &SharedArena) -> LoroResult<()> {
@@ -131,38 +142,22 @@ impl ContainerState for MapState {
         })
     }
 
-    fn start_txn(&mut self) {
-        self.in_txn = true;
-    }
-
-    fn abort_txn(&mut self) {
-        for (key, value) in mem::take(&mut self.map_when_txn_start) {
-            if let Some(value) = value {
-                self.map.insert(key, value);
-            } else {
-                self.map.remove(&key);
-            }
-        }
-
-        self.in_txn = false;
-    }
-
-    fn commit_txn(&mut self) {
-        self.map_when_txn_start.clear();
-        self.in_txn = false;
-    }
-
     fn get_value(&mut self) -> LoroValue {
         let ans = self.to_map();
         LoroValue::Map(Arc::new(ans))
     }
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {
+        debug_log::group!("Get child index {:?}", id);
         for (key, value) in self.map.iter() {
+            debug_log::group!("Key {} value {:?}", key, value);
             if let Some(LoroValue::Container(x)) = &value.value {
+                debug_log::debug_log!("Cmp {:?} with {:?}", &x, &id);
                 if x == id {
+                    debug_log::debug_log!("Same");
                     return Some(Index::Key(key.clone()));
                 }
+                debug_log::debug_log!("Diff");
             }
         }
 
@@ -221,22 +216,11 @@ impl MapState {
             id,
             idx,
             map: FxHashMap::default(),
-            in_txn: false,
-            map_when_txn_start: FxHashMap::default(),
-        }
-    }
-
-    fn store_txn_snapshot(&mut self, key: InternalString, old: Option<MapValue>) {
-        if self.in_txn && !self.map_when_txn_start.contains_key(&key) {
-            self.map_when_txn_start.insert(key, old);
         }
     }
 
     pub fn insert(&mut self, key: InternalString, value: MapValue) {
-        let old = self.map.insert(key.clone(), value);
-        if self.in_txn {
-            self.store_txn_snapshot(key, old);
-        }
+        self.map.insert(key.clone(), value);
     }
 
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, InternalString, MapValue> {

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -63,7 +63,7 @@ impl ContainerState for MapState {
                 key,
                 ResolvedMapValue {
                     counter: value.counter,
-                    lamport: value.lamport,
+                    lamport: (value.lamp, value.peer),
                     value: value
                         .value
                         .map(|v| ValueOrContainer::from_value(v, arena, txn, state)),
@@ -91,7 +91,8 @@ impl ContainerState for MapState {
                     self.insert(
                         key.clone(),
                         MapValue {
-                            lamport: (op.lamport, op.id.peer),
+                            lamp: op.lamport,
+                            peer: op.id.peer,
                             counter: op.id.counter,
                             value: None,
                         },
@@ -107,7 +108,8 @@ impl ContainerState for MapState {
                 self.insert(
                     key.clone(),
                     MapValue {
-                        lamport: (op.lamport, op.id.peer),
+                        lamp: op.lamport,
+                        peer: op.id.peer,
                         counter: op.id.counter,
                         value: Some(value),
                     },
@@ -173,7 +175,7 @@ impl ContainerState for MapState {
     fn encode_snapshot(&self, mut encoder: StateSnapshotEncoder) -> Vec<u8> {
         let mut lamports = DeltaRleEncodedNums::new();
         for v in self.map.values() {
-            lamports.push(v.lamport.0);
+            lamports.push(v.lamp);
             encoder.encode_op(v.id().into(), || unimplemented!());
         }
 
@@ -198,7 +200,8 @@ impl ContainerState for MapState {
                 MapValue {
                     counter: op.op.counter,
                     value: content.value.clone(),
-                    lamport: (iter.next().unwrap(), op.peer),
+                    lamp: iter.next().unwrap(),
+                    peer: op.peer,
                 },
             );
         }

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -43,7 +43,7 @@ impl RichtextState {
         Self {
             id,
             idx,
-            state: Box::new(LazyLoad::new_dst(Default::default())),
+            state: Box::new(LazyLoad::Src(Default::default())),
         }
     }
 

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -32,16 +32,14 @@ use super::ContainerState;
 
 #[derive(Debug)]
 pub struct RichtextState {
-    id: ContainerID,
     idx: ContainerIdx,
     pub(crate) state: Box<LazyLoad<RichtextStateLoader, InnerState>>,
 }
 
 impl RichtextState {
     #[inline]
-    pub fn new(id: ContainerID, idx: ContainerIdx) -> Self {
+    pub fn new(idx: ContainerIdx) -> Self {
         Self {
-            id,
             idx,
             state: Box::new(LazyLoad::Src(Default::default())),
         }
@@ -75,7 +73,6 @@ impl RichtextState {
 impl Clone for RichtextState {
     fn clone(&self) -> Self {
         Self {
-            id: self.id.clone(),
             idx: self.idx,
             state: self.state.clone(),
         }
@@ -85,10 +82,6 @@ impl Clone for RichtextState {
 impl ContainerState for RichtextState {
     fn container_idx(&self) -> ContainerIdx {
         self.idx
-    }
-
-    fn container_id(&self) -> &ContainerID {
-        &self.id
     }
 
     fn estimate_size(&self) -> usize {

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -33,7 +33,7 @@ use super::ContainerState;
 #[derive(Debug)]
 pub struct RichtextState {
     idx: ContainerIdx,
-    pub(crate) state: Box<LazyLoad<RichtextStateLoader, InnerState>>,
+    pub(crate) state: LazyLoad<RichtextStateLoader, InnerState>,
 }
 
 impl RichtextState {
@@ -41,7 +41,7 @@ impl RichtextState {
     pub fn new(idx: ContainerIdx) -> Self {
         Self {
             idx,
-            state: Box::new(LazyLoad::Src(Default::default())),
+            state: LazyLoad::Src(Default::default()),
         }
     }
 
@@ -56,14 +56,14 @@ impl RichtextState {
     #[allow(unused)]
     #[inline(always)]
     pub(crate) fn is_empty(&self) -> bool {
-        match &*self.state {
+        match &self.state {
             LazyLoad::Src(s) => s.elements.is_empty(),
             LazyLoad::Dst(d) => d.is_empty(),
         }
     }
 
     pub(crate) fn diagnose(&self) {
-        match &*self.state {
+        match &self.state {
             LazyLoad::Src(_) => {}
             LazyLoad::Dst(d) => d.diagnose(),
         }
@@ -85,14 +85,14 @@ impl ContainerState for RichtextState {
     }
 
     fn estimate_size(&self) -> usize {
-        match &*self.state {
+        match &self.state {
             LazyLoad::Src(s) => s.elements.len() * std::mem::size_of::<RichtextStateChunk>(),
             LazyLoad::Dst(s) => s.estimate_size(),
         }
     }
 
     fn is_state_empty(&self) -> bool {
-        match &*self.state {
+        match &self.state {
             LazyLoad::Src(s) => s.is_empty(),
             LazyLoad::Dst(s) => s.is_empty(),
         }
@@ -385,7 +385,7 @@ impl ContainerState for RichtextState {
         let iter: &mut dyn Iterator<Item = &RichtextStateChunk>;
         let mut a;
         let mut b;
-        match &*self.state {
+        match &self.state {
             LazyLoad::Src(s) => {
                 a = Some(s.elements.iter());
                 iter = &mut *a.as_mut().unwrap();
@@ -454,7 +454,7 @@ impl ContainerState for RichtextState {
             loader.push(chunk);
         }
 
-        *self.state = LazyLoad::Src(loader);
+        self.state = LazyLoad::Src(loader);
         // self.check_consistency_between_content_and_style_ranges();
     }
 }
@@ -472,7 +472,7 @@ impl RichtextState {
 
     #[inline(always)]
     pub fn len_entity(&self) -> usize {
-        match &*self.state {
+        match &self.state {
             LazyLoad::Src(s) => s.entity_index,
             LazyLoad::Dst(d) => d.len_entity(),
         }

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -28,7 +28,6 @@ use super::ContainerState;
 /// using flat representation
 #[derive(Debug, Clone)]
 pub struct TreeState {
-    id: ContainerID,
     idx: ContainerIdx,
     pub(crate) trees: FxHashMap<TreeID, TreeStateNode>,
     pub(crate) deleted: FxHashSet<TreeID>,
@@ -60,7 +59,7 @@ impl PartialOrd for TreeStateNode {
 }
 
 impl TreeState {
-    pub fn new(id: ContainerID, idx: ContainerIdx) -> Self {
+    pub fn new(idx: ContainerIdx) -> Self {
         let mut trees = FxHashMap::default();
         trees.insert(
             TreeID::delete_root().unwrap(),
@@ -79,7 +78,6 @@ impl TreeState {
         let mut deleted = FxHashSet::default();
         deleted.insert(TreeID::delete_root().unwrap());
         Self {
-            id,
             idx,
             trees,
             deleted,
@@ -211,10 +209,6 @@ impl TreeState {
 impl ContainerState for TreeState {
     fn container_idx(&self) -> crate::container::idx::ContainerIdx {
         self.idx
-    }
-
-    fn container_id(&self) -> &ContainerID {
-        &self.id
     }
 
     fn estimate_size(&self) -> usize {
@@ -560,20 +554,20 @@ mod tests {
 
     #[test]
     fn test_tree_state() {
-        let mut state = TreeState::new(
-            ContainerID::new_normal(ID::new(0, 0), loro_common::ContainerType::Tree),
-            ContainerIdx::from_index_and_type(0, loro_common::ContainerType::Tree),
-        );
+        let mut state = TreeState::new(ContainerIdx::from_index_and_type(
+            0,
+            loro_common::ContainerType::Tree,
+        ));
         state.mov(ID1, None, ID::NONE_ID).unwrap();
         state.mov(ID2, Some(ID1), ID::NONE_ID).unwrap();
     }
 
     #[test]
     fn tree_convert() {
-        let mut state = TreeState::new(
-            ContainerID::new_normal(ID::new(0, 0), loro_common::ContainerType::Tree),
-            ContainerIdx::from_index_and_type(0, loro_common::ContainerType::Tree),
-        );
+        let mut state = TreeState::new(ContainerIdx::from_index_and_type(
+            0,
+            loro_common::ContainerType::Tree,
+        ));
         state.mov(ID1, None, ID::NONE_ID).unwrap();
         state.mov(ID2, Some(ID1), ID::NONE_ID).unwrap();
         let roots = Forest::from_tree_state(&state.trees);
@@ -586,10 +580,10 @@ mod tests {
 
     #[test]
     fn delete_node() {
-        let mut state = TreeState::new(
-            ContainerID::new_normal(ID::new(0, 0), loro_common::ContainerType::Tree),
-            ContainerIdx::from_index_and_type(0, loro_common::ContainerType::Tree),
-        );
+        let mut state = TreeState::new(ContainerIdx::from_index_and_type(
+            0,
+            loro_common::ContainerType::Tree,
+        ));
         state.mov(ID1, None, ID::NONE_ID).unwrap();
         state.mov(ID2, Some(ID1), ID::NONE_ID).unwrap();
         state.mov(ID3, Some(ID2), ID::NONE_ID).unwrap();

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -444,6 +444,7 @@ fn test_checkout() {
     let value: Arc<Mutex<LoroValue>> = Arc::new(Mutex::new(LoroValue::Map(Default::default())));
     let root_value = value.clone();
     doc_0.subscribe_root(Arc::new(move |event| {
+        dbg!(&event);
         let mut root_value = root_value.lock().unwrap();
         root_value.apply(
             &event.container.path.iter().map(|x| x.1.clone()).collect(),

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -271,6 +271,10 @@ impl LoroDoc {
     pub fn unsubscribe(&self, id: SubID) {
         self.doc.unsubscribe(id)
     }
+
+    pub fn log_estimate_size(&self) {
+        self.doc.log_estimated_size();
+    }
 }
 
 /// LoroList container. It's used to model array.


### PR DESCRIPTION
This PR removes the abort behavior of transaction. So we no long need the undo stack in each container, which was used to revert the changes if the txn is aborted.

This PR also tries to reduce the mem usage by reducing the cost of storing states.