### PR TITLE
fix missing event when checkout

### DIFF
--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZeroU16, sync::Arc};
 
 pub(super) mod tree;
 use itertools::Itertools;
@@ -36,8 +36,8 @@ use super::{event::InternalContainerDiff, oplog::OpLog};
 pub struct DiffCalculator {
     /// ContainerIdx -> (depth, calculator)
     ///
-    /// if depth == u16::MAX, we need to calculate it again
-    calculators: FxHashMap<ContainerIdx, (u16, ContainerDiffCalculator)>,
+    /// if depth is None, we need to calculate it again
+    calculators: FxHashMap<ContainerIdx, (Option<NonZeroU16>, ContainerDiffCalculator)>,
     last_vv: VersionVector,
     has_all: bool,
 }
@@ -141,7 +141,7 @@ impl DiffCalculator {
                     }
                     let vv = &mut vv.borrow_mut();
                     vv.extend_to_include_end_id(ID::new(change.peer(), op.counter));
-                    let depth = oplog.arena.get_depth(op.container).unwrap_or(u16::MAX);
+                    let depth = oplog.arena.get_depth(op.container);
                     let (old_depth, calculator) =
                         self.calculators.entry(op.container).or_insert_with(|| {
                             match op.container.get_type() {
@@ -215,7 +215,7 @@ impl DiffCalculator {
         // we need to iterate from parents to children. i.e. from smaller depth to larger depth.
         let mut new_containers = FxHashSet::default();
         let mut container_id_to_depth = FxHashMap::default();
-        let mut all: Vec<(u16, ContainerIdx)> = if let Some(set) = affected_set {
+        let mut all: Vec<(Option<NonZeroU16>, ContainerIdx)> = if let Some(set) = affected_set {
             // only visit the affected containers
             set.into_iter()
                 .map(|x| {
@@ -240,13 +240,12 @@ impl DiffCalculator {
                     continue;
                 }
                 let (depth, calc) = self.calculators.get_mut(&idx).unwrap();
-                if *depth == u16::MAX && !are_rest_containers_deleted {
-                    if let Some(d) = oplog.arena.get_depth(idx) {
-                        if d != *depth {
-                            *depth = d;
-                            all.push((*depth, idx));
-                            continue;
-                        }
+                if depth.is_none() && !are_rest_containers_deleted {
+                    let d = oplog.arena.get_depth(idx);
+                    if d != *depth {
+                        *depth = d;
+                        all.push((*depth, idx));
+                        continue;
                     }
                 }
                 let id = oplog.arena.idx_to_id(idx).unwrap();
@@ -255,7 +254,8 @@ impl DiffCalculator {
                 let diff = calc.calculate_diff(oplog, before, after, |c| {
                     if !are_rest_containers_deleted {
                         new_containers.insert(c.clone());
-                        container_id_to_depth.insert(c.clone(), depth.saturating_add(1));
+                        container_id_to_depth
+                            .insert(c.clone(), depth.and_then(|d| d.checked_add(1)));
                         oplog.arena.register_container(c);
                     }
                 });
@@ -285,6 +285,7 @@ impl DiffCalculator {
                 are_rest_containers_deleted = true;
             }
         }
+
         while !new_containers.is_empty() {
             for id in std::mem::take(&mut new_containers) {
                 let Some(idx) = oplog.arena.id_to_idx(&id) else {

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -142,7 +142,7 @@ impl DiffCalculator {
                     let vv = &mut vv.borrow_mut();
                     vv.extend_to_include_end_id(ID::new(change.peer(), op.counter));
                     let depth = oplog.arena.get_depth(op.container).unwrap_or(u16::MAX);
-                    let (_, calculator) =
+                    let (old_depth, calculator) =
                         self.calculators.entry(op.container).or_insert_with(|| {
                             match op.container.get_type() {
                                 crate::ContainerType::Text => (
@@ -169,6 +169,9 @@ impl DiffCalculator {
                                 ),
                             }
                         });
+                    if *old_depth != depth {
+                        *old_depth = depth;
+                    }
 
                     if !started_set.contains(&op.container) {
                         started_set.insert(op.container);

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -169,6 +169,8 @@ impl DiffCalculator {
                                 ),
                             }
                         });
+                    // checkout use the same diff_calculator, the depth of calculator is not updated
+                    // That may cause the container to be considered deleted
                     if *old_depth != depth {
                         *old_depth = depth;
                     }

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -7,7 +7,7 @@ use loro_internal::{
     event::Diff,
     handler::{Handler, TextDelta, ValueOrContainer},
     version::Frontiers,
-    ApplyDiff, ContainerDiff, LoroDoc, ToJson,
+    ApplyDiff, LoroDoc, ToJson,
 };
 use serde_json::json;
 

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -1,10 +1,13 @@
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
+use fxhash::FxHashMap;
 use loro_common::{ContainerID, ContainerType, LoroResult, LoroValue, ID};
 use loro_internal::{
+    delta::ResolvedMapValue,
+    event::Diff,
     handler::{Handler, TextDelta, ValueOrContainer},
     version::Frontiers,
-    ApplyDiff, LoroDoc, ToJson,
+    ApplyDiff, ContainerDiff, LoroDoc, ToJson,
 };
 use serde_json::json;
 
@@ -828,4 +831,54 @@ fn state_may_deadlock_when_import() {
         doc2.get_map("map").insert("foo", 123).unwrap();
         doc.import(&doc.export_snapshot()).unwrap();
     })
+}
+
+#[test]
+fn missing_event_when_checkout() {
+    let doc = LoroDoc::new_auto_commit();
+    doc.checkout(&doc.oplog_frontiers()).unwrap();
+    let value = Arc::new(Mutex::new(FxHashMap::default()));
+    let map = value.clone();
+    doc.subscribe(
+        &ContainerID::new_root("tree", ContainerType::Tree),
+        Arc::new(move |e| {
+            let mut v = map.lock().unwrap();
+            for container_diff in e.events.iter() {
+                let from_children =
+                    container_diff.id != ContainerID::new_root("tree", ContainerType::Tree);
+                if from_children {
+                    if let Diff::Map(map) = &container_diff.diff {
+                        for (k, ResolvedMapValue { value, .. }) in map.updated.iter() {
+                            match value {
+                                Some(value) => {
+                                    v.insert(
+                                        k.to_string(),
+                                        *value.as_value().unwrap().as_i64().unwrap(),
+                                    );
+                                }
+                                None => {
+                                    v.remove(&k.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+
+    let doc2 = LoroDoc::new_auto_commit();
+    let tree = doc2.get_tree("tree");
+    let node = tree.create(None).unwrap();
+    let _ = tree.create(None).unwrap();
+    let meta = tree.get_meta(node).unwrap();
+    meta.insert("a", 0).unwrap();
+    doc.import(&doc2.export_from(&doc.oplog_vv())).unwrap();
+    doc.attach();
+    meta.insert("b", 1).unwrap();
+    doc.checkout(&doc.oplog_frontiers()).unwrap();
+    doc.import(&doc2.export_from(&doc.oplog_vv())).unwrap();
+    // checkout use the same diff_calculator, the depth of calculator is not updated
+    doc.attach();
+    assert!(value.lock().unwrap().contains_key("b"));
 }


### PR DESCRIPTION
When the doc is attached, it uses the `diff_calc` in `LoroDoc`, and the depth of `ContainerDiffCalculator` may still be the old cached value. That causes the `diff_calc` to believe that the depth is inconsistent and the container may have been deleted. So we cannot receive the event.

Maybe we should have a better way to determine whether the container is deleted. 