### PR TITLE
Fix rich text time travel event issue

### DIFF
--- a/crates/loro-internal/src/container/richtext.rs
+++ b/crates/loro-internal/src/container/richtext.rs
@@ -60,12 +60,6 @@ pub(crate) enum StyleKey {
 }
 
 impl StyleKey {
-    pub fn to_attr_key(&self) -> String {
-        match self {
-            Self::Key(key) => key.to_string(),
-        }
-    }
-
     pub fn key(&self) -> &InternalString {
         match self {
             Self::Key(key) => key,

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -6,7 +6,10 @@ use generic_btree::{
 };
 use loro_common::{IdSpan, LoroValue, ID};
 use serde::{ser::SerializeStruct, Serialize};
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    ops::RangeBounds,
+};
 use std::{
     ops::{Add, AddAssign, Range, Sub},
     str::Utf8Error,
@@ -32,7 +35,7 @@ use self::{
 
 use super::{
     query_by_len::{IndexQuery, QueryByLen},
-    style_range_map::{IterAnchorItem, StyleRangeMap, Styles},
+    style_range_map::{self, IterAnchorItem, StyleRangeMap, Styles},
     AnchorType, RichtextSpan, StyleOp,
 };
 
@@ -276,11 +279,13 @@ mod text_chunk {
             let mut start = 0;
             let mut end = 0;
             let mut started = false;
+            let mut last_unicode_index = 0;
             for (unicode_index, (i, c)) in self.as_str().char_indices().enumerate() {
                 if unicode_index == range.start {
                     start = i;
                     started = true;
                 }
+
                 if unicode_index == range.end {
                     end = i;
                     break;
@@ -288,6 +293,14 @@ mod text_chunk {
                 if started {
                     utf16_len += c.len_utf16();
                 }
+
+                last_unicode_index = unicode_index;
+            }
+
+            assert!(started);
+            if end == 0 {
+                assert_eq!(last_unicode_index + 1, range.end);
+                end = self.bytes.len();
             }
 
             let ans = Self {
@@ -1660,7 +1673,7 @@ impl RichtextState {
         &mut self,
         pos: usize,
         len: usize,
-        mut f: impl FnMut(RichtextStateChunk),
+        mut f: Option<&mut dyn FnMut(RichtextStateChunk)>,
     ) -> (usize, usize) {
         assert!(
             pos + len <= self.len_entity(),
@@ -1719,13 +1732,25 @@ impl RichtextState {
                 updater.update(&*elem);
                 match elem {
                     RichtextStateChunk::Text(text) => {
+                        if let Some(f) = f {
+                            let span = text.slice(start_cursor.offset..start_cursor.offset + len);
+                            f(RichtextStateChunk::Text(span));
+                        }
                         let (next, event_len_) =
                             text.delete_by_entity_index(start_cursor.offset, len);
                         event_len = event_len_;
                         (true, next.map(RichtextStateChunk::Text), None)
                     }
                     RichtextStateChunk::Style { .. } => {
-                        *elem = RichtextStateChunk::Text(TextChunk::new_empty());
+                        if let Some(f) = f {
+                            let v = std::mem::replace(
+                                elem,
+                                RichtextStateChunk::Text(TextChunk::new_empty()),
+                            );
+                            f(v);
+                        } else {
+                            *elem = RichtextStateChunk::Text(TextChunk::new_empty());
+                        }
                         (true, None, None)
                     }
                 }
@@ -1742,7 +1767,9 @@ impl RichtextState {
             let mut updater = StyleRangeUpdater::new(self.style_ranges.as_mut(), pos);
             for iter in generic_btree::iter::Drain::new(&mut self.tree, start, end) {
                 updater.update(&iter);
-                f(iter)
+                if let Some(f) = f.as_mut() {
+                    f(iter)
+                }
             }
 
             if let Some(s) = self.style_ranges.as_mut() {
@@ -1826,7 +1853,6 @@ impl RichtextState {
     }
 
     pub fn get_richtext_value(&self) -> LoroValue {
-        self.check_consistency_between_content_and_style_ranges();
         let mut ans: Vec<LoroValue> = Vec::new();
         let mut last_attributes: Option<LoroValue> = None;
         for span in self.iter() {
@@ -2001,6 +2027,14 @@ impl RichtextState {
                 .map(|x| x.estimate_size())
                 .unwrap_or(0)
     }
+
+    /// Iter style ranges in the given range in entity index
+    pub(crate) fn iter_style_range(
+        &self,
+        range: impl RangeBounds<usize>,
+    ) -> Option<impl Iterator<Item = &style_range_map::Elem>> {
+        self.style_ranges.as_ref().map(|x| x.iter_range(range))
+    }
 }
 
 use converter::ContinuousIndexConverter;
@@ -2101,7 +2135,7 @@ mod test {
                 self.state.drain_by_entity_index(
                     range.entity_start,
                     range.entity_end - range.entity_start,
-                    |_| {},
+                    None,
                 );
             }
         }
@@ -2485,11 +2519,15 @@ mod test {
         wrapper.insert(0, "Hello World!");
         wrapper.mark(0..5, bold(0));
         let mut count = 0;
-        wrapper.state.drain_by_entity_index(0, 7, |span| {
-            if matches!(span, RichtextStateChunk::Style { .. }) {
-                count += 1;
-            }
-        });
+        wrapper.state.drain_by_entity_index(
+            0,
+            7,
+            Some(&mut |span| {
+                if matches!(span, RichtextStateChunk::Style { .. }) {
+                    count += 1;
+                }
+            }),
+        );
 
         assert_eq!(count, 2);
         assert_eq!(
@@ -2505,8 +2543,8 @@ mod test {
         let mut wrapper = SimpleWrapper::default();
         wrapper.insert(0, "Hello World!");
         wrapper.mark(0..5, bold(0));
-        wrapper.state.drain_by_entity_index(6, 1, |_| {});
-        wrapper.state.drain_by_entity_index(0, 1, |_| {});
+        wrapper.state.drain_by_entity_index(6, 1, None);
+        wrapper.state.drain_by_entity_index(0, 1, None);
         assert_eq!(
             wrapper.state.get_richtext_value().to_json_value(),
             json!([{
@@ -2520,8 +2558,8 @@ mod test {
         let mut wrapper = SimpleWrapper::default();
         wrapper.insert(0, "Hello World!");
         wrapper.mark(2..5, bold(0));
-        wrapper.state.drain_by_entity_index(6, 1, |_| {});
-        wrapper.state.drain_by_entity_index(1, 2, |_| {});
+        wrapper.state.drain_by_entity_index(6, 1, None);
+        wrapper.state.drain_by_entity_index(1, 2, None);
         assert_eq!(
             wrapper.state.get_richtext_value().to_json_value(),
             json!([{

--- a/crates/loro-internal/src/event.rs
+++ b/crates/loro-internal/src/event.rs
@@ -161,6 +161,8 @@ impl From<InternalDiff> for DiffVariant {
 #[derive(Clone, Debug, EnumAsInner)]
 pub enum Diff {
     List(Delta<Vec<ValueOrContainer>>),
+    // TODO: refactor, doesn't make much sense to use `StyleMeta` here, because sometime style
+    // don't have peer and lamport info
     /// - When feature `wasm` is enabled, it should use utf16 indexes.
     /// - When feature `wasm` is disabled, it should use unicode indexes.
     Text(Delta<StringSlice, StyleMeta>),

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -12,8 +12,7 @@ use crate::{
     array_mut_ref, container::ContainerID, delta::DeltaItem, id::PeerID, ContainerType, LoroValue,
 };
 use crate::{
-    container::richtext::StyleKey, event::Diff, handler::TextDelta, loro::LoroDoc, value::ToJson,
-    version::Frontiers, TextHandler,
+    event::Diff, handler::TextDelta, loro::LoroDoc, value::ToJson, version::Frontiers, TextHandler,
 };
 
 const STYLES_NAME: [&str; 4] = ["bold", "comment", "link", "highlight"];
@@ -96,9 +95,7 @@ impl Actor {
                                 let attributes: FxHashMap<_, _> = attributes
                                     .iter()
                                     .filter(|(_, v)| !v.data.is_null())
-                                    .map(|(k, v)| match k {
-                                        StyleKey::Key(k) => (k.to_string(), v.data),
-                                    })
+                                    .map(|(k, v)| (k.to_string(), v.data))
                                     .collect();
                                 let attributes = if attributes.is_empty() {
                                     None
@@ -118,9 +115,7 @@ impl Actor {
                                 let attributes: FxHashMap<_, _> = attributes
                                     .iter()
                                     .filter(|(_, v)| !v.data.is_null())
-                                    .map(|(k, v)| match k {
-                                        StyleKey::Key(k) => (k.to_string(), v.data),
-                                    })
+                                    .map(|(k, v)| (k.to_string(), v.data))
                                     .collect();
                                 let attributes = if attributes.is_empty() {
                                     None

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -16,7 +16,7 @@ use crate::{
     container::{
         idx::ContainerIdx,
         list::list_op::{DeleteSpan, InnerListOp},
-        richtext::{Style, StyleKey},
+        richtext::Style,
         IntoContainerId,
     },
     delta::{
@@ -503,7 +503,7 @@ fn change_to_diff(
                 EventHint::Mark { start, end, style } => {
                     let mut meta = StyleMeta::default();
                     meta.insert(
-                        StyleKey::Key(style.key.clone()),
+                        style.key.clone(),
                         StyleMetaItem {
                             lamport,
                             peer: change.id.peer,

--- a/crates/loro-internal/src/value.rs
+++ b/crates/loro-internal/src/value.rs
@@ -457,7 +457,7 @@ pub mod wasm {
             let obj = Object::new();
             for (key, style) in value.iter() {
                 let value = JsValue::from(style.data);
-                js_sys::Reflect::set(&obj, &JsValue::from_str(&key.to_attr_key()), &value).unwrap();
+                js_sys::Reflect::set(&obj, &JsValue::from_str(&key), &value).unwrap();
             }
 
             obj.into_js_result().unwrap()


### PR DESCRIPTION
When traveling back, it should be able to nullify the newly created styles through the text event.