### PR TITLE
(wasm) Extract VersionVector class and fix inconsistent PeerID repr

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "arbtest",
+    "bolds",
     "cids",
     "clippy",
     "collab",
@@ -25,9 +26,11 @@
     "thiserror",
     "tinyvec",
     "txns",
+    "typeparam",
     "unbold",
     "unexist",
     "unmark",
+    "unmergeable",
     "yspan"
   ],
   "rust-analyzer.runnableEnv": {

--- a/crates/loro-common/src/id.rs
+++ b/crates/loro-common/src/id.rs
@@ -15,7 +15,7 @@ impl Debug for ID {
 
 impl Display for ID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(format!("{}@{:X}", self.counter, self.peer).as_str())
+        f.write_str(format!("{}@{}", self.counter, self.peer).as_str())
     }
 }
 
@@ -33,7 +33,10 @@ impl TryFrom<&str> for ID {
             .unwrap()
             .parse::<Counter>()
             .map_err(|_| LoroError::DecodeError("Invalid ID format".into()))?;
-        let client_id = u64::from_str_radix(iter.next().unwrap(), 16)
+        let client_id = iter
+            .next()
+            .unwrap()
+            .parse::<u64>()
             .map_err(|_| LoroError::DecodeError("Invalid ID format".into()))?;
         Ok(ID {
             peer: client_id,

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -376,7 +376,7 @@ mod test {
             container_type: crate::ContainerType::Map,
         };
         let id_str = id.to_string();
-        assert_eq!(id_str.as_str(), "cid:10@FF:Map");
+        assert_eq!(id_str.as_str(), "cid:10@255:Map");
         assert_eq!(ContainerID::try_from(id_str.as_str()).unwrap(), id);
 
         let id = ContainerID::try_from("cid:root-a:b:c:Tree").unwrap();

--- a/crates/loro-internal/src/container.rs
+++ b/crates/loro-internal/src/container.rs
@@ -187,7 +187,7 @@ mod test {
     fn container_id_convert() {
         let container_id = ContainerID::new_normal(ID::new(12, 12), ContainerType::List);
         let s = container_id.to_string();
-        assert_eq!(s, "cid:12@C:List");
+        assert_eq!(s, "cid:12@12:List");
         let actual = ContainerID::try_from(s.as_str()).unwrap();
         assert_eq!(actual, container_id);
 

--- a/examples/loro-quill/src/App.vue
+++ b/examples/loro-quill/src/App.vue
@@ -5,7 +5,7 @@
   import "quill/dist/quill.bubble.css";
   import "quill/dist/quill.snow.css";
   import { QuillBinding } from "./binding";
-  import { Loro, toReadableVersion } from "loro-crdt";
+  import { Loro } from "loro-crdt";
 
   const editor1 = ref<null | HTMLDivElement>(null);
   const editor2 = ref<null | HTMLDivElement>(null);
@@ -62,7 +62,7 @@
         }
         Promise.resolve().then(() => {
           const version = text.version();
-          const map = toReadableVersion(version);
+          const map = version.toJSON();
           const versionObj = {};
           for (const [key, value] of map) {
             versionObj[key.toString()] = value;

--- a/examples/loro-quill/src/binding.ts
+++ b/examples/loro-quill/src/binding.ts
@@ -101,7 +101,9 @@ export class QuillBinding {
         const a = this.richtext.toDelta();
         const b = this.quill.getContents().ops;
         console.log(this.doc.peerId, "COMPARE AFTER QUILL_EVENT");
-        assertEqual(a, b as any);
+        if (!assertEqual(a, b as any)) {
+          this.quill.setContents(new Delta(a), "this" as any);
+        }
         console.log("SIZE", this.doc.exportFrom().length);
         this.doc.debugHistory();
       }

--- a/examples/loro-quill/src/binding.ts
+++ b/examples/loro-quill/src/binding.ts
@@ -25,6 +25,13 @@ export class QuillBinding {
     public doc: Loro,
     public quill: Quill,
   ) {
+    doc.configTextStyle({
+      bold: { expand: "after" },
+      italic: { expand: "after" },
+      underline: { expand: "after" },
+      link: { expand: "none" },
+      header: { expand: "none" },
+    })
     this.quill = quill;
     this.richtext = doc.getText("text");
     this.richtext.subscribe(doc, (event) => {
@@ -113,9 +120,9 @@ export class QuillBinding {
           for (const key of Object.keys(op.attributes)) {
             let value = op.attributes[key];
             if (value == null) {
-              this.richtext.unmark({ start: index, end, expand: EXPAND_CONFIG[key] }, key)
+              this.richtext.unmark({ start: index, end, }, key)
             } else {
-              this.richtext.mark({ start: index, end, expand: EXPAND_CONFIG[key] }, key, value,)
+              this.richtext.mark({ start: index, end }, key, value,)
             }
           }
         }
@@ -128,9 +135,9 @@ export class QuillBinding {
             for (const key of Object.keys(op.attributes)) {
               let value = op.attributes[key];
               if (value == null) {
-                this.richtext.unmark({ start: index, end, expand: EXPAND_CONFIG[key] }, key)
+                this.richtext.unmark({ start: index, end, }, key)
               } else {
-                this.richtext.mark({ start: index, end, expand: EXPAND_CONFIG[key] }, key, value)
+                this.richtext.mark({ start: index, end }, key, value)
               }
             }
           }

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -4,10 +4,11 @@ import {
   LoroList,
   LoroMap,
   isContainer,
-  toEncodedVersion,
   getType,
+  VersionVector,
 } from "../src";
 import { Container } from "../dist/loro";
+
 
 it("basic example", () => {
   const doc = new Loro();
@@ -155,7 +156,7 @@ describe("import", () => {
     b.getText("text").insert(1, "b");
     b.getList("list").insert(0, [1, 2]);
     const updates = b.exportFrom(
-      toEncodedVersion(b.frontiersToVV(a.frontiers())),
+      b.frontiersToVV(a.frontiers()),
     );
     a.import(updates);
     expect(a.toJson()).toStrictEqual(b.toJson());

--- a/loro-js/tests/misc.test.ts
+++ b/loro-js/tests/misc.test.ts
@@ -3,6 +3,7 @@ import {
   Loro,
   LoroList,
   LoroMap,
+  VersionVector,
 } from "../src";
 import { expectTypeOf } from "vitest";
 
@@ -131,8 +132,8 @@ describe("sync", () => {
   it("two insert at beginning", async () => {
     const a = new Loro();
     const b = new Loro();
-    let a_version: undefined | Uint8Array = undefined;
-    let b_version: undefined | Uint8Array = undefined;
+    let a_version: undefined | VersionVector = undefined;
+    let b_version: undefined | VersionVector = undefined;
     a.subscribe((e: { local: boolean }) => {
       if (e.local) {
         const exported = a.exportFrom(a_version);

--- a/loro-js/tests/version.test.ts
+++ b/loro-js/tests/version.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Loro, toReadableVersion, setPanicHook, OpId } from "../src";
+import { Loro, OpId, VersionVector } from "../src";
 
 describe("Frontiers", () => {
   it("two clients", () => {
@@ -42,10 +42,12 @@ describe("Version", () => {
       const vv = new Map();
       vv.set("0", 3);
       vv.set("1", 2);
-      expect(toReadableVersion(a.version())).toStrictEqual(vv);
-      expect(toReadableVersion(a.version())).toStrictEqual(vv);
-      expect(a.vvToFrontiers(vv)).toStrictEqual(a.frontiers());
-      expect(a.vvToFrontiers(a.version())).toStrictEqual(a.frontiers());
+      expect((a.version().toJSON())).toStrictEqual(vv);
+      expect((a.version().toJSON())).toStrictEqual(vv);
+      expect(a.vvToFrontiers(new VersionVector(vv))).toStrictEqual(a.frontiers());
+      const v = a.version();
+      const temp = a.vvToFrontiers(v);
+      expect(temp).toStrictEqual(a.frontiers());
       expect(a.frontiers()).toStrictEqual([{ peer: "0", counter: 2 }] as OpId[]);
     }
   });

--- a/loro-js/tests/version.test.ts
+++ b/loro-js/tests/version.test.ts
@@ -26,6 +26,25 @@ describe("Frontiers", () => {
   });
 });
 
+it('peer id repr should be consistent', () => {
+  const doc = new Loro();
+  const id = doc.peerIdStr;
+  doc.getText("text").insert(0, "hello");
+  doc.commit();
+  const f = doc.frontiers();
+  expect(f[0].peer).toBe(id);
+  const map = doc.getList("list").insertContainer(0, "Map");
+  const mapId = map.id;
+  const peerIdInContainerId = mapId.split(":")[1].split("@")[1]
+  expect(peerIdInContainerId).toBe(id);
+  doc.commit();
+  expect(doc.version().get(id)).toBe(6);
+  expect(doc.version().toJSON().get(id)).toBe(6);
+  const m = doc.getMap(mapId);
+  m.set("0", 1);
+  expect(map.get("0")).toBe(1)
+})
+
 describe("Version", () => {
   const a = new Loro();
   a.setPeerId(0n);


### PR DESCRIPTION
Now, we use decimal as peer ID's string representation by default.

LORO-460