### PR TITLE
feat(wasm): get change at lamport

### DIFF
--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -7,6 +7,7 @@ use loro_internal::handler::ValueOrContainer;
 use loro_internal::id::PeerID;
 use loro_internal::id::TreeID;
 use loro_internal::LoroDoc as InnerLoroDoc;
+use loro_internal::OpLog;
 use loro_internal::{
     handler::Handler as InnerHandler, ListHandler as InnerListHandler,
     MapHandler as InnerMapHandler, TextHandler as InnerTextHandler,
@@ -174,6 +175,11 @@ impl LoroDoc {
     /// Convert `VersionVector` into `Frontiers`
     pub fn vv_to_frontiers(&self, vv: &VersionVector) -> Frontiers {
         self.doc.vv_to_frontiers(vv)
+    }
+
+    pub fn with_oplog<R>(&self, f: impl FnOnce(&OpLog) -> R) -> R {
+        let oplog = self.doc.oplog().lock().unwrap();
+        f(&oplog)
     }
 
     /// Get the `VersionVector` version of `OpLog`

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -239,6 +239,53 @@ it("handlers should still be usable after doc is dropped", () => {
   expect(map.toJson()).toStrictEqual({ k: 8 });
 });
 
+it("get change with given lamport", () => {
+  const doc1 = new Loro();
+  doc1.setPeerId(1);
+  const doc2 = new Loro();
+  doc2.setPeerId(2);
+  doc1.getText("text").insert(0, "01234");
+  doc2.import(doc1.exportFrom());
+  doc2.getText("text").insert(0, "56789");
+  doc1.import(doc2.exportFrom());
+  doc1.getText("text").insert(0, "01234");
+  doc1.commit();
+  {
+    const change = doc1.getChangeAtLamport("1", 1);
+    expect(change.lamport).toBe(0);
+    expect(change.peer).toBe("1");
+    expect(change.length).toBe(5);
+  }
+  {
+    const change = doc1.getChangeAtLamport("1", 7);
+    expect(change.lamport).toBe(0);
+    expect(change.peer).toBe("1");
+    expect(change.length).toBe(5);
+  }
+  {
+    const change = doc1.getChangeAtLamport("1", 10);
+    expect(change.lamport).toBe(10);
+    expect(change.peer).toBe("1");
+    expect(change.length).toBe(5);
+  }
+  {
+    const change = doc1.getChangeAtLamport("1", 13);
+    expect(change.lamport).toBe(10);
+    expect(change.peer).toBe("1");
+    expect(change.length).toBe(5);
+  }
+  {
+    const change = doc1.getChangeAtLamport("1", 20);
+    expect(change.lamport).toBe(10);
+    expect(change.peer).toBe("1");
+    expect(change.length).toBe(5);
+  }
+  {
+    const change = doc1.getChangeAtLamport("111", 13);
+    expect(change).toBeUndefined();
+  }
+});
+
 
 it("isContainer", () => {
   expect(isContainer("123")).toBeFalsy();


### PR DESCRIPTION
This pull request adds a new method `get_change_at_lamport` to the `Loro` class in the `loro-wasm` crate. This method allows retrieving the change with a specific peer ID and a lamport value less than or equal to the given lamport value. The implementation uses the `OpLog` struct to find the appropriate change.