### PR TITLE
Fix time travel issue

### DIFF
--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -1838,7 +1838,6 @@ impl RichtextState {
             return;
         }
 
-        debug_log::debug_dbg!(&self);
         let mut entity_index_to_style_anchor: FxHashMap<usize, &RichtextStateChunk> =
             FxHashMap::default();
         let mut index = 0;

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -70,6 +70,7 @@ impl Tracker {
     }
 
     pub(crate) fn insert(&mut self, mut op_id: ID, mut pos: usize, mut content: RichtextChunk) {
+        // debug_log::group!("TrackerInsert");
         // debug_log::debug_dbg!(&op_id, pos, content);
         // debug_log::debug_dbg!(&self);
         let last_id = op_id.inc(content.len() as Counter - 1);
@@ -104,8 +105,10 @@ impl Tracker {
             content = content.slice(start..);
         }
 
-        // debug_log::group!("before insert {} pos={}", op_id, pos);
-        // debug_log::debug_dbg!(&self);
+        // {
+        //     debug_log::group!("before insert {} pos={}", op_id, pos);
+        //     debug_log::debug_dbg!(&self);
+        // }
         let result = self.rope.insert(
             pos,
             FugueSpan {
@@ -129,7 +132,6 @@ impl Tracker {
         self.current_vv.extend_to_include_end_id(end_id);
         self.applied_vv.extend_to_include_end_id(end_id);
         // debug_log::debug_dbg!(&self);
-        //
     }
 
     fn update_insert_by_split(&mut self, split: &[LeafIndex]) {

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -144,8 +144,8 @@ impl Tracker {
     /// Delete the element from pos..pos+len
     ///
     /// If `reverse` is true, the deletion happens from the end of the range to the start.
-    /// Then the first op_id is the one that deletes char at `pos+len-1`, the last op
-    /// is the one that deletes char at `pos`.
+    /// So the first op is the one that deletes element at `pos+len-1`, the last op
+    /// is the one that deletes element at `pos`.
     pub(crate) fn delete(&mut self, mut op_id: ID, pos: usize, mut len: usize, reverse: bool) {
         // debug_log::group!("Tracker Delete");
         // debug_log::debug_dbg!(&op_id, pos, len, reverse);

--- a/crates/loro-internal/src/encoding.rs
+++ b/crates/loro-internal/src/encoding.rs
@@ -63,7 +63,6 @@ pub(crate) struct StateSnapshotEncoder<'a> {
 
 impl StateSnapshotEncoder<'_> {
     pub fn encode_op(&mut self, id_span: IdSpan, get_op: impl FnOnce() -> OpWithId) {
-        debug_log::debug_dbg!(id_span);
         if let Err(span) = (self.check_idspan)(id_span) {
             let mut op = get_op();
             if span == id_span {

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -939,4 +939,51 @@ mod failed_tests {
             ],
         )
     }
+
+    #[test]
+    fn checkout_4() {
+        test_multi_sites(
+            5,
+            &mut [
+                RichText {
+                    site: 5,
+                    pos: 1010580480,
+                    value: 0,
+                    action: RichTextAction::Insert,
+                },
+                SyncAll,
+                RichText {
+                    site: 0,
+                    pos: 2377900603268071424,
+                    value: 2387225703656530209,
+                    action: RichTextAction::Insert,
+                },
+                RichText {
+                    site: 33,
+                    pos: 6701392671700754720,
+                    value: 2387189277486809121,
+                    action: RichTextAction::Delete,
+                },
+                Sync { from: 137, to: 137 },
+                RichText {
+                    site: 33,
+                    pos: 2377900746545832225,
+                    value: 9928747371269792033,
+                    action: RichTextAction::Delete,
+                },
+                Checkout {
+                    site: 137,
+                    to: 16777215,
+                },
+                RichText {
+                    site: 0,
+                    pos: 1993875390464,
+                    value: 38712713492299776,
+                    action: RichTextAction::Mark(12731870418897514672),
+                },
+                Sync { from: 176, to: 91 },
+                Sync { from: 137, to: 137 },
+            ],
+        );
+    }
 }

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -986,4 +986,52 @@ mod failed_tests {
             ],
         );
     }
+
+    #[test]
+    fn checkout_5() {
+        test_multi_sites(
+            5,
+            &mut [
+                RichText {
+                    site: 0,
+                    pos: 9910603113857775223,
+                    value: 8536291640920163781,
+                    action: RichTextAction::Mark(516939283022490631),
+                },
+                Checkout {
+                    site: 66,
+                    to: 1111638594,
+                },
+                Checkout {
+                    site: 95,
+                    to: 65417,
+                },
+                SyncAll,
+                RichText {
+                    site: 0,
+                    pos: 280965477201664,
+                    value: 622770227593,
+                    action: RichTextAction::Insert,
+                },
+                Sync { from: 137, to: 139 },
+                RichText {
+                    site: 255,
+                    pos: 36659862010,
+                    value: 14497138624149061632,
+                    action: RichTextAction::Insert,
+                },
+                Checkout {
+                    site: 31,
+                    to: 773922591,
+                },
+                RichText {
+                    site: 0,
+                    pos: 8759942810400289,
+                    value: 2377900603251727259,
+                    action: RichTextAction::Insert,
+                },
+                Sync { from: 155, to: 1 },
+            ],
+        )
+    }
 }

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -381,7 +381,7 @@ impl LoroDoc {
         match parsed.mode.is_snapshot() {
             false => {
                 // TODO: need to throw error if state is in transaction
-                debug_log::group!("Import updates to {}", self.peer_id());
+                debug_log::group!("Import updates {}", self.peer_id());
                 self.update_oplog_and_apply_delta_to_state_if_needed(
                     |oplog| oplog.decode(parsed),
                     origin,

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -276,6 +276,7 @@ impl DocState {
         if self.in_txn {
             panic!("apply_diff should not be called in a transaction");
         }
+        // debug_log::debug_log!("Diff = {:#?}", &diff);
         let is_recording = self.is_recording();
         self.pre_txn(diff.origin.clone(), diff.local);
         let Cow::Owned(inner) = std::mem::take(&mut diff.diff) else {

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -171,6 +171,7 @@ impl ContainerState for RichtextState {
             unreachable!()
         };
 
+        // debug_log::debug_log!("Self state = {:#?}", &self);
         // PERF: compose delta
         let mut ans: Delta<StringSlice, StyleMeta> = Delta::new();
         let mut style_delta: Delta<StringSlice, StyleMeta> = Delta::new();
@@ -486,10 +487,8 @@ impl ContainerState for RichtextState {
             }
         }
 
-        debug_log::group!("encode_snapshot");
         let mut lamports = DeltaRleEncodedNums::new();
         for chunk in iter {
-            debug_log::debug_dbg!(&chunk);
             match chunk {
                 RichtextStateChunk::Style { style, anchor_type }
                     if *anchor_type == AnchorType::Start =>

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -703,7 +703,6 @@ impl RichtextStateLoader {
     }
 
     pub fn into_state(self) -> InnerState {
-        debug_log::debug_dbg!(&self);
         let mut state = InnerState::from_chunks(self.elements.into_iter());
         for (style, range) in self.style_ranges {
             state.annotate_style_range(range, style);


### PR DESCRIPTION
This pull request fixes a time travel issue in the code. 

The issue was caused by the ambiguity of "reverse" in the `delete` method in `Tracker`. 


```rust
pub(crate) fn delete(&mut self, mut op_id: ID, pos: usize, mut len: usize, reverse: bool) {
   ...
}
```

When I wrote the buggy code, I thought `reverse` means it deleted elements in `pos-len+1..=pos`. But actually it means delete elements in `pos..pos+len` but the first op is the one that deletes element at `pos + len - 1`.