### PR TITLE
refactor: replace LoroValue::i32 with i64

### DIFF
--- a/crates/examples/src/draw.rs
+++ b/crates/examples/src/draw.rs
@@ -127,13 +127,13 @@ impl ActorTrait for DrawActor {
 
                 let map = self.doc.get_map(id);
                 let pos_map = map.get("pos").unwrap().unwrap_right().into_map().unwrap();
-                let x = pos_map.get("x").unwrap().unwrap_left().into_i32().unwrap();
-                let y = pos_map.get("y").unwrap().unwrap_left().into_i32().unwrap();
+                let x = pos_map.get("x").unwrap().unwrap_left().into_i64().unwrap();
+                let y = pos_map.get("y").unwrap().unwrap_left().into_i64().unwrap();
                 pos_map
-                    .insert("x", x.overflowing_add(relative_to.x).0)
+                    .insert("x", x.overflowing_add(relative_to.x as i64).0)
                     .unwrap();
                 pos_map
-                    .insert("y", y.overflowing_add(relative_to.y).0)
+                    .insert("y", y.overflowing_add(relative_to.y as i64).0)
                     .unwrap();
             }
         }

--- a/crates/loro-common/src/macros.rs
+++ b/crates/loro-common/src/macros.rs
@@ -293,7 +293,7 @@ mod test {
         assert!(!(*map.get("false").unwrap().as_bool().unwrap()));
         assert!(map.get("null").unwrap().is_null());
         assert_eq!(map.get("list").unwrap().as_list().unwrap().len(), 0);
-        assert_eq!(*map.get("integer").unwrap().as_i32().unwrap(), 123);
+        assert_eq!(*map.get("integer").unwrap().as_i64().unwrap(), 123);
         assert_eq!(*map.get("float").unwrap().as_double().unwrap(), 123.123);
         assert_eq!(map.get("map").unwrap().as_map().unwrap().len(), 1);
         assert_eq!(

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -419,7 +419,7 @@ where
     #[allow(clippy::redundant_clone)]
     let mut actions_clone = actions.clone();
     let action_ref: usize = (&mut actions_clone) as *mut _ as usize;
-    #[allow(clippy::blocks_in_if_conditions)]
+    #[allow(clippy::blocks_in_conditions)]
     if std::panic::catch_unwind(|| {
         // SAFETY: test
         let f = unsafe { &*(f_ref as *const F) };
@@ -448,7 +448,7 @@ where
         let f_ref: usize = f_ref as usize;
         let mut actions_clone = candidate.clone();
         let action_ref: usize = (&mut actions_clone) as *mut _ as usize;
-        #[allow(clippy::blocks_in_if_conditions)]
+        #[allow(clippy::blocks_in_conditions)]
         if std::panic::catch_unwind(|| {
             // SAFETY: test
             let f = unsafe { &*(f_ref as *const F) };

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -270,7 +270,7 @@ impl From<FuzzValue> for LoroValue {
     fn from(v: FuzzValue) -> Self {
         match v {
             FuzzValue::Null => LoroValue::Null,
-            FuzzValue::I32(i) => LoroValue::I32(i),
+            FuzzValue::I32(i) => LoroValue::I64(i as i64),
             FuzzValue::Container(_) => unreachable!(),
         }
     }
@@ -815,7 +815,7 @@ pub fn normalize(site_num: u8, actions: &mut [Action]) -> Vec<Action> {
         sites.preprocess(action);
         applied.push(action.clone());
         let sites_ptr: usize = &mut sites as *mut _ as usize;
-        #[allow(clippy::blocks_in_if_conditions)]
+        #[allow(clippy::blocks_in_conditions)]
         if std::panic::catch_unwind(|| {
             // SAFETY: Test
             let sites = unsafe { &mut *(sites_ptr as *mut Vec<_>) };

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -171,7 +171,7 @@ impl From<FuzzValue> for LoroValue {
     fn from(v: FuzzValue) -> Self {
         match v {
             FuzzValue::Null => LoroValue::Null,
-            FuzzValue::I32(i) => LoroValue::I32(i),
+            FuzzValue::I32(i) => LoroValue::I64(i as i64),
             FuzzValue::Container(_) => unreachable!(),
         }
     }
@@ -477,7 +477,7 @@ pub fn normalize(site_num: u8, actions: &mut [Action]) -> Vec<Action> {
         sites.preprocess(action);
         applied.push(action.clone());
         let sites_ptr: usize = &mut sites as *mut _ as usize;
-        #[allow(clippy::blocks_in_if_conditions)]
+        #[allow(clippy::blocks_in_conditions)]
         if std::panic::catch_unwind(|| {
             // SAFETY: Test
             let sites = unsafe { &mut *(sites_ptr as *mut Vec<_>) };

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -207,7 +207,7 @@ impl From<FuzzValue> for LoroValue {
     fn from(v: FuzzValue) -> Self {
         match v {
             FuzzValue::Null => LoroValue::Null,
-            FuzzValue::I32(i) => LoroValue::I32(i),
+            FuzzValue::I32(i) => LoroValue::I64(i as i64),
             FuzzValue::Container(_) => unreachable!(),
         }
     }
@@ -734,7 +734,7 @@ pub fn normalize(site_num: u8, actions: &mut [Action]) -> Vec<Action> {
         sites.preprocess(action);
         applied.push(action.clone());
         let sites_ptr: usize = &mut sites as *mut _ as usize;
-        #[allow(clippy::blocks_in_if_conditions)]
+        #[allow(clippy::blocks_in_conditions)]
         if std::panic::catch_unwind(|| {
             // SAFETY: Test
             let sites = unsafe { &mut *(sites_ptr as *mut Vec<_>) };

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -169,7 +169,7 @@ pub fn convert(value: LoroValue) -> JsValue {
         LoroValue::Null => JsValue::NULL,
         LoroValue::Bool(b) => JsValue::from_bool(b),
         LoroValue::Double(f) => JsValue::from_f64(f),
-        LoroValue::I32(i) => JsValue::from_f64(i as f64),
+        LoroValue::I64(i) => JsValue::from_f64(i as f64),
         LoroValue::String(s) => JsValue::from_str(&s),
         LoroValue::List(list) => {
             let list = Arc::try_unwrap(list).unwrap_or_else(|m| (*m).clone());

--- a/crates/rle/src/rle_vec.rs
+++ b/crates/rle/src/rle_vec.rs
@@ -622,7 +622,7 @@ impl<A: Array> Deref for RleVecWithLen<A> {
     }
 }
 
-pub fn slice_vec_by<T, F>(vec: &Vec<T>, index: F, start: usize, end: usize) -> Vec<T>
+pub fn slice_vec_by<T, F>(vec: &[T], index: F, start: usize, end: usize) -> Vec<T>
 where
     F: Fn(&T) -> usize,
     T: Sliceable + HasLength,


### PR DESCRIPTION
They have the same cost in terms of mem and storage and i64 will be more useful. For compatibility, JS number also supports up to 53-bit integer. So there is no reason for us to stick with i32.