### PR TITLE
feat: expose timestamp related configures

### DIFF
--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -44,6 +44,8 @@ pub enum LoroError {
     Unknown(Box<str>),
     #[error("The given ID ({0}) is not contained by the doc")]
     InvalidFrontierIdNotFound(ID),
+    #[error("Cannot import when the doc is in a transaction")]
+    ImportWhenInTxn,
 }
 
 #[derive(Error, Debug)]

--- a/crates/loro-internal/src/change.rs
+++ b/crates/loro-internal/src/change.rs
@@ -216,7 +216,7 @@ pub(crate) fn get_sys_timestamp() -> Timestamp {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_secs()
+        .as_millis()
         .as_()
 }
 
@@ -231,7 +231,7 @@ pub fn get_sys_timestamp() -> Timestamp {
         pub fn now() -> f64;
     }
 
-    (now() / 1000.0) as Timestamp
+    now() as Timestamp
 }
 
 #[cfg(test)]

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -487,6 +487,7 @@ fn import() {
 #[test]
 fn test_timestamp() {
     let doc = LoroDoc::new();
+    doc.set_record_timestamp(true);
     let text = doc.get_text("text");
     let mut txn = doc.txn().unwrap();
     text.insert_with_txn(&mut txn, 0, "123").unwrap();

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -224,6 +224,28 @@ impl Loro {
         Self(Arc::new(doc))
     }
 
+    /// Set whether to record the timestamp of each change. Default is `false`.
+    ///
+    /// If enabled, the Unix timestamp will be recorded for each change automatically.
+    ///
+    /// You can also set each timestamp manually when you commit a change.
+    /// The timstamp manually set will override the automatic one.
+    ///
+    /// NOTE: Timestamps are forced to be in ascending order.
+    /// If you commit a new change with a timestamp that is less than the existing one,
+    /// the largest existing timestamp will be used instead.
+    #[wasm_bindgen(js_name = "setRecordTimestamp")]
+    pub fn set_record_timestamp(&self, auto_record: bool) {
+        self.0.set_record_timestamp(auto_record);
+    }
+
+    /// If two continuous local changes are within the interval, they will be merged into one change.
+    /// The defualt value is 1000 seconds
+    #[wasm_bindgen(js_name = "setChangeMergeInterval")]
+    pub fn set_change_merge_interval(&self, interval: i64) {
+        self.0.set_change_merge_interval(interval);
+    }
+
     /// Set the rich text format configuration of the document.
     ///
     /// You need to config it if you use rich text `mark` method.
@@ -442,8 +464,15 @@ impl Loro {
     }
 
     /// Commit the cumulative auto committed transaction.
-    pub fn commit(&self, origin: Option<String>) {
-        self.0.commit_with(origin.map(|x| x.into()), None, true);
+    ///
+    /// You can specify the `origin` and `timestamp` of the commit.
+    ///
+    /// NOTE: Timestamps are forced to be in ascending order.
+    /// If you commit a new change with a timestamp that is less than the existing one,
+    /// the largest existing timestamp will be used instead.
+    pub fn commit(&self, origin: Option<String>, timestamp: Option<f64>) {
+        self.0
+            .commit_with(origin.map(|x| x.into()), timestamp.map(|x| x as i64), true);
     }
 
     /// Get a LoroText by container id
@@ -2403,6 +2432,7 @@ export interface Change {
     counter: number,
     lamport: number,
     length: number,
+    timestamp: number,
     deps: OpId[],
 }
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -242,8 +242,8 @@ impl Loro {
     /// If two continuous local changes are within the interval, they will be merged into one change.
     /// The defualt value is 1000 seconds
     #[wasm_bindgen(js_name = "setChangeMergeInterval")]
-    pub fn set_change_merge_interval(&self, interval: i64) {
-        self.0.set_change_merge_interval(interval);
+    pub fn set_change_merge_interval(&self, interval: f64) {
+        self.0.set_change_merge_interval(interval as i64);
     }
 
     /// Set the rich text format configuration of the document.

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -17,6 +17,7 @@ use loro_internal::{
 use std::cmp::Ordering;
 use std::ops::Range;
 
+pub use loro_internal::configure::Configure;
 pub use loro_internal::container::richtext::ExpandType;
 pub use loro_internal::container::{ContainerID, ContainerType};
 pub use loro_internal::obs::SubID;
@@ -44,6 +45,34 @@ impl LoroDoc {
         let mut doc = InnerLoroDoc::default();
         doc.start_auto_commit();
         LoroDoc { doc }
+    }
+
+    /// Get the configureations of the document.
+    pub fn config(&self) -> &Configure {
+        self.doc.config()
+    }
+
+    /// Set whether to record the timestamp of each change. Default is `false`.
+    ///
+    /// If enabled, the Unix timestamp will be recorded for each change automatically.
+    ///
+    /// You can set each timestamp manually when commiting a change.
+    ///
+    /// NOTE: Timestamps are forced to be in ascending order.
+    /// If you commit a new change with a timestamp that is less than the existing one,
+    /// the largest existing timestamp will be used instead.
+    #[inline]
+    pub fn set_record_timestamp(&self, record: bool) {
+        self.doc.set_record_timestamp(record);
+    }
+
+    /// Set the interval of mergeable changes.
+    ///
+    /// If two continuous local changes are within the interval, they will be merged into one change.
+    /// The defualt value is 1000 seconds.
+    #[inline]
+    pub fn set_change_merge_interval(&self, interval: i64) {
+        self.doc.set_change_merge_interval(interval);
     }
 
     /// Set the rich text format configuration of the document.
@@ -83,6 +112,9 @@ impl LoroDoc {
         self.doc.cmp_with_frontiers(other)
     }
 
+    /// Compare two frontiers.
+    ///
+    /// If the frontiers are not included in the document, return `FrontiersNotIncluded`.
     pub fn cmp_frontiers(
         &self,
         a: &Frontiers,

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -325,7 +325,7 @@ it("getValueType", () => {
   expect(getType(tree)).toBe("Tree");
 });
 
-it("timestamp", () => {
+it("enable timestamp", () => {
   const doc = new Loro();
   doc.setPeerId(1);
   doc.getText("123").insert(0, "123");
@@ -341,5 +341,37 @@ it("timestamp", () => {
   {
     const c = doc.getChangeAt({ peer: "1", counter: 4 });
     expect(c.timestamp).toBeCloseTo(Date.now(), 0);
+  }
+});
+
+it("commit with specified timestamp", () => {
+  const doc = new Loro();
+  doc.setPeerId(1);
+  doc.getText("123").insert(0, "123");
+  doc.commit(undefined, 111);
+  const c = doc.getChangeAt({ peer: "1", counter: 0 });
+  expect(c.timestamp).toBe(111);
+});
+
+it("can control the mergeable interval", () => {
+  {
+    const doc = new Loro();
+    doc.setPeerId(1);
+    doc.getText("123").insert(0, "1");
+    doc.commit(undefined, 110);
+    doc.getText("123").insert(0, "1");
+    doc.commit(undefined, 120);
+    expect(doc.getAllChanges().get("1")?.length).toBe(1);
+  }
+
+  {
+    const doc = new Loro();
+    doc.setPeerId(1);
+    doc.setChangeMergeInterval(10);
+    doc.getText("123").insert(0, "1");
+    doc.commit(undefined, 110);
+    doc.getText("123").insert(0, "1");
+    doc.commit(undefined, 120);
+    expect(doc.getAllChanges().get("1")?.length).toBe(2);
   }
 });

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../src";
 import { Container } from "../dist/loro";
 
-
 it("basic example", () => {
   const doc = new Loro();
   const list: LoroList = doc.getList("list");
@@ -79,7 +78,7 @@ it("basic sync example", () => {
 
 it("basic events", () => {
   const doc = new Loro();
-  doc.subscribe((event) => { });
+  doc.subscribe((event) => {});
   const list = doc.getList("list");
 });
 
@@ -155,9 +154,7 @@ describe("import", () => {
     b.import(a.exportFrom());
     b.getText("text").insert(1, "b");
     b.getList("list").insert(0, [1, 2]);
-    const updates = b.exportFrom(
-      b.frontiersToVV(a.frontiers()),
-    );
+    const updates = b.exportFrom(b.frontiersToVV(a.frontiers()));
     a.import(updates);
     expect(a.toJson()).toStrictEqual(b.toJson());
   });
@@ -222,7 +219,7 @@ describe("map", () => {
     map.set("foo", "bar");
     const entries = map.entries();
     expect((entries[0][1]! as Container).kind() === "Text").toBeTruthy();
-  })
+  });
 });
 
 it("handlers should still be usable after doc is dropped", () => {
@@ -286,7 +283,6 @@ it("get change with given lamport", () => {
   }
 });
 
-
 it("isContainer", () => {
   expect(isContainer("123")).toBeFalsy();
   expect(isContainer(123)).toBeFalsy();
@@ -301,7 +297,7 @@ it("isContainer", () => {
   expect(isContainer(t)).toBeTruthy();
   expect(getType(t)).toBe("Text");
   expect(getType(123)).toBe("Json");
-})
+});
 
 it("getValueType", () => {
   // Type tests
@@ -327,4 +323,23 @@ it("getValueType", () => {
   expect(getType(list)).toBe("List");
   expectTypeOf(getType(tree)).toEqualTypeOf<"Tree">();
   expect(getType(tree)).toBe("Tree");
-})
+});
+
+it("timestamp", () => {
+  const doc = new Loro();
+  doc.setPeerId(1);
+  doc.getText("123").insert(0, "123");
+  doc.commit();
+  {
+    const c = doc.getChangeAt({ peer: "1", counter: 0 });
+    expect(c.timestamp).toBe(0);
+  }
+
+  doc.setRecordTimestamp(true);
+  doc.getText("123").insert(0, "123");
+  doc.commit();
+  {
+    const c = doc.getChangeAt({ peer: "1", counter: 4 });
+    expect(c.timestamp).toBeCloseTo(Date.now(), 0);
+  }
+});


### PR DESCRIPTION
- Timestamp will not be recorded by default. It will use 0 as the default value instead
- Users can now control the mergeable interval
- Use standard Unix Timestamp as the timestamp

# Example

Enable Timestamp.

```ts
  const doc = new Loro();
  doc.setPeerId(1);
  doc.getText("123").insert(0, "123");
  doc.commit();
  {
    const c = doc.getChangeAt({ peer: "1", counter: 0 });
    expect(c.timestamp).toBe(0);
  }

  doc.setRecordTimestamp(true);
  doc.getText("123").insert(0, "123");
  doc.commit();
  {
    const c = doc.getChangeAt({ peer: "1", counter: 4 });
    expect(c.timestamp).toBeCloseTo(Date.now(), 0);
  }
```

Commit with a specific timestamp:

```ts
  const doc = new Loro();
  doc.setPeerId(1);
  doc.getText("123").insert(0, "123");
  doc.commit(undefined, 111);
  const c = doc.getChangeAt({ peer: "1", counter: 0 });
  expect(c.timestamp).toBe(111);
```

Config the mergeable interval. If two continuous local changes are within the interval, they will be merged into one change.
The defualt value is 1000 seconds.

```ts
  {
    const doc = new Loro();
    doc.setPeerId(1);
    doc.getText("123").insert(0, "1");
    doc.commit(undefined, 110);
    doc.getText("123").insert(0, "1");
    doc.commit(undefined, 120);
    expect(doc.getAllChanges().get("1")?.length).toBe(1);
  }

  {
    const doc = new Loro();
    doc.setPeerId(1);
    doc.setChangeMergeInterval(10);
    doc.getText("123").insert(0, "1");
    doc.commit(undefined, 110);
    doc.getText("123").insert(0, "1");
    doc.commit(undefined, 120);
    expect(doc.getAllChanges().get("1")?.length).toBe(2);
  }
}
```