### PR TITLE
add PeerID Getter to public API of loro crate

### DIFF
--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -239,6 +239,11 @@ impl LoroDoc {
         self.doc.state_frontiers()
     }
 
+    /// Get the PeerID
+    pub fn peer_id(&self) -> PeerID {
+        self.doc.peer_id()
+    }
+
     /// Change the PeerID
     ///
     /// NOTE: You need ot make sure there is no chance two peer have the same PeerID.


### PR DESCRIPTION
I think this was just forgotten since the getter is exported in loro-wasm