### PR TITLE
refactor: Optimizing Encoding Representation for Child Container Creation to Reduce Document Size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "color-backtrace 0.6.1",
  "ctor 0.2.6",
  "debug-log",
+ "flate2",
  "loro",
  "serde_json",
  "tabled 0.15.0",

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -14,5 +14,6 @@ debug-log = { version = "0.3.1", features = [] }
 serde_json = "1.0.111"
 
 [dev-dependencies]
+flate2 = "1.0"
 color-backtrace = { version = "0.6" }
 ctor = "0.2"

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -1769,10 +1769,13 @@ mod value {
                     if len > MAX_COLLECTION_SIZE {
                         return Err(LoroError::DecodeDataCorruptionError);
                     }
-
                     let mut ans = Vec::with_capacity(len);
-                    for _ in 0..len {
-                        ans.push(self.recursive_read_value_type_and_content(keys, cids, id)?);
+                    for i in 0..len {
+                        ans.push(self.recursive_read_value_type_and_content(
+                            keys,
+                            cids,
+                            id.inc(i as i32),
+                        )?);
                     }
                     ans.into()
                 }
@@ -1781,7 +1784,6 @@ mod value {
                     if len > MAX_COLLECTION_SIZE {
                         return Err(LoroError::DecodeDataCorruptionError);
                     }
-
                     let mut ans = FxHashMap::with_capacity_and_hasher(len, Default::default());
                     for _ in 0..len {
                         let key_idx = self.read_usize()?;

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -1208,6 +1208,52 @@ mod failed_tests {
     }
 
     #[test]
+    fn encoding_sub_container() {
+        test_multi_sites(
+            5,
+            &mut [
+                List {
+                    site: 96,
+                    container_idx: 96,
+                    key: 96,
+                    value: Container(C::Tree),
+                },
+                List {
+                    site: 96,
+                    container_idx: 96,
+                    key: 96,
+                    value: Container(C::List),
+                },
+                List {
+                    site: 90,
+                    container_idx: 96,
+                    key: 96,
+                    value: I32(1516265568),
+                },
+                List {
+                    site: 96,
+                    container_idx: 96,
+                    key: 7,
+                    value: Container(C::Map),
+                },
+                SyncAll,
+                Map {
+                    site: 4,
+                    container_idx: 21,
+                    key: 64,
+                    value: I32(-13828256),
+                },
+                List {
+                    site: 45,
+                    container_idx: 89,
+                    key: 235,
+                    value: I32(2122219134),
+                },
+            ],
+        )
+    }
+
+    #[test]
     fn notify_causal_order_check() {
         test_multi_sites(
             5,

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -14,7 +14,7 @@ use crate::{
         idx::ContainerIdx, list::list_op::ListOp, map::MapSet, tree::tree_op::TreeOp,
         ContainerIdRaw,
     },
-    delta::{DeltaItem, MapValue},
+    delta::DeltaItem,
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalContainerDiff, InternalDiff},
     fx_map,


### PR DESCRIPTION
This PR involves a refactoring process where the `OpID` can be directly utilized as the `ID` portion of the `ContainerId` in child container creation operations. So we need not encode this kind of 'ContainerId', requiring only the 'ContainerType' to be encoded. The primary goal is to reduce document size.

The doc size of `draw` examples:

|    | main | | | | PR| | | |
|  ----  | ----  |---|---|---|----  |---|---|---|
| | snapshot| compressed snapshot|updates|compressed updates| snapshot| compressed snapshot|updates|compressed updates|
| async draw 100-1  | 3439 | 1664 | 2510 | 1281  | 3381 | 1499 | 2452 | 1115|
| async draw 10000-10  | 4289502 | 1537942 | 3149949 | 1168121 |3950650 | 1242185 | 2811097 | 889327 | 
| realtime draw 100-5  | 2242 | 1278 | 1690 | 1009 |2212 | 1189 | 1660 | 918| 
| realtime draw 10000-10  | 2851275 | 1059382 | 2083740 | 789115 |2622958 | 857457 | 1859828 | 603519| 