### PR TITLE
refactor: use rich text style config

### DIFF
--- a/crates/examples/examples/draw.rs
+++ b/crates/examples/examples/draw.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use bench_utils::{json, SyncKind};
+use bench_utils::SyncKind;
 use examples::{draw::DrawActor, run_async_workflow, run_realtime_collab_workflow};
 use loro::{LoroDoc, ToJson};
 use tabled::{settings::Style, Table, Tabled};
@@ -25,24 +25,24 @@ struct BenchResult {
 pub fn main() {
     let seed = 123123;
     let ans = vec![
-        // run_async(1, 100, seed),
-        // run_async(1, 1000, seed),
-        // run_async(1, 5000, seed),
-        // run_async(1, 10000, seed),
-        // run_async(5, 100, seed),
-        // run_async(5, 1000, seed),
-        // run_async(5, 10000, seed),
-        // run_async(10, 1000, seed),
-        // run_async(10, 10000, seed),
-        // run_async(10, 100000, seed),
-        // run_async(10, 100000, 1000),
-        // run_realtime_collab(5, 100, seed),
-        // run_realtime_collab(5, 1000, seed),
-        // run_realtime_collab(5, 10000, seed),
-        // run_realtime_collab(10, 1000, seed),
+        run_async(1, 100, seed),
+        run_async(1, 1000, seed),
+        run_async(1, 5000, seed),
+        run_async(1, 10000, seed),
+        run_async(5, 100, seed),
+        run_async(5, 1000, seed),
+        run_async(5, 10000, seed),
+        run_async(10, 1000, seed),
+        run_async(10, 10000, seed),
+        run_async(10, 100000, seed),
+        run_async(10, 100000, 1000),
+        run_realtime_collab(5, 100, seed),
+        run_realtime_collab(5, 1000, seed),
+        run_realtime_collab(5, 10000, seed),
+        run_realtime_collab(10, 1000, seed),
         run_realtime_collab(10, 10000, seed),
-        // run_realtime_collab(10, 100000, seed),
-        // run_realtime_collab(10, 100000, 1000),
+        run_realtime_collab(10, 100000, seed),
+        run_realtime_collab(10, 100000, 1000),
     ];
     let mut table = Table::new(ans);
     let style = Style::markdown();

--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -1,7 +1,7 @@
 use serde_columnar::ColumnarError;
 use thiserror::Error;
 
-use crate::{PeerID, TreeID, ID};
+use crate::{InternalString, PeerID, TreeID, ID};
 
 pub type LoroResult<T> = Result<T, LoroError>;
 
@@ -23,7 +23,7 @@ pub enum LoroError {
     LockError,
     #[error("Each AppState can only have one transaction at a time")]
     DuplicatedTransactionError,
-    #[error("Cannot find ({0}) ")]
+    #[error("Cannot find ({0})")]
     NotFoundError(Box<str>),
     // TODO: more details transaction error
     #[error("Transaction error ({0})")]
@@ -38,6 +38,8 @@ pub enum LoroError {
     ArgErr(Box<str>),
     #[error("Auto commit has not started. The doc is readonly when detached. You should ensure autocommit is on and the doc and the state is attached.")]
     AutoCommitNotStarted,
+    #[error("You need to specify the style flag for \"({0:?})\" before mark with this key")]
+    StyleConfigMissing(InternalString),
     #[error("Unknown Error ({0})")]
     Unknown(Box<str>),
 }

--- a/crates/loro-internal/src/configure.rs
+++ b/crates/loro-internal/src/configure.rs
@@ -1,4 +1,4 @@
-use crate::container::richtext::config::StyleConfigMap;
+pub use crate::container::richtext::config::{StyleConfig, StyleConfigMap};
 
 #[derive(Clone)]
 pub struct Configure {

--- a/crates/loro-internal/src/configure.rs
+++ b/crates/loro-internal/src/configure.rs
@@ -1,18 +1,15 @@
-use std::{fmt::Debug, sync::Arc};
-
-use crate::Timestamp;
+use crate::container::richtext::config::StyleConfigMap;
 
 #[derive(Clone)]
 pub struct Configure {
-    pub get_time: fn() -> Timestamp,
-    pub rand: Arc<dyn SecureRandomGenerator>,
+    pub text_style_config: Arc<RwLock<StyleConfigMap>>,
 }
 
-impl Debug for Configure {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Configure")
-            .field("get_time", &self.get_time)
-            .finish()
+impl Default for Configure {
+    fn default() -> Self {
+        Self {
+            text_style_config: Arc::new(RwLock::new(StyleConfigMap::default_rich_text_config())),
+        }
     }
 }
 
@@ -20,6 +17,7 @@ pub struct DefaultRandom;
 
 #[cfg(test)]
 use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, RwLock};
 #[cfg(test)]
 static mut TEST_RANDOM: AtomicU64 = AtomicU64::new(0);
 
@@ -61,14 +59,5 @@ pub trait SecureRandomGenerator: Send + Sync {
         let mut buf = [0u8; 4];
         self.fill_byte(&mut buf);
         i32::from_le_bytes(buf)
-    }
-}
-
-impl Default for Configure {
-    fn default() -> Self {
-        Self {
-            get_time: || 0,
-            rand: Arc::new(DefaultRandom),
-        }
     }
 }

--- a/crates/loro-internal/src/container/richtext/config.rs
+++ b/crates/loro-internal/src/container/richtext/config.rs
@@ -16,6 +16,10 @@ impl StyleConfigMap {
     }
 
     pub fn insert(&mut self, key: InternalString, value: StyleConfig) {
+        if key.contains(':') {
+            panic!("style key should not contain ':'");
+        }
+
         self.map.insert(key, value);
     }
 

--- a/crates/loro-internal/src/container/richtext/config.rs
+++ b/crates/loro-internal/src/container/richtext/config.rs
@@ -1,0 +1,124 @@
+use fxhash::FxHashMap;
+use loro_common::InternalString;
+
+use super::{ExpandType, TextStyleInfoFlag};
+
+#[derive(Debug, Default, Clone)]
+pub struct StyleConfigMap {
+    map: FxHashMap<InternalString, StyleConfig>,
+}
+
+impl StyleConfigMap {
+    pub fn new() -> Self {
+        Self {
+            map: FxHashMap::default(),
+        }
+    }
+
+    pub fn insert(&mut self, key: InternalString, value: StyleConfig) {
+        self.map.insert(key, value);
+    }
+
+    pub fn get(&self, key: &InternalString) -> Option<&StyleConfig> {
+        self.map.get(key)
+    }
+
+    pub fn get_style_flag(&self, key: &InternalString) -> Option<TextStyleInfoFlag> {
+        self.map
+            .get(key)
+            .map(|x| TextStyleInfoFlag::new(!x.allow_overlap, x.expand))
+    }
+
+    pub fn get_style_flag_for_unmark(&self, key: &InternalString) -> Option<TextStyleInfoFlag> {
+        self.map
+            .get(key)
+            .map(|x| TextStyleInfoFlag::new(!x.allow_overlap, x.expand.reverse()))
+    }
+
+    pub fn default_rich_text_config() -> Self {
+        let mut map = Self {
+            map: FxHashMap::default(),
+        };
+
+        map.map.insert(
+            "bold".into(),
+            StyleConfig {
+                allow_overlap: false,
+                expand: ExpandType::After,
+            },
+        );
+
+        map.map.insert(
+            "italic".into(),
+            StyleConfig {
+                allow_overlap: false,
+                expand: ExpandType::After,
+            },
+        );
+
+        map.map.insert(
+            "underline".into(),
+            StyleConfig {
+                allow_overlap: false,
+                expand: ExpandType::After,
+            },
+        );
+
+        map.map.insert(
+            "link".into(),
+            StyleConfig {
+                allow_overlap: false,
+                expand: ExpandType::None,
+            },
+        );
+
+        map.map.insert(
+            "highlight".into(),
+            StyleConfig {
+                allow_overlap: false,
+                expand: ExpandType::None,
+            },
+        );
+
+        map.map.insert(
+            "comment".into(),
+            StyleConfig {
+                allow_overlap: true,
+                expand: ExpandType::None,
+            },
+        );
+
+        map
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StyleConfig {
+    pub allow_overlap: bool,
+    pub expand: ExpandType,
+}
+
+impl StyleConfig {
+    pub fn new() -> Self {
+        Self {
+            allow_overlap: false,
+            expand: ExpandType::None,
+        }
+    }
+
+    pub fn allow_overlap(mut self, allow_overlap: bool) -> Self {
+        self.allow_overlap = allow_overlap;
+        self
+    }
+
+    pub fn expand(mut self, expand: ExpandType) -> Self {
+        self.expand = expand;
+        self
+    }
+}
+
+impl Default for StyleConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -4,7 +4,6 @@ use generic_btree::{
     rle::{HasLength, Mergeable, Sliceable},
     BTree, BTreeTrait, Cursor,
 };
-use itertools::Itertools;
 use loro_common::{IdSpan, LoroValue, ID};
 use serde::{ser::SerializeStruct, Serialize};
 use std::fmt::{Display, Formatter};
@@ -2130,7 +2129,7 @@ mod test {
     fn comment(n: isize) -> Arc<StyleOp> {
         Arc::new(StyleOp::new_for_test(
             n,
-            "comment",
+            &format!("comment:{}", n),
             "comment".into(),
             TextStyleInfoFlag::COMMENT,
         ))
@@ -2456,33 +2455,21 @@ mod test {
                 {
                     "insert": "H",
                     "attributes": {
-                        "id:0@0": {
-                            "key": "comment",
-                            "data": "comment"
-                        },
+                        "comment:0": "comment",
                     },
                 },
                 {
                     "insert": "ello",
                     "attributes": {
-                        "id:0@0": {
-                            "key": "comment",
-                            "data": "comment"
-                        },
-                        "id:1@1": {
-                            "key": "comment",
-                            "data": "comment"
-                        }
+                        "comment:0": "comment",
+                        "comment:1": "comment",
                     },
                 },
 
                 {
                     "insert": " ",
                     "attributes": {
-                        "id:1@1": {
-                            "key": "comment",
-                            "data": "comment"
-                        }
+                        "comment:1": "comment",
                     },
                 },
                 {

--- a/crates/loro-internal/src/delta/seq.rs
+++ b/crates/loro-internal/src/delta/seq.rs
@@ -615,12 +615,15 @@ impl<Value: DeltaValue, M: Meta> Delta<Value, M> {
     }
 
     pub fn chop(mut self) -> Self {
-        let last_op = self.vec.last();
-        if let Some(last_op) = last_op {
-            if last_op.is_retain() && last_op.meta().is_empty() {
-                self.vec.pop();
+        loop {
+            match self.vec.last() {
+                Some(last_op) if last_op.is_retain() && last_op.meta().is_empty() => {
+                    self.vec.pop();
+                }
+                _ => break,
             }
         }
+
         self
     }
 }

--- a/crates/loro-internal/src/delta/text.rs
+++ b/crates/loro-internal/src/delta/text.rs
@@ -33,8 +33,8 @@ impl StyleMetaItem {
     }
 }
 
-impl From<Styles> for StyleMeta {
-    fn from(styles: Styles) -> Self {
+impl From<&Styles> for StyleMeta {
+    fn from(styles: &Styles) -> Self {
         let mut map = FxHashMap::with_capacity_and_hasher(styles.len(), Default::default());
         for (key, value) in styles.iter() {
             if let Some(value) = value.get() {
@@ -49,6 +49,13 @@ impl From<Styles> for StyleMeta {
             }
         }
         Self { map }
+    }
+}
+
+impl From<Styles> for StyleMeta {
+    fn from(styles: Styles) -> Self {
+        let temp = &styles;
+        temp.into()
     }
 }
 

--- a/crates/loro-internal/src/delta/text.rs
+++ b/crates/loro-internal/src/delta/text.rs
@@ -110,17 +110,7 @@ impl StyleMeta {
                         return None;
                     }
 
-                    Some((
-                        key.to_attr_key(),
-                        if key.contains_id() {
-                            let mut map: FxHashMap<String, LoroValue> = Default::default();
-                            map.insert("key".into(), key.key().to_string().into());
-                            map.insert("data".into(), value.value.clone());
-                            LoroValue::Map(Arc::new(map))
-                        } else {
-                            value.value.clone()
-                        },
-                    ))
+                    Some((key.to_attr_key(), value.value.clone()))
                 })
                 .collect(),
         ))
@@ -131,15 +121,7 @@ impl ToJson for StyleMeta {
     fn to_json_value(&self) -> serde_json::Value {
         let mut map = serde_json::Map::new();
         for (key, style) in self.iter() {
-            let value = if !key.contains_id() {
-                serde_json::to_value(&style.data).unwrap()
-            } else {
-                let mut value = serde_json::Map::new();
-                value.insert("key".to_string(), style.key.to_string().into());
-                let data = serde_json::to_value(&style.data).unwrap();
-                value.insert("data".to_string(), data);
-                value.into()
-            };
+            let value = serde_json::to_value(&style.data).unwrap();
             map.insert(key.to_attr_key(), value);
         }
 

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -98,15 +98,6 @@ impl Actor {
                                     .filter(|(_, v)| !v.data.is_null())
                                     .map(|(k, v)| match k {
                                         StyleKey::Key(k) => (k.to_string(), v.data),
-                                        StyleKey::KeyWithId { key, id } => {
-                                            let mut data = FxHashMap::default();
-                                            data.insert(
-                                                "key".to_string(),
-                                                LoroValue::String(Arc::new(key.to_string())),
-                                            );
-                                            data.insert("data".to_string(), v.data);
-                                            (format!("id:{}", id), LoroValue::Map(Arc::new(data)))
-                                        }
                                     })
                                     .collect();
                                 let attributes = if attributes.is_empty() {
@@ -129,15 +120,6 @@ impl Actor {
                                     .filter(|(_, v)| !v.data.is_null())
                                     .map(|(k, v)| match k {
                                         StyleKey::Key(k) => (k.to_string(), v.data),
-                                        StyleKey::KeyWithId { key, id } => {
-                                            let mut data = FxHashMap::default();
-                                            data.insert(
-                                                "key".to_string(),
-                                                LoroValue::String(Arc::new(key.to_string())),
-                                            );
-                                            data.insert("data".to_string(), v.data);
-                                            (format!("id:{}", id), LoroValue::Map(Arc::new(data)))
-                                        }
                                     })
                                     .collect();
                                 let attributes = if attributes.is_empty() {
@@ -157,7 +139,7 @@ impl Actor {
                     //     text_doc.peer_id(),
                     //     text_h.get_richtext_value()
                     // );
-                    // println!("delta {:?}", text_deltas);
+                    debug_log::debug_log!("delta {:?}", text_deltas);
                     text_h.apply_delta_with_txn(&mut txn, &text_deltas).unwrap();
 
                     // println!("after {:?}\n", text_h.get_richtext_value());
@@ -439,7 +421,7 @@ fn check_eq(a_actor: &mut Actor, b_actor: &mut Actor) {
 
     debug_log::debug_log!("{}", a_result.to_json_pretty());
     assert_eq!(&a_result, &b_result);
-    a_actor.text_container.check();
+    debug_log::debug_log!("{}", a_value.to_json_pretty());
     assert_value_eq(&a_result, &a_value);
 }
 
@@ -1004,5 +986,26 @@ mod failed_tests {
                 Sync { from: 155, to: 1 },
             ],
         )
+    }
+
+    #[test]
+    fn allow_overlap() {
+        test_multi_sites(
+            5,
+            &mut [
+                RichText {
+                    site: 255,
+                    pos: 562949940576255,
+                    value: 10,
+                    action: RichTextAction::Insert,
+                },
+                RichText {
+                    site: 0,
+                    pos: 52793738066393,
+                    value: 15637060856183783423,
+                    action: RichTextAction::Mark(15697817505862638041),
+                },
+            ],
+        );
     }
 }

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -440,7 +440,6 @@ fn check_eq(a_actor: &mut Actor, b_actor: &mut Actor) {
     debug_log::debug_log!("{}", a_result.to_json_pretty());
     assert_eq!(&a_result, &b_result);
     a_actor.text_container.check();
-    dbg!(&a_result, &a_value);
     assert_value_eq(&a_result, &a_value);
 }
 

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -45,7 +45,6 @@ pub(crate) mod group;
 pub(crate) mod macros;
 pub(crate) mod state;
 pub(crate) mod value;
-pub(crate) use change::Timestamp;
 pub(crate) use id::{PeerID, ID};
 
 // TODO: rename as Key?

--- a/crates/loro-internal/src/utils/lazy.rs
+++ b/crates/loro-internal/src/utils/lazy.rs
@@ -5,10 +5,6 @@ pub enum LazyLoad<Src, Dst: From<Src>> {
 }
 
 impl<Src: Default, Dst: From<Src>> LazyLoad<Src, Dst> {
-    pub fn new_dst(dst: Dst) -> Self {
-        LazyLoad::Dst(dst)
-    }
-
     pub fn get_mut(&mut self) -> &mut Dst {
         match self {
             LazyLoad::Src(src) => {

--- a/crates/loro-internal/src/value.rs
+++ b/crates/loro-internal/src/value.rs
@@ -456,16 +456,7 @@ pub mod wasm {
             // TODO: refactor: should we extract the common code of ToJson and ToJsValue
             let obj = Object::new();
             for (key, style) in value.iter() {
-                let value = if !key.contains_id() {
-                    JsValue::from(style.data)
-                } else {
-                    let value = Object::new();
-                    js_sys::Reflect::set(&value, &"key".into(), &JsValue::from_str(&style.key))
-                        .unwrap();
-                    let data = JsValue::from(style.data);
-                    js_sys::Reflect::set(&value, &"data".into(), &data).unwrap();
-                    value.into()
-                };
+                let value = JsValue::from(style.data);
                 js_sys::Reflect::set(&obj, &JsValue::from_str(&key.to_attr_key()), &value).unwrap();
             }
 

--- a/crates/loro-internal/tests/richtext.md
+++ b/crates/loro-internal/tests/richtext.md
@@ -36,18 +36,7 @@
 | Concurrent B    | `Hello a World`        |
 | Expected Result | `Hello a <b>World</b>` |
 
-#### 4. Concurrently insert text and style that expands
-
-This doesn't work well in our implementation
-
-| Name            | Text                  |
-|:----------------|:----------------------|
-| Origin          | `Hello World`         |
-| Concurrent A    | `<b>Hello</b> World`  |
-| Concurrent B    | `Hello* World`        |
-| Expected Result | `<b>Hello*</b> World` |
-
-#### 5. Concurrent text edit & style that shrink
+#### 4. Concurrent text edit & style that shrink
 
 | Name            | Text                       |
 |:----------------|:---------------------------|
@@ -56,7 +45,7 @@ This doesn't work well in our implementation
 | Concurrent B    | `Hey World`                |
 | Expected Result | `<link>Hey</link> World`   |
 
-#### 6. Local insertion expand rules
+#### 5. Local insertion expand rules
 
 > [**Hello**](https://www.google.com) World
 
@@ -71,7 +60,7 @@ When insert a new character after "Hello", the new char should be bold but not l
 | Expected Result | `<b><link>Hello</link>t<b> World` |
 
 
-#### 7. Concurrent unbold
+#### 6. Concurrent unbold
 
 In Peritext paper 2.3.2
 
@@ -82,7 +71,7 @@ In Peritext paper 2.3.2
 | Concurrent B    | `<b>The </b>fox<b> jumped</b> over the dog.` |
 | Expected Result | `The fox jumped over the dog.`               |
 
-#### 8. Bold & Unbold
+#### 7. Bold & Unbold
 
 In Peritext paper 2.3.3
 
@@ -93,7 +82,7 @@ In Peritext paper 2.3.3
 | Concurrent B    | `<b>The</b> fox jumped over the <b>dog</b>.` |
 | Expected Result | `<b>The</b> fox jumped over the <b>dog</b>.` |
 
-#### 9. Overlapped formatting
+#### 8. Overlapped formatting
 
 In Peritext paper 3.2, example 3
 
@@ -104,6 +93,6 @@ In Peritext paper 3.2, example 3
 | Concurrent B    | The *fox jumped*.            |
 | Expected Result | **The _fox_**<i> jumped</i>. |
 
-#### 10. Multiple instances of the same mark
+#### 9. Multiple instances of the same mark
 
 ![](https://i.postimg.cc/MTNGq8cH/Clean-Shot-2023-10-09-at-12-16-29-2x.png)

--- a/crates/loro-internal/tests/richtext.rs
+++ b/crates/loro-internal/tests/richtext.rs
@@ -2,7 +2,8 @@
 
 use std::ops::Range;
 
-use loro_internal::{container::richtext::TextStyleInfoFlag, LoroDoc, ToJson};
+use loro_common::LoroValue;
+use loro_internal::{LoroDoc, ToJson};
 use serde_json::json;
 
 fn init(s: &str) -> LoroDoc {
@@ -62,6 +63,14 @@ fn unmark(doc: &LoroDoc, range: Range<usize>, kind: Kind) {
     let richtext = doc.get_text("r");
     doc.with_txn(|txn| {
         richtext.mark_with_txn(txn, range.start, range.end, kind.key(), false.into(), false)
+    })
+    .unwrap();
+}
+
+fn mark_kv(doc: &LoroDoc, range: Range<usize>, key: &str, value: impl Into<LoroValue>) {
+    let richtext = doc.get_text("r");
+    doc.with_txn(|txn| {
+        richtext.mark_with_txn(txn, range.start, range.end, key, value.into(), false)
     })
     .unwrap();
 }
@@ -158,7 +167,7 @@ fn case3() {
 /// | Concurrent B    | `Hey World`                |
 /// | Expected Result | `<link>Hey</link> World`   |
 #[test]
-fn case5() {
+fn case4() {
     let doc_a = init("Hello World");
     let doc_b = clone(&doc_a, 2);
     mark(&doc_a, 0..5, Kind::Link);
@@ -186,7 +195,7 @@ fn case5() {
 /// | Origin          | `<b><link>Hello</link><b> World`  |
 /// | Expected Result | `<b><link>Hello</link>t<b> World` |
 #[test]
-fn case6() {
+fn case5() {
     let doc = init("Hello World");
     mark(&doc, 0..5, Kind::Bold);
     expect_result(
@@ -224,7 +233,7 @@ fn case6() {
 /// | Concurrent B    | `<b>The </b>fox<b> jumped</b> over the dog.` |
 /// | Expected Result | `The fox jumped over the dog.`               |
 #[test]
-fn case7() {
+fn case6() {
     let doc_a = init("The fox jumped over the dog.");
     mark(&doc_a, 0..3, Kind::Bold);
     let doc_b = clone(&doc_a, 2);
@@ -251,7 +260,7 @@ fn case7() {
 /// | Concurrent B    | `<b>The</b> fox jumped over the <b>dog</b>.` |
 /// | Expected Result | `<b>The</b> fox jumped over the <b>dog</b>.` |
 #[test]
-fn case8() {
+fn case7() {
     let doc_a = init("The fox jumped over the dog.");
     mark(&doc_a, 0..14, Kind::Bold);
     let doc_b = clone(&doc_a, 2);
@@ -280,7 +289,7 @@ fn case8() {
 /// | Concurrent B    | The *fox jumped*.            |
 /// | Expected Result | **The _fox_**<i> jumped</i>. |
 #[test]
-fn case9() {
+fn case8() {
     let doc_a = init("The fox jumped.");
     let doc_b = clone(&doc_a, 2);
     mark(&doc_a, 0..7, Kind::Bold);
@@ -297,6 +306,25 @@ fn case9() {
     );
     doc_a.check_state_diff_calc_consistency_slow();
     doc_b.check_state_diff_calc_consistency_slow();
+}
+
+/// ![](https://i.postimg.cc/MTNGq8cH/Clean-Shot-2023-10-09-at-12-16-29-2x.png)
+#[test]
+fn case9() {
+    let doc_a = init("The fox jumped.");
+    let doc_b = clone(&doc_a, 2);
+    mark_kv(&doc_a, 0..7, "comment:alice", "alice comment");
+    mark_kv(&doc_a, 4..14, "comment:bob", "bob comment");
+    merge(&doc_a, &doc_b);
+    expect_result(
+        &doc_a,
+        serde_json::json!([
+            {"insert": "The ", "attributes": {"comment:alice": "alice comment"}},
+            {"insert": "fox", "attributes": {"comment:alice": "alice comment", "comment:bob": "bob comment"}},
+            {"insert": " jumped", "attributes": {"comment:bob": "bob comment"}},
+            {"insert": "."}
+        ]),
+    );
 }
 
 #[test]

--- a/crates/loro-internal/tests/richtext.rs
+++ b/crates/loro-internal/tests/richtext.rs
@@ -2,7 +2,6 @@
 
 use std::ops::Range;
 
-use loro_common::LoroValue;
 use loro_internal::{container::richtext::TextStyleInfoFlag, LoroDoc, ToJson};
 use serde_json::json;
 
@@ -37,14 +36,6 @@ impl Kind {
             Kind::Italic => "italic",
         }
     }
-
-    fn flag(&self) -> TextStyleInfoFlag {
-        match self {
-            Kind::Bold => TextStyleInfoFlag::BOLD,
-            Kind::Link => TextStyleInfoFlag::LINK,
-            Kind::Italic => TextStyleInfoFlag::BOLD,
-        }
-    }
 }
 
 fn insert(doc: &LoroDoc, pos: usize, s: &str) {
@@ -62,18 +53,7 @@ fn delete(doc: &LoroDoc, pos: usize, len: usize) {
 fn mark(doc: &LoroDoc, range: Range<usize>, kind: Kind) {
     let richtext = doc.get_text("r");
     doc.with_txn(|txn| {
-        richtext.mark_with_txn(
-            txn,
-            range.start,
-            range.end,
-            kind.key(),
-            if kind.flag().is_delete() {
-                LoroValue::Null
-            } else {
-                true.into()
-            },
-            kind.flag(),
-        )
+        richtext.mark_with_txn(txn, range.start, range.end, kind.key(), true.into(), false)
     })
     .unwrap();
 }
@@ -81,14 +61,7 @@ fn mark(doc: &LoroDoc, range: Range<usize>, kind: Kind) {
 fn unmark(doc: &LoroDoc, range: Range<usize>, kind: Kind) {
     let richtext = doc.get_text("r");
     doc.with_txn(|txn| {
-        richtext.mark_with_txn(
-            txn,
-            range.start,
-            range.end,
-            kind.key(),
-            false.into(),
-            kind.flag().to_delete(),
-        )
+        richtext.mark_with_txn(txn, range.start, range.end, kind.key(), false.into(), false)
     })
     .unwrap();
 }

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3,10 +3,7 @@ use convert::resolved_diff_to_js;
 use js_sys::{Array, Object, Promise, Reflect, Uint8Array};
 use loro_internal::{
     change::Lamport,
-    container::{
-        richtext::{ExpandType, TextStyleInfoFlag},
-        ContainerID,
-    },
+    container::ContainerID,
     event::{Diff, Index},
     handler::{ListHandler, MapHandler, TextDelta, TextHandler, TreeHandler, ValueOrContainer},
     id::{Counter, TreeID, ID},
@@ -1104,20 +1101,7 @@ impl LoroText {
     pub fn mark(&self, range: JsRange, key: &str, value: JsValue) -> Result<(), JsError> {
         let range: MarkRange = serde_wasm_bindgen::from_value(range.into())?;
         let value: LoroValue = LoroValue::from(value);
-        let expand = range
-            .expand
-            .map(|x| {
-                ExpandType::try_from_str(&x)
-                    .expect_throw("`expand` must be one of `none`, `start`, `end`, `both`")
-            })
-            .unwrap_or(ExpandType::After);
-        self.handler.mark(
-            range.start,
-            range.end,
-            key,
-            value,
-            TextStyleInfoFlag::new(true, expand, false, false),
-        )?;
+        self.handler.mark(range.start, range.end, key, value)?;
         Ok(())
     }
 
@@ -1151,21 +1135,7 @@ impl LoroText {
     pub fn unmark(&self, range: JsRange, key: &str) -> Result<(), JsValue> {
         // Internally, this may be marking with null or deleting all the marks with key in the range entirely.
         let range: MarkRange = serde_wasm_bindgen::from_value(range.into())?;
-        let expand = range
-            .expand
-            .map(|x| {
-                ExpandType::try_from_str(&x)
-                    .expect_throw("`expand` must be one of `none`, `start`, `end`, `both`")
-            })
-            .unwrap_or(ExpandType::After);
-        let expand = expand.reverse();
-        self.handler.mark(
-            range.start,
-            range.end,
-            key,
-            LoroValue::Null,
-            TextStyleInfoFlag::new(true, expand, true, false),
-        )?;
+        self.handler.unmark(range.start, range.end, key)?;
         Ok(())
     }
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -88,9 +88,7 @@ extern "C" {
     pub type JsValueOrContainerOrUndefined;
     #[wasm_bindgen(typescript_type = "[string, Value | Container]")]
     pub type MapEntry;
-    #[wasm_bindgen(
-        typescript_type = "{[key: string]: { expand: 'before'|'after'|'none'|'both', allowOverlap?: boolean }}"
-    )]
+    #[wasm_bindgen(typescript_type = "{[key: string]: { expand: 'before'|'after'|'none'|'both' }}")]
     pub type JsTextStyles;
 }
 
@@ -247,11 +245,9 @@ impl Loro {
             let expand = Reflect::get(&value, &"expand".into()).expect("`expand` not specified");
             let expand_str = expand.as_string().unwrap();
             // read allowOverlap value from value
-            let allow_overlap = Reflect::get(&value, &"allowOverlap".into()).unwrap();
             style_config.insert(
                 key.into(),
                 StyleConfig {
-                    allow_overlap: allow_overlap.as_bool().unwrap_or(false),
                     expand: ExpandType::try_from_str(&expand_str)
                         .expect("`expand` must be one of `none`, `start`, `end`, `both`"),
                 },

--- a/crates/loro/README.md
+++ b/crates/loro/README.md
@@ -55,7 +55,7 @@ use serde_json::json;
 let doc = LoroDoc::new();
 let text = doc.get_text("text");
 text.insert(0, "Hello world!").unwrap();
-text.mark(0..5, ExpandType::After, "bold", true).unwrap();
+text.mark(0..5, "bold", true).unwrap();
 assert_eq!(
     text.to_delta().to_json_value(),
     json!([
@@ -63,7 +63,7 @@ assert_eq!(
         { "insert": " world!" },
     ])
 );
-text.unmark(3..5, ExpandType::After, "bold").unwrap();
+text.unmark(3..5, "bold").unwrap();
 assert_eq!(
     text.to_delta().to_json_value(),
     json!([
@@ -88,7 +88,7 @@ doc_b.import(&bytes).unwrap();
 assert_eq!(doc.get_deep_value(), doc_b.get_deep_value());
 let text_b = doc_b.get_text("text");
 text_b
-    .mark(0..5, loro::ExpandType::After, "bold", true)
+    .mark(0..5, "bold", true)
     .unwrap();
 doc.import(&doc_b.export_from(&doc.oplog_vv())).unwrap();
 assert_eq!(

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 use either::Either;
 use loro_internal::change::Timestamp;
-use loro_internal::container::richtext::TextStyleInfoFlag;
 use loro_internal::container::IntoContainerId;
 use loro_internal::handler::TextDelta;
 use loro_internal::handler::ValueOrContainer;
@@ -534,17 +533,10 @@ impl LoroText {
     pub fn mark(
         &self,
         range: Range<usize>,
-        expand: ExpandType,
         key: &str,
         value: impl Into<LoroValue>,
     ) -> LoroResult<()> {
-        self.handler.mark(
-            range.start,
-            range.end,
-            key,
-            value.into(),
-            TextStyleInfoFlag::new(true, expand, false, false),
-        )
+        self.handler.mark(range.start, range.end, key, value.into())
     }
 
     /// Unmark a range of text with a key and a value.
@@ -563,15 +555,8 @@ impl LoroText {
     /// *You should make sure that a key is always associated with the same expand type.*
     ///
     /// Note: you cannot delete unmergeable annotations like comments by this method.
-    pub fn unmark(&self, range: Range<usize>, expand: ExpandType, key: &str) -> LoroResult<()> {
-        let expand = expand.reverse();
-        self.handler.mark(
-            range.start,
-            range.end,
-            key,
-            LoroValue::Null,
-            TextStyleInfoFlag::new(true, expand, true, false),
-        )
+    pub fn unmark(&self, range: Range<usize>, key: &str) -> LoroResult<()> {
+        self.handler.unmark(range.start, range.end, key)
     }
 
     /// Get the text in [Delta](https://quilljs.com/docs/delta/) format.
@@ -584,7 +569,7 @@ impl LoroText {
     /// let doc = LoroDoc::new();
     /// let text = doc.get_text("text");
     /// text.insert(0, "Hello world!").unwrap();
-    /// text.mark(0..5, ExpandType::After, "bold", true).unwrap();
+    /// text.mark(0..5, "bold", true).unwrap();
     /// assert_eq!(
     ///     text.to_delta().to_json_value(),
     ///     json!([
@@ -592,7 +577,7 @@ impl LoroText {
     ///         { "insert": " world!" },
     ///     ])
     /// );
-    /// text.unmark(3..5, ExpandType::After, "bold").unwrap();
+    /// text.unmark(3..5, "bold").unwrap();
     /// assert_eq!(
     ///     text.to_delta().to_json_value(),
     ///     json!([

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -90,13 +90,13 @@ fn check_sync_send(_doc: impl Sync + Send) {}
 
 #[test]
 fn richtext_test() {
-    use loro::{ExpandType, LoroDoc, ToJson};
+    use loro::{LoroDoc, ToJson};
     use serde_json::json;
 
     let doc = LoroDoc::new();
     let text = doc.get_text("text");
     text.insert(0, "Hello world!").unwrap();
-    text.mark(0..5, ExpandType::After, "bold", true).unwrap();
+    text.mark(0..5, "bold", true).unwrap();
     assert_eq!(
         text.to_delta().to_json_value(),
         json!([
@@ -104,7 +104,7 @@ fn richtext_test() {
             { "insert": " world!" },
         ])
     );
-    text.unmark(3..5, ExpandType::After, "bold").unwrap();
+    text.unmark(3..5, "bold").unwrap();
     assert_eq!(
         text.to_delta().to_json_value(),
         json!([
@@ -127,9 +127,7 @@ fn sync() {
     doc_b.import(&bytes).unwrap();
     assert_eq!(doc.get_deep_value(), doc_b.get_deep_value());
     let text_b = doc_b.get_text("text");
-    text_b
-        .mark(0..5, loro::ExpandType::After, "bold", true)
-        .unwrap();
+    text_b.mark(0..5, "bold", true).unwrap();
     doc.import(&doc_b.export_from(&doc.oplog_vv())).unwrap();
     assert_eq!(
         text.to_delta().to_json_value(),

--- a/loro-js/tests/richtext.test.ts
+++ b/loro-js/tests/richtext.test.ts
@@ -146,22 +146,25 @@ describe("richtext", () => {
 
   it("allow overlapped styles", () => {
     const doc = new Loro();
+    doc.configTextStyle({
+      comment: { expand: "none", }
+    })
     const text = doc.getText("text");
-    text.insert(0, "Hello world!");
-    text.mark({ start: 0, end: 5 }, "comment:alice", "Hi");
-    text.mark({ start: 4, end: 11 }, "comment:bob", "I'm a comment!");
+    text.insert(0, "The fox jumped.");
+    text.mark({ start: 0, end: 7 }, "comment:alice", "Hi");
+    text.mark({ start: 4, end: 14 }, "comment:bob", "Jump");
     expect(text.toDelta()).toStrictEqual([
       {
-        insert: "Hell", attributes: { "comment:alice": "Hi" },
+        insert: "The ", attributes: { "comment:alice": "Hi" },
       },
       {
-        insert: "o", attributes: { "comment:alice": "Hi", "comment:bob": "I'm a comment!" },
+        insert: "fox", attributes: { "comment:alice": "Hi", "comment:bob": "Jump" },
       },
       {
-        insert: " world", attributes: { "comment:bob": "I'm a comment!" },
+        insert: " jumped", attributes: { "comment:bob": "Jump" },
       },
       {
-        insert: "!",
+        insert: ".",
       }
     ])
   })

--- a/loro-js/tests/richtext.test.ts
+++ b/loro-js/tests/richtext.test.ts
@@ -114,11 +114,33 @@ describe("richtext", () => {
       text2.applyDelta(e.diff);
     });
     text.insert(0, "foo");
-    text.mark({ start: 0, end: 3, expand: "none" }, "link", true);
+    text.mark({ start: 0, end: 3 }, "link", true);
     doc.commit();
     text.insert(3, "baz");
     doc.commit();
     await new Promise((r) => setTimeout(r, 1));
     expect(text2.toDelta()).toStrictEqual([{ insert: 'foo', attributes: { link: true } }, { insert: 'baz' }]);
+  })
+
+  it("custom richtext type", async () => {
+    const doc = new Loro();
+    doc.configTextStyle({
+      myStyle: {
+        expand: "none"
+      }
+    })
+    const text = doc.getText("text");
+    text.insert(0, "foo");
+    text.mark({ start: 0, end: 3 }, "myStyle", 123);
+    expect(text.toDelta()).toStrictEqual([{ insert: 'foo', attributes: { myStyle: 123 } }]);
+
+    expect(() => {
+      text.mark({ start: 0, end: 3 }, "unknownStyle", 2);
+    }).toThrowError()
+
+    expect(() => {
+      // default style config should be overwritten
+      text.mark({ start: 0, end: 3 }, "bold", 2);
+    }).toThrowError()
   })
 });

--- a/loro-js/tests/richtext.test.ts
+++ b/loro-js/tests/richtext.test.ts
@@ -126,7 +126,7 @@ describe("richtext", () => {
     const doc = new Loro();
     doc.configTextStyle({
       myStyle: {
-        expand: "none"
+        expand: "none",
       }
     })
     const text = doc.getText("text");
@@ -142,5 +142,27 @@ describe("richtext", () => {
       // default style config should be overwritten
       text.mark({ start: 0, end: 3 }, "bold", 2);
     }).toThrowError()
+  })
+
+  it("allow overlapped styles", () => {
+    const doc = new Loro();
+    const text = doc.getText("text");
+    text.insert(0, "Hello world!");
+    text.mark({ start: 0, end: 5 }, "comment:0", "Hi");
+    text.mark({ start: 4, end: 11 }, "comment:1", "I'm a comment!");
+    expect(text.toDelta()).toStrictEqual([
+      {
+        insert: "Hell", attributes: { "comment:0": "Hi" },
+      },
+      {
+        insert: "o", attributes: { "comment:0": "Hi", "comment:1": "I'm a comment!" },
+      },
+      {
+        insert: " world", attributes: { "comment:1": "I'm a comment!" },
+      },
+      {
+        insert: "!",
+      }
+    ])
   })
 });

--- a/loro-js/tests/richtext.test.ts
+++ b/loro-js/tests/richtext.test.ts
@@ -148,17 +148,17 @@ describe("richtext", () => {
     const doc = new Loro();
     const text = doc.getText("text");
     text.insert(0, "Hello world!");
-    text.mark({ start: 0, end: 5 }, "comment:0", "Hi");
-    text.mark({ start: 4, end: 11 }, "comment:1", "I'm a comment!");
+    text.mark({ start: 0, end: 5 }, "comment:alice", "Hi");
+    text.mark({ start: 4, end: 11 }, "comment:bob", "I'm a comment!");
     expect(text.toDelta()).toStrictEqual([
       {
-        insert: "Hell", attributes: { "comment:0": "Hi" },
+        insert: "Hell", attributes: { "comment:alice": "Hi" },
       },
       {
-        insert: "o", attributes: { "comment:0": "Hi", "comment:1": "I'm a comment!" },
+        insert: "o", attributes: { "comment:alice": "Hi", "comment:bob": "I'm a comment!" },
       },
       {
-        insert: " world", attributes: { "comment:1": "I'm a comment!" },
+        insert: " world", attributes: { "comment:bob": "I'm a comment!" },
       },
       {
         insert: "!",


### PR DESCRIPTION
This PR simplifies the usage of rich text.

We used to specify the expand behavior during each `mark` call. But it's quite hard to use, which makes introducing the types that allow overlapping harder. We only need to specify the configuration once at the doc level.

The usage before

```ts
const doc = new Loro();
const text = doc.getText("text");
text.insert(0, "foo");
text.mark({ start: 0, end: 3, expand: "none"}, "myStyle", 123);
expect(text.toDelta()).toStrictEqual([{ insert: 'foo', attributes: { myStyle: 123 } }]);
```

The usage now

```ts
const doc = new Loro();
// only need to do this once
doc.configTextStyle({
  myStyle: {
    expand: "none",
    allowOverlap: false,
  }
});

const text = doc.getText("text");
text.insert(0, "foo");
// don't need to specify the expand type now when we call `mark`
text.mark({ start: 0, end: 3 }, "myStyle", 123);
expect(text.toDelta()).toStrictEqual([{ insert: 'foo', attributes: { myStyle: 123 } }]);

expect(() => {
  text.mark({ start: 0, end: 3 }, "unknownStyle", 2);
}).toThrowError()
```

This PR also makes styles that allow overlapping work:
(This is much easier to use compared to the previous design)

```ts
const doc = new Loro();
const text = doc.getText("text");
text.insert(0, "Hello world!");
text.mark({ start: 0, end: 5 }, "comment:alice", "Hi");
text.mark({ start: 4, end: 11 }, "comment:bob", "I'm a comment!");
expect(text.toDelta()).toStrictEqual([
  {
    insert: "Hell", attributes: { "comment:alice": "Hi" },
  },
  {
    insert: "o", attributes: { "comment:alice": "Hi", "comment:bob": "I'm a comment!" },
  },
  {
    insert: " world", attributes: { "comment:bob": "I'm a comment!" },
  },
  {
    insert: "!",
  }
])
```