### PR TITLE
fix: how to find best insert pos for richtext & expand type reverse behavior

### DIFF
--- a/crates/loro-common/src/value.rs
+++ b/crates/loro-common/src/value.rs
@@ -63,6 +63,13 @@ impl LoroValue {
         }
     }
 
+    pub fn is_false(&self) -> bool {
+        match self {
+            LoroValue::Bool(b) => !*b,
+            _ => false,
+        }
+    }
+
     pub fn get_depth(&self) -> usize {
         let mut max_depth = 0;
         let mut value_depth_pairs = vec![(self, 0)];

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -1527,7 +1527,9 @@ impl RichtextState {
             };
 
             visited.push((style, anchor_type, iter, entity_index));
-            if anchor_type == AnchorType::Start && !style.value.is_null() {
+            if anchor_type == AnchorType::Start
+                && (!style.value.is_null() || !style.value.is_false())
+            {
                 // case 1. should be before this anchor
                 break;
             }

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -1527,7 +1527,7 @@ impl RichtextState {
             };
 
             visited.push((style, anchor_type, iter, entity_index));
-            if anchor_type == AnchorType::Start {
+            if anchor_type == AnchorType::Start && !style.value.is_null() {
                 // case 1. should be before this anchor
                 break;
             }

--- a/crates/loro-wasm/CHANGELOG.md
+++ b/crates/loro-wasm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.1
+
+### Patch Changes
+
+- Fix use consistnt peer id repr and expose VersionVector type
+
 ## 0.9.0
 
 ### Minor Changes

--- a/crates/loro-wasm/package.json
+++ b/crates/loro-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loro-wasm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Loro CRDTs is a high-performance CRDT framework that makes your app state synchronized, collaborative and maintainable effortlessly.",
   "keywords": [
     "crdt",

--- a/loro-js/CHANGELOG.md
+++ b/loro-js/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.1
+
+### Patch Changes
+
+- Fix use consistnt peer id repr and expose VersionVector type
+- Updated dependencies
+  - loro-wasm@0.9.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/loro-js/package.json
+++ b/loro-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loro-crdt",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Loro CRDTs is a high-performance CRDT framework that makes your app state synchronized, collaborative and maintainable effortlessly.",
   "keywords": [
     "crdt",


### PR DESCRIPTION
Though counter-intuitive, when we toggle the `ExpandType` between for creation and for deletion, the correct conversion should be:

```
- ExpandType::After -> ExpandType::After
- ExpandType::Before -> ExpandType::Before
- ExpandType::None -> ExpandType::Both
- ExpandType::Both -> ExpandType::None
```

So that when there are overlaps between the style creation and the style's deletion, each style can still have the same expand type. For example:

When we make "Hello" bold and then make "ll" unbold if the style with `unbold` also has ExpandType::After, it'll make it appear to have a bold span at "He", and a bold span at "o", both have `ExpandType::After`, which is the desired behavior.

![image](https://github.com/loro-dev/loro/assets/18425020/6917c9c4-616f-4e4d-a948-77b1857355f3)
