### PR TITLE
chore: add a warning for string_cache usage

### DIFF
--- a/crates/loro-common/src/internal_string.rs
+++ b/crates/loro-common/src/internal_string.rs
@@ -1,14 +1,27 @@
 use std::{fmt::Display, ops::Deref};
 
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::AtomicU32;
 
 #[repr(transparent)]
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InternalString(string_cache::DefaultAtom);
+
+#[cfg(debug_assertions)]
+static mut INTERNAL_STRING_COUNT: AtomicU32 = AtomicU32::new(0);
+
+#[cfg(debug_assertions)]
+fn fetch_add() {
+    unsafe {
+        INTERNAL_STRING_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
 
 impl<T: Into<string_cache::DefaultAtom>> From<T> for InternalString {
     #[inline(always)]
     fn from(value: T) -> Self {
+        #[cfg(debug_assertions)]
+        fetch_add();
         Self(value.into())
     }
 }
@@ -23,7 +36,25 @@ impl From<&InternalString> for String {
 impl From<&InternalString> for InternalString {
     #[inline(always)]
     fn from(value: &InternalString) -> Self {
+        #[cfg(debug_assertions)]
+        fetch_add();
         value.clone()
+    }
+}
+
+impl Clone for InternalString {
+    fn clone(&self) -> Self {
+        #[cfg(debug_assertions)]
+        fetch_add();
+        Self(self.0.clone())
+    }
+}
+
+impl Default for InternalString {
+    fn default() -> Self {
+        #[cfg(debug_assertions)]
+        fetch_add();
+        Self(Default::default())
     }
 }
 
@@ -39,4 +70,22 @@ impl Deref for InternalString {
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
     }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for InternalString {
+    fn drop(&mut self) {
+        unsafe {
+            INTERNAL_STRING_COUNT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+}
+
+/// Returns the total number of internal strings created.
+///
+/// It should not exceed 100K for the optimal performance.
+/// See https://github.com/zxch3n/test-string-cache
+#[cfg(debug_assertions)]
+pub fn get_total_internal_string_size() -> usize {
+    unsafe { INTERNAL_STRING_COUNT.load(std::sync::atomic::Ordering::Relaxed) as usize }
 }

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -14,7 +14,7 @@ mod value;
 pub use error::{LoroError, LoroResult, LoroTreeError};
 #[doc(hidden)]
 pub use fxhash::FxHashMap;
-pub use internal_string::InternalString;
+pub use internal_string::{get_total_internal_string_size, InternalString};
 pub use span::*;
 pub use value::{to_value, LoroValue};
 


### PR DESCRIPTION
Maybe it's better to use Arc<str> on server side