### PR TITLE
refactor: replace debug-log with tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dhat-heap.json
 node_modules/
 .idea/
 lcov.info
+trace-*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "loro-rle",
  "serde",
  "serde-wasm-bindgen",
+ "tracing-wasm",
  "wasm-bindgen",
 ]
 
@@ -1844,6 +1845,17 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,16 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug-log"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf861b629ec23fc562cccc8b47cc98a54d192ecf4e7b575ce30659d8c814c3a"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,11 +499,11 @@ dependencies = [
  "bench-utils",
  "color-backtrace 0.6.1",
  "ctor 0.2.6",
- "debug-log",
  "flate2",
  "loro",
  "serde_json",
  "tabled 0.15.0",
+ "tracing",
 ]
 
 [[package]]
@@ -799,7 +789,6 @@ dependencies = [
  "color-backtrace 0.5.1",
  "criterion",
  "ctor 0.1.26",
- "debug-log",
  "dhat",
  "enum-as-inner 0.5.1",
  "enum_dispatch",
@@ -831,6 +820,9 @@ dependencies = [
  "static_assertions",
  "tabled 0.10.0",
  "thiserror",
+ "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
  "wasm-bindgen",
  "zstd",
 ]
@@ -853,7 +845,6 @@ dependencies = [
  "arref",
  "color-backtrace 0.5.1",
  "ctor 0.1.26",
- "debug-log",
  "enum-as-inner 0.6.0",
  "fxhash",
  "num",
@@ -875,7 +866,6 @@ name = "loro-wasm"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "debug-log",
  "getrandom",
  "js-sys",
  "loro-internal",
@@ -945,6 +935,16 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -1071,6 +1071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "papergrid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1129,12 @@ checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
@@ -1515,6 +1527,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1759,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1776,74 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1770,6 +1869,12 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -10,8 +10,8 @@ bench-utils = { path = "../bench-utils" }
 loro = { path = "../loro" }
 tabled = "0.15.0"
 arbitrary = { version = "1.3.0", features = ["derive"] }
-debug-log = { version = "0.3.1", features = [] }
 serde_json = "1.0.111"
+tracing = "0.1.40"
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -31,7 +31,6 @@ serde-wasm-bindgen = { version = "0.5.0", optional = true }
 js-sys = { version = "0.3.60", optional = true }
 serde_json = { version = "1" }
 arref = "0.1.0"
-debug-log = { version = "0.3.1", features = [] }
 serde_columnar = { version = "0.3.3" }
 append-only-bytes = { version = "0.1.12", features = ["u32_range"] }
 itertools = "0.11.0"
@@ -44,6 +43,10 @@ leb128 = "0.2.5"
 num-traits = "0.2"
 num-derive = "0.3"
 md5 = "0.7.0"
+tracing = { version = "0.1", features = [
+  "max_level_debug",
+  "release_max_level_warn",
+] }
 
 [dev-dependencies]
 miniz_oxide = "0.7.1"
@@ -61,6 +64,8 @@ criterion = "0.4.0"
 arbtest = "0.2.0"
 bench-utils = { path = "../bench-utils" }
 zstd = "0.13.0"
+tracing-subscriber = "0.3.18"
+tracing-chrome = "0.7.1"
 
 # See https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 [lib]

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -161,7 +161,7 @@ impl SharedArena {
     pub fn log_hierarchy(&self) {
         if cfg!(debug_assertions) {
             for (c, p) in self.inner.parents.lock().unwrap().iter() {
-                debug_log::debug_log!(
+                tracing::info!(
                     "container {:?} {:?} {:?}",
                     c,
                     self.get_container_id(*c),

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -2128,8 +2128,7 @@ impl RichtextState {
         };
         assert!(end > start);
         assert!(end <= self.len_entity());
-        // debug_log::debug_dbg!(start, end);
-        // debug_log::debug_dbg!(&self.tree);
+
         let mut style_iter = self
             .style_ranges
             .as_ref()
@@ -2172,7 +2171,7 @@ impl RichtextState {
             }
 
             let iter_chunk = chunk.as_ref()?;
-            // debug_log::debug_dbg!(&iter_chunk, &chunk, offset, chunk_left_len);
+
             let styles = cur_style;
             let iter_len;
             let event_range;

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -614,13 +614,13 @@ pub(crate) fn utf16_to_unicode_index(s: &str, utf16_index: usize) -> Result<usiz
             return Ok(i + 1);
         }
         if current_utf16_index > utf16_index {
-            debug_log::debug_log!("WARNING: UTF16 MISMATCHED!");
+            tracing::info!("WARNING: UTF16 MISMATCHED!");
             return Err(i);
         }
         current_unicode_index = i + 1;
     }
 
-    debug_log::debug_log!("WARNING: UTF16 MISMATCHED!");
+    tracing::info!("WARNING: UTF16 MISMATCHED!");
     Err(current_unicode_index)
 }
 

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -72,8 +72,7 @@ impl Tracker {
 
     pub(crate) fn insert(&mut self, mut op_id: IdFull, mut pos: usize, mut content: RichtextChunk) {
         // tracing::span!(tracing::Level::INFO, "TrackerInsert");
-        // debug_log::debug_dbg!(&op_id, pos, content);
-        // debug_log::debug_dbg!(&self);
+
         let last_id = op_id.inc(content.len() as Counter - 1);
         let applied_counter_end = self.applied_vv.get(&last_id.peer).copied().unwrap_or(0);
         if applied_counter_end > op_id.counter {
@@ -138,13 +137,12 @@ impl Tracker {
         let end_id = op_id.inc(content.len() as Counter);
         self.current_vv.extend_to_include_end_id(end_id.id());
         self.applied_vv.extend_to_include_end_id(end_id.id());
-        // debug_log::debug_dbg!(&self);
     }
 
     fn update_insert_by_split(&mut self, split: &[LeafIndex]) {
         for &new_leaf_idx in split {
             let leaf = self.rope.tree().get_elem(new_leaf_idx).unwrap();
-            // debug_log::debug_dbg!(&leaf.id_span(), new_leaf_idx);
+
             self.id_to_cursor
                 .update_insert(leaf.id_span(), new_leaf_idx)
         }
@@ -164,8 +162,7 @@ impl Tracker {
         reverse: bool,
     ) {
         // tracing::span!(tracing::Level::INFO, "Tracker Delete");
-        // debug_log::debug_dbg!(&op_id, pos, len, reverse);
-        // debug_log::debug_dbg!(&self);
+
         let last_id = op_id.inc(len as Counter - 1);
         let applied_counter_end = self.applied_vv.get(&last_id.peer).copied().unwrap_or(0);
         if applied_counter_end > op_id.counter {
@@ -192,10 +189,9 @@ impl Tracker {
             // If reverse, don't need to change the pos, because it's deleting backwards.
             // If not reverse, we don't need to change the pos either, because the `start` chars after it are already deleted
         }
-        // debug_log::debug_dbg!(&op_id, pos, len, reverse);
 
         // tracing::info!("after forwarding pos={} len={}", pos, len);
-        // debug_log::debug_dbg!(&self);
+
         let mut ans = Vec::new();
         let split = self
             .rope
@@ -223,7 +219,6 @@ impl Tracker {
         let end_id = op_id.inc(len as Counter);
         self.current_vv.extend_to_include_end_id(end_id);
         self.applied_vv.extend_to_include_end_id(end_id);
-        // debug_log::debug_dbg!(&self);
     }
 
     #[inline]
@@ -379,7 +374,7 @@ impl Tracker {
         self._checkout(from, false);
         self._checkout(to, true);
         // self.id_to_cursor.diagnose();
-        // debug_log::debug_dbg!(&self);
+
         self.rope.get_diff()
     }
 }

--- a/crates/loro-internal/src/container/richtext/tracker.rs
+++ b/crates/loro-internal/src/container/richtext/tracker.rs
@@ -71,7 +71,7 @@ impl Tracker {
     }
 
     pub(crate) fn insert(&mut self, mut op_id: IdFull, mut pos: usize, mut content: RichtextChunk) {
-        // debug_log::group!("TrackerInsert");
+        // tracing::span!(tracing::Level::INFO, "TrackerInsert");
         // debug_log::debug_dbg!(&op_id, pos, content);
         // debug_log::debug_dbg!(&self);
         let last_id = op_id.inc(content.len() as Counter - 1);
@@ -95,7 +95,7 @@ impl Tracker {
             if applied_counter_end > last_id.counter {
                 // the op is included in the applied vv
                 self.current_vv.extend_to_include_last_id(last_id.id());
-                // debug_log::debug_log!("Ops are already included {:#?}", &self);
+                // tracing::info!("Ops are already included {:#?}", &self);
                 return;
             }
 
@@ -108,7 +108,7 @@ impl Tracker {
         }
 
         // {
-        //     debug_log::group!("before insert {} pos={}", op_id, pos);
+        //     tracing::span!(tracing::Level::INFO, "before insert {} pos={}", op_id, pos);
         //     debug_log::debug_dbg!(&self);
         // }
         let result = self.rope.insert(
@@ -163,7 +163,7 @@ impl Tracker {
         mut len: usize,
         reverse: bool,
     ) {
-        // debug_log::group!("Tracker Delete");
+        // tracing::span!(tracing::Level::INFO, "Tracker Delete");
         // debug_log::debug_dbg!(&op_id, pos, len, reverse);
         // debug_log::debug_dbg!(&self);
         let last_id = op_id.inc(len as Counter - 1);
@@ -182,7 +182,6 @@ impl Tracker {
 
             if applied_counter_end > last_id.counter {
                 self.current_vv.extend_to_include_last_id(last_id);
-                debug_log::debug_dbg!(&self);
                 return;
             }
 
@@ -195,7 +194,7 @@ impl Tracker {
         }
         // debug_log::debug_dbg!(&op_id, pos, len, reverse);
 
-        // debug_log::debug_log!("after forwarding pos={} len={}", pos, len);
+        // tracing::info!("after forwarding pos={} len={}", pos, len);
         // debug_log::debug_dbg!(&self);
         let mut ans = Vec::new();
         let split = self
@@ -233,7 +232,7 @@ impl Tracker {
     }
 
     fn _checkout(&mut self, vv: &VersionVector, on_diff_status: bool) {
-        // debug_log::debug_log!("Checkout to {:?} from {:?}", vv, self.current_vv);
+        // tracing::info!("Checkout to {:?} from {:?}", vv, self.current_vv);
         if on_diff_status {
             self.rope.clear_diff_status();
         }
@@ -375,8 +374,8 @@ impl Tracker {
         from: &VersionVector,
         to: &VersionVector,
     ) -> impl Iterator<Item = CrdtRopeDelta> + '_ {
-        // debug_log::group!("From {:?} To {:?}", from, to);
-        // debug_log::debug_log!("Init: {:#?}, ", &self);
+        // tracing::span!(tracing::Level::INFO, "From {:?} To {:?}", from, to);
+        // tracing::info!("Init: {:#?}, ", &self);
         self._checkout(from, false);
         self._checkout(to, true);
         // self.id_to_cursor.diagnose();

--- a/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
+++ b/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
@@ -57,7 +57,7 @@ impl CrdtRope {
             };
         }
 
-        // debug_log::group!("Inserting {} len={}", content.id, content.rle_len());
+        // tracing::span!(tracing::Level::INFO, "Inserting {} len={}", content.id, content.rle_len());
         // debug_log::debug_dbg!(&self.tree);
         let pos = pos as i32;
         let start = self.tree.query::<ActiveLenQueryPreferLeft>(&pos).unwrap();
@@ -142,7 +142,7 @@ impl CrdtRope {
             let mut scanning = false;
             let mut visited: SmallVec<[IdSpan; 4]> = Default::default();
             for (other_leaf, other_elem) in in_between.iter() {
-                // debug_log::debug_log!("Visiting {}", &other_elem.id);
+                // tracing::info!("Visiting {}", &other_elem.id);
                 let other_origin_left = other_elem.origin_left;
                 if other_origin_left != content.origin_left
                     && other_origin_left
@@ -152,7 +152,7 @@ impl CrdtRope {
                     // The other_elem's origin_left must be at the left side of content's origin_left.
                     // So the content must be at the left side of other_elem.
 
-                    // debug_log::debug_log!("Break because the node's origin_left is at the left side of new_elem's origin left");
+                    // tracing::info!("Break because the node's origin_left is at the left side of new_elem's origin left");
                     break;
                 }
 
@@ -164,16 +164,16 @@ impl CrdtRope {
 
                 if content.origin_left == other_origin_left {
                     if other_elem.origin_right == content.origin_right {
-                        // debug_log::debug_log!("Same right parent");
+                        // tracing::info!("Same right parent");
                         // Same right parent
                         if other_elem.id.peer > content.id.peer {
-                            // debug_log::debug_log!("Break on larger peer");
+                            // tracing::info!("Break on larger peer");
                             break;
                         } else {
                             scanning = false;
                         }
                     } else {
-                        // debug_log::debug_log!("Different right parent");
+                        // tracing::info!("Different right parent");
                         // Different right parent, we need to compare the right parents' position
 
                         let other_parent_right_idx =
@@ -193,15 +193,15 @@ impl CrdtRope {
 
                         match self.cmp_pos(other_parent_right_idx, parent_right_leaf) {
                             Ordering::Less => {
-                                // debug_log::debug_log!("Less");
+                                // tracing::info!("Less");
                                 scanning = true;
                             }
                             Ordering::Equal if other_elem.id.peer > content.id.peer => {
-                                // debug_log::debug_log!("Break on eq");
+                                // tracing::info!("Break on eq");
                                 break;
                             }
                             _ => {
-                                // debug_log::debug_log!("Scanning");
+                                // tracing::info!("Scanning");
                                 scanning = false;
                             }
                         }
@@ -213,12 +213,12 @@ impl CrdtRope {
                         leaf: *other_leaf,
                         offset: other_elem.rle_len(),
                     };
-                    // debug_log::debug_log!("updating insert pos {:?}", &insert_pos);
+                    // tracing::info!("updating insert pos {:?}", &insert_pos);
                 }
             }
         }
 
-        // debug_log::debug_log!("Inserting at {:?}", insert_pos);
+        // tracing::info!("Inserting at {:?}", insert_pos);
         //
         let (cursor, splitted) = self.tree.insert_by_path(insert_pos, content);
         InsertResult {
@@ -260,7 +260,6 @@ impl CrdtRope {
             return ans;
         }
 
-        debug_log::debug_dbg!(&start_id);
         let start = self
             .tree
             .query::<ActiveLenQueryPreferRight>(&(pos as i32))
@@ -269,7 +268,7 @@ impl CrdtRope {
         let start = start.cursor;
         let elem = self.tree.get_elem_mut(start.leaf).unwrap();
         if elem.rle_len() >= start.offset + len {
-            // debug_log::debug_log!("len={} offset={} l={} ", elem.rle_len(), start.offset, len,);
+            // tracing::info!("len={} offset={} l={} ", elem.rle_len(), start.offset, len,);
             let (_, splitted) = self.tree.update_leaf(start.leaf, |elem| {
                 let (a, b) = elem.update_with_split(start.offset..start.offset + len, |elem| {
                     assert!(elem.is_activated());

--- a/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
+++ b/crates/loro-internal/src/container/richtext/tracker/crdt_rope.rs
@@ -58,7 +58,7 @@ impl CrdtRope {
         }
 
         // tracing::span!(tracing::Level::INFO, "Inserting {} len={}", content.id, content.rle_len());
-        // debug_log::debug_dbg!(&self.tree);
+
         let pos = pos as i32;
         let start = self.tree.query::<ActiveLenQueryPreferLeft>(&pos).unwrap();
 
@@ -134,7 +134,6 @@ impl CrdtRope {
             (parent_right_leaf, in_between)
         };
 
-        // debug_log::debug_dbg!(&parent_right_leaf, &in_between);
         let mut insert_pos = start.cursor;
 
         if !in_between.is_empty() {
@@ -285,7 +284,6 @@ impl CrdtRope {
                 (true, a, b)
             });
 
-            // debug_log::debug_dbg!(&splitted);
             return smallvec![splitted];
         }
 

--- a/crates/loro-internal/src/container/richtext/tracker/id_to_cursor.rs
+++ b/crates/loro-internal/src/container/richtext/tracker/id_to_cursor.rs
@@ -283,7 +283,7 @@ impl Cursor {
     }
 
     fn update_insert(&mut self, from: usize, to: usize, new_leaf: LeafIndex) {
-        // debug_log::debug_log!(
+        // tracing::info!(
         //     "set_insert: from={}, to={}, new_leaf={:?}",
         //     from,
         //     to,

--- a/crates/loro-internal/src/dag/iter.rs
+++ b/crates/loro-internal/src/dag/iter.rs
@@ -312,7 +312,7 @@ impl<'a, T: DagNode + 'a, D: Dag<Node = T>> Iterator for DagCausalIter<'a, D> {
 
         let path = self.dag.find_path(&self.frontier, &deps);
 
-        // debug_log::group!("Dag Causal");
+        // tracing::span!(tracing::Level::INFO, "Dag Causal");
         // debug_log::debug_dbg!(&deps);
         // debug_log::debug_dbg!(&path);
         //

--- a/crates/loro-internal/src/dag/iter.rs
+++ b/crates/loro-internal/src/dag/iter.rs
@@ -313,8 +313,7 @@ impl<'a, T: DagNode + 'a, D: Dag<Node = T>> Iterator for DagCausalIter<'a, D> {
         let path = self.dag.find_path(&self.frontier, &deps);
 
         // tracing::span!(tracing::Level::INFO, "Dag Causal");
-        // debug_log::debug_dbg!(&deps);
-        // debug_log::debug_dbg!(&path);
+
         //
 
         // NOTE: we expect user to update the tracker, to apply node, after visiting the node

--- a/crates/loro-internal/src/delta/seq.rs
+++ b/crates/loro-internal/src/delta/seq.rs
@@ -531,7 +531,6 @@ impl<Value: DeltaValue, M: Meta> Delta<Value, M> {
     /// Reference: [Quill Delta](https://github.com/quilljs/delta)
     // TODO: PERF use &mut self and &other
     pub fn compose(self, other: Delta<Value, M>) -> Delta<Value, M> {
-        // debug_log::debug_dbg!(&self, &other);
         let mut this_iter = self.into_op_iter();
         let mut other_iter = other.into_op_iter();
         let mut ops = vec![];
@@ -601,7 +600,6 @@ impl<Value: DeltaValue, M: Meta> Delta<Value, M> {
             }
         }
 
-        // debug_log::debug_dbg!(&delta);
         delta.chop()
     }
 

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -727,7 +727,6 @@ impl DiffCalculatorTrait for RichtextDiffCalculator {
             }
         }
 
-        // debug_log::debug_dbg!(&self.tracker);
         InternalDiff::RichtextRaw(delta)
     }
 }

--- a/crates/loro-internal/src/diff_calc.rs
+++ b/crates/loro-internal/src/diff_calc.rs
@@ -72,8 +72,9 @@ impl DiffCalculator {
         after: &crate::VersionVector,
         after_frontiers: Option<&Frontiers>,
     ) -> Vec<InternalContainerDiff> {
-        debug_log::group!("DiffCalc");
-        debug_log::debug_log!("Before: {:?} After: {:?}", &before, &after);
+        let s = tracing::span!(tracing::Level::INFO, "DiffCalc");
+        let _e = s.enter();
+        tracing::info!("Before: {:?} After: {:?}", &before, &after);
         if self.has_all {
             let include_before = self.last_vv.includes_vv(before);
             let include_after = self.last_vv.includes_vv(after);
@@ -693,7 +694,6 @@ impl DiffCalculatorTrait for RichtextDiffCalculator {
                     RichtextChunkValue::Unknown(len) => {
                         // assert not unknown id
                         assert_ne!(id.peer, PeerID::MAX);
-                        debug_log::debug_dbg!(oplog.changes(), id, len);
                         let mut acc_len = 0;
                         for rich_op in oplog.iter_ops(IdSpan::new(
                             id.peer,

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -531,14 +531,12 @@ fn calc_sorted_ops_for_snapshot<'a>(
 ) -> Vec<TempOp<'a>> {
     origin_ops.sort_unstable();
     pos_mapping_heap.sort_unstable();
-    debug_log::debug_dbg!(&origin_ops, &pos_mapping_heap);
     let mut ops: Vec<TempOp<'a>> = Vec::with_capacity(origin_ops.len());
     let ops_len: usize = origin_ops.iter().map(|x| x.atom_len()).sum();
     let mut origin_top = origin_ops.pop();
     let mut pos_top = pos_mapping_heap.pop();
 
     while origin_top.is_some() || pos_top.is_some() {
-        debug_log::debug_dbg!(&origin_top, &pos_top);
         let Some(mut inner_origin_top) = origin_top else {
             unreachable!()
         };

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -137,7 +137,7 @@ pub(crate) fn decode_updates(oplog: &mut OpLog, bytes: &[u8]) -> LoroResult<()> 
     .ops_map;
 
     let changes = decode_changes(iter.changes, iter.start_counters, peer_ids, deps, ops_map)?;
-    // debug_log::debug_dbg!(&changes);
+
     let (latest_ids, pending_changes) = import_changes_to_oplog(changes, oplog)?;
     if oplog.try_apply_pending(latest_ids).should_update && !oplog.batch_importing {
         oplog.dag.refresh_frontiers();

--- a/crates/loro-internal/src/fuzz/tree.rs
+++ b/crates/loro-internal/src/fuzz/tree.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use arbitrary::Arbitrary;
-use debug_log::debug_dbg;
 use enum_as_inner::EnumAsInner;
 use fxhash::FxHashMap;
 use loro_common::{LoroError, LoroTreeError, TreeID, ID};
@@ -104,7 +103,6 @@ impl Actor {
         let root_value = Arc::clone(&actor.value_tracker);
         actor.loro.subscribe_root(Arc::new(move |event| {
             let mut root_value = root_value.lock().unwrap();
-            debug_dbg!(&event);
             for container_diff in event.events {
                 // if id == 0 {
                 //     println!("\nbefore {:?}", root_value);
@@ -166,7 +164,6 @@ impl Actor {
                         let mut v = TreeValue(&mut tree);
                         v.apply_diff(tree_diff);
                     } else {
-                        debug_dbg!(&container_diff);
                         unreachable!()
                     }
                 }
@@ -648,7 +645,7 @@ fn check_eq(a_actor: &mut Actor, b_actor: &mut Actor) {
             id.clone().into_string().unwrap()
         });
     }
-    debug_log::debug_log!("{}", a_result.to_json_pretty());
+    tracing::info!("{}", a_result.to_json_pretty());
     assert_eq!(&a_result, &b_result);
     assert_value_eq(&a_result, &a_value);
 
@@ -671,21 +668,26 @@ fn check_eq(a_actor: &mut Actor, b_actor: &mut Actor) {
 fn check_synced(sites: &mut [Actor]) {
     for i in 0..sites.len() - 1 {
         for j in i + 1..sites.len() {
-            debug_log::group!("checking {} with {}", i, j);
+            let s = tracing::span!(tracing::Level::INFO, "checking {} with {}", i, j);
+            let _e = s.enter();
             let (a, b) = array_mut_ref!(sites, [i, j]);
             let a_doc = &mut a.loro;
             let b_doc = &mut b.loro;
             if (i + j) % 2 == 0 {
-                debug_log::group!("Updates {} to {}", j, i);
+                let s = tracing::span!(tracing::Level::INFO, "Updates {} to {}", j, i);
+                let _e = s.enter();
                 a_doc.import(&b_doc.export_from(&a_doc.oplog_vv())).unwrap();
 
-                debug_log::group!("Updates {} to {}", i, j);
+                let s = tracing::span!(tracing::Level::INFO, "Updates {} to {}", i, j);
+                let _e = s.enter();
                 b_doc.import(&a_doc.export_from(&b_doc.oplog_vv())).unwrap();
             } else {
-                debug_log::group!("Snapshot {} to {}", j, i);
+                let s = tracing::span!(tracing::Level::INFO, "Snapshot {} to {}", j, i);
+                let _e = s.enter();
                 a_doc.import(&b_doc.export_snapshot()).unwrap();
 
-                debug_log::group!("Snapshot {} to {}", i, j);
+                let s = tracing::span!(tracing::Level::INFO, "Snapshot {} to {}", i, j);
+                let _e = s.enter();
                 b_doc.import(&a_doc.export_snapshot()).unwrap();
             }
             check_eq(a, b);
@@ -760,11 +762,12 @@ pub fn test_multi_sites(site_num: u8, actions: &mut [Action]) {
     for action in actions.iter_mut() {
         sites.preprocess(action);
         applied.push(action.clone());
-        debug_log::debug_log!("\n{}", (&applied).table());
+        tracing::info!("\n{}", (&applied).table());
         sites.apply_action(action);
     }
 
-    debug_log::group!("check synced");
+    let s = tracing::span!(tracing::Level::INFO, "check synced");
+    let _e = s.enter();
     check_synced(&mut sites);
 
     check_history(&mut sites[1]);

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -365,7 +365,6 @@ impl TextHandler {
         if let Some(attr) = attr {
             // current styles
             let map: FxHashMap<_, _> = styles.iter().map(|x| (x.0.clone(), x.1.data)).collect();
-            debug_log::debug_dbg!(&map);
             for (key, style) in map.iter() {
                 match attr.get(key.deref()) {
                     Some(v) if v == style => {}
@@ -439,7 +438,8 @@ impl TextHandler {
             });
         }
 
-        debug_log::group!("delete pos={} len={}", pos, len);
+        let s = tracing::span!(tracing::Level::INFO, "delete pos={} len={}", pos, len);
+        let _e = s.enter();
         let ranges = self
             .state
             .upgrade()
@@ -637,7 +637,6 @@ impl TextHandler {
                         Some(attributes.as_ref().unwrap_or(&Default::default())),
                     )?;
 
-                    debug_log::debug_dbg!(&override_styles);
                     for (key, value) in override_styles {
                         marks.push((index, end, key, value));
                     }

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -776,7 +776,7 @@ impl OpLog {
                     }
 
                     inner_vv.extend_to_include_end_id(change.id);
-                    // debug_log::debug_dbg!(&change, &inner_vv);
+
                     Some((change, cnt, vv.clone()))
                 } else {
                     None

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -867,10 +867,7 @@ impl OpLog {
                     let counter = (id.lamport - change.lamport) as Counter + change.id.counter;
                     Some(ID::new(id.peer, counter))
                 }
-                Err(_) => {
-                    debug_log::debug_dbg!(id, &peer_changes);
-                    None
-                }
+                Err(_) => None,
             }
         } else {
             None

--- a/crates/loro-internal/src/oplog/pending_changes.rs
+++ b/crates/loro-internal/src/oplog/pending_changes.rs
@@ -135,7 +135,6 @@ impl OpLog {
             return;
         };
         self.next_lamport = self.next_lamport.max(change.lamport_end());
-        // debug_dbg!(&change_causal_arr);
         self.dag.vv.extend_to_include_last_id(change.id_last());
         self.latest_timestamp = self.latest_timestamp.max(change.timestamp);
         let mark = self.update_dag_on_new_change(&change);

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -337,9 +337,7 @@ impl DocState {
         let diffs = std::mem::take(&mut recorder.diffs);
         let start = recorder.diff_start_version.take().unwrap();
         recorder.diff_start_version = Some((*diffs.last().unwrap().new_version).to_owned());
-        // debug_dbg!(&diffs);
         let event = self.diffs_to_event(diffs, start);
-        // debug_dbg!(&event);
         self.event_recorder.events.push(event);
     }
 

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -359,7 +359,7 @@ impl DocState {
         if self.in_txn {
             panic!("apply_diff should not be called in a transaction");
         }
-        // debug_log::debug_log!("Diff = {:#?}", &diff);
+        // tracing::info!("Diff = {:#?}", &diff);
         let is_recording = self.is_recording();
         self.pre_txn(diff.origin.clone(), diff.local);
         let Cow::Owned(inner) = std::mem::take(&mut diff.diff) else {
@@ -921,7 +921,7 @@ impl DocState {
                     } else {
                         // if we cannot find the path to the container, the container must be overwritten afterwards.
                         // So we can ignore the diff from it.
-                        debug_log::debug_log!(
+                        tracing::info!(
                             "⚠️ WARNING: ignore because cannot find path {:#?} deep_value {:#?}",
                             &container_diff,
                             self.get_deep_value_with_id()
@@ -965,24 +965,23 @@ impl DocState {
 
     // the container may be override, so it may return None
     fn get_path(&self, idx: ContainerIdx) -> Option<Vec<(ContainerID, Index)>> {
-        debug_log::group!("GET PATH {:?}", idx);
+        let s = tracing::span!(tracing::Level::INFO, "GET PATH ", ?idx);
+        let _e = s.enter();
         let mut ans = Vec::new();
         let mut idx = idx;
         loop {
             let id = self.arena.idx_to_id(idx).unwrap();
-            debug_log::debug_dbg!(&id);
             if let Some(parent_idx) = self.arena.get_parent(idx) {
                 let parent_state = self.states.get(&parent_idx).unwrap();
-                debug_log::debug_dbg!(&parent_state);
                 let Some(prop) = parent_state.get_child_index(&id) else {
-                    debug_log::debug_log!("Missing in parent children");
+                    tracing::info!("Missing in parent children");
                     return None;
                 };
                 ans.push((id, prop));
                 idx = parent_idx;
             } else {
                 // this container may be deleted
-                debug_log::debug_log!("Deleted or root");
+                tracing::info!("Deleted or root");
                 let prop = id.as_root()?.0.clone();
                 ans.push((id, Index::Key(prop)));
                 break;

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -356,7 +356,6 @@ impl ContainerState for ListState {
         _txn: &Weak<Mutex<Option<Transaction>>>,
         _state: &Weak<Mutex<DocState>>,
     ) {
-        // debug_log::debug_dbg!(&diff);
         match diff {
             InternalDiff::ListRaw(delta) => {
                 let mut index = 0;

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -131,16 +131,18 @@ impl ContainerState for MapState {
     }
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {
-        debug_log::group!("Get child index {:?}", id);
+        let s = tracing::span!(tracing::Level::INFO, "Get child index ", id = ?id);
+        let _e = s.enter();
         for (key, value) in self.map.iter() {
-            debug_log::group!("Key {} value {:?}", key, value);
+            let s = tracing::span!(tracing::Level::INFO, "Key Value", key = ?key, value = ?value);
+            let _e = s.enter();
             if let Some(LoroValue::Container(x)) = &value.value {
-                debug_log::debug_log!("Cmp {:?} with {:?}", &x, &id);
+                tracing::info!("Cmp {:?} with {:?}", &x, &id);
                 if x == id {
-                    debug_log::debug_log!("Same");
+                    tracing::info!("Same");
                     return Some(Index::Key(key.clone()));
                 }
-                debug_log::debug_log!("Diff");
+                tracing::info!("Diff");
             }
         }
 

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -275,7 +275,7 @@ impl ContainerState for RichtextState {
                             Delta::new().retain(event_range.start);
                         let mut entity_len_sum = 0;
                         let expected_sum = entity_range.len();
-                        // debug_log::debug_dbg!(&entity_range);
+
                         for IterRangeItem {
                             event_len,
                             chunk,
@@ -284,7 +284,6 @@ impl ContainerState for RichtextState {
                             ..
                         } in self.state.get_mut().iter_range(entity_range)
                         {
-                            // debug_log::debug_dbg!(&chunk, entity_len);
                             entity_len_sum += entity_len;
                             match chunk {
                                 RichtextStateChunk::Text(_) => {

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -153,7 +153,7 @@ impl ContainerState for RichtextState {
             unreachable!()
         };
 
-        // debug_log::debug_log!("Self state = {:#?}", &self);
+        // tracing::info!("Self state = {:#?}", &self);
         // PERF: compose delta
         let mut ans: Delta<StringSlice, StyleMeta> = Delta::new();
         let mut style_delta: Delta<StringSlice, StyleMeta> = Delta::new();
@@ -526,7 +526,6 @@ impl ContainerState for RichtextState {
         }
 
         for chunk in iter {
-            debug_log::debug_dbg!(&chunk);
             let id_span = chunk.get_id_lp_span();
             encoder.encode_op(id_span, || unimplemented!());
         }
@@ -566,7 +565,6 @@ impl ContainerState for RichtextState {
                 a => unreachable!("richtext state should not have {a:?}"),
             };
 
-            debug_log::debug_dbg!(&chunk);
             loader.push(chunk);
         }
 
@@ -671,7 +669,6 @@ impl RichtextStateLoader {
                 self.start_anchor_pos
                     .insert(ID::new(style.peer, style.cnt), self.entity_index);
             } else {
-                debug_log::debug_dbg!(&self.start_anchor_pos);
                 let start_pos = self
                     .start_anchor_pos
                     .remove(&ID::new(style.peer, style.cnt))

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -669,7 +669,6 @@ fn a_list_of_map_checkout() {
     doc.checkout(&v2).unwrap();
     println!("{}", doc.get_deep_value_with_id().to_json_pretty());
     assert_eq!(doc.get_deep_value().to_json(), d2);
-    debug_log::group!("checking out v1");
     doc.checkout(&v1).unwrap();
 
     println!("{}", doc.get_deep_value_with_id().to_json_pretty());

--- a/crates/loro-wasm/Cargo.toml
+++ b/crates/loro-wasm/Cargo.toml
@@ -13,7 +13,6 @@ wasm-bindgen = "=0.2.90"
 serde-wasm-bindgen = { version = "0.5.0" }
 console_error_panic_hook = { version = "0.1.6", optional = true }
 getrandom = { version = "0.2.10", features = ["js"] }
-debug-log = { version = "0.3.1", features = ["wasm"] }
 serde = { version = "1", features = ["derive"] }
 rle = { path = "../rle", package = "loro-rle" }
 

--- a/crates/loro-wasm/Cargo.toml
+++ b/crates/loro-wasm/Cargo.toml
@@ -15,6 +15,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 getrandom = { version = "0.2.10", features = ["js"] }
 serde = { version = "1", features = ["derive"] }
 rle = { path = "../rle", package = "loro-rle" }
+tracing-wasm = "0.2.1"
 
 [features]
 default = ["console_error_panic_hook"]

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -29,8 +29,8 @@ fn run() {
 }
 
 #[wasm_bindgen(js_name = setDebug)]
-pub fn set_debug(filter: &str) {
-    debug_log::set_debug(filter)
+pub fn set_debug() {
+    todo!("add tracing sub")
 }
 
 type JsResult<T> = Result<T, JsValue>;
@@ -1170,7 +1170,6 @@ impl LoroText {
     /// text.insert(0, "Hello");
     /// ```
     pub fn insert(&mut self, index: usize, content: &str) -> JsResult<()> {
-        debug_log::debug_log!("InsertLogWasm");
         self.handler.insert(index, content)?;
         Ok(())
     }

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -30,7 +30,7 @@ fn run() {
 
 #[wasm_bindgen(js_name = setDebug)]
 pub fn set_debug() {
-    todo!("add tracing sub")
+    tracing_wasm::set_as_global_default();
 }
 
 type JsResult<T> = Result<T, JsValue>;

--- a/crates/rle/Cargo.toml
+++ b/crates/rle/Cargo.toml
@@ -18,7 +18,6 @@ num = "0.4.0"
 enum-as-inner = "0.6.0"
 arref = "0.1.0"
 fxhash = "0.2.1"
-debug-log = "0.3.1"
 append-only-bytes = { version = "0.1.11", features = ["u32_range"] }
 
 [dev-dependencies]


### PR DESCRIPTION
When compiling the tests with "DEBUG=1", the log will be written to a `trace-*.json` file. This file can be imported to https://ui.perfetto.dev to visualize.

