### PR TITLE
feat: add getOrCreateContainer for Map

### DIFF
--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -288,12 +288,12 @@ mod container {
 
         fn try_from(value: &str) -> Result<Self, Self::Error> {
             match value {
-                "Map" => Ok(ContainerType::Map),
-                "List" => Ok(ContainerType::List),
-                "Text" => Ok(ContainerType::Text),
-                "Tree" => Ok(ContainerType::Tree),
+                "Map" | "map" => Ok(ContainerType::Map),
+                "List" | "list" => Ok(ContainerType::List),
+                "Text" | "text" => Ok(ContainerType::Text),
+                "Tree" | "tree" => Ok(ContainerType::Tree),
                 _ => Err(LoroError::DecodeError(
-                    ("Unknown container type".to_string() + value).into(),
+                    format!("Unknown container type \"{}\". The valid options are Map|List|Text|Tree|MovableList.", value).into(),
                 )),
             }
         }

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -992,7 +992,6 @@ impl MapHandler {
     {
         let mutex = &self.inner.state.upgrade().unwrap();
         let mut doc_state = mutex.lock().unwrap();
-        let arena = doc_state.arena.clone();
         doc_state.with_state(self.inner.container_idx, |state| {
             let a = state.as_map_state().unwrap();
             for (k, v) in a.iter() {
@@ -1050,6 +1049,25 @@ impl MapHandler {
                 None => None,
             }
         })
+    }
+
+    pub fn get_or_create_container_(
+        &self,
+        key: &str,
+        container_type: ContainerType,
+    ) -> LoroResult<Handler> {
+        if let Some(ans) = self.get_(key) {
+            if let ValueOrHandler::Handler(h) = ans {
+                return Ok(h);
+            } else {
+                return Err(LoroError::ArgErr(
+                    format!("Expected value type {} but found {:?}", container_type, ans)
+                        .into_boxed_str(),
+                ));
+            }
+        }
+
+        self.insert_container(key, container_type)
     }
 
     pub fn len(&self) -> usize {

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -1,6 +1,18 @@
 export * from "loro-wasm";
-import { Container, Delta, LoroText, LoroTree,LoroTreeNode, OpId, Value, ContainerID, Loro, LoroList, LoroMap, TreeID } from "loro-wasm";
-
+import {
+  Container,
+  Delta,
+  LoroText,
+  LoroTree,
+  LoroTreeNode,
+  OpId,
+  Value,
+  ContainerID,
+  Loro,
+  LoroList,
+  LoroMap,
+  TreeID,
+} from "loro-wasm";
 
 Loro.prototype.getTypedMap = function (...args) {
   return this.getMap(...args);
@@ -36,10 +48,10 @@ export type Frontiers = OpId[];
 /**
  * Represents a path to identify the exact location of an event's target.
  * The path is composed of numbers (e.g., indices of a list container) strings
- * (e.g., keys of a map container) and TreeID (the node of a tree container), 
+ * (e.g., keys of a map container) and TreeID (the node of a tree container),
  * indicating the absolute position of the event's source within a loro document.
  */
-export type Path = (number | string | TreeID )[];
+export type Path = (number | string | TreeID)[];
 
 /**
  * A batch of events that created by a single `import`/`transaction`/`checkout`.
@@ -95,9 +107,10 @@ export type MapDiff = {
   updated: Record<string, Value | Container | undefined>;
 };
 
-export type TreeDiffItem = { target: TreeID; action: "create"; parent: TreeID | undefined }
-   | { target: TreeID; action: "delete" }
-   | { target: TreeID; action: "move"; parent: TreeID | undefined };
+export type TreeDiffItem =
+  | { target: TreeID; action: "create"; parent: TreeID | undefined }
+  | { target: TreeID; action: "delete" }
+  | { target: TreeID; action: "move"; parent: TreeID | undefined };
 
 export type TreeDiff = {
   type: "tree";
@@ -212,6 +225,12 @@ declare module "loro-wasm" {
   }
 
   interface LoroMap<T extends Record<string, any> = Record<string, any>> {
+    getOrCreateContainer(key: string, container_type: "Map"): LoroMap;
+    getOrCreateContainer(key: string, container_type: "List"): LoroList;
+    getOrCreateContainer(key: string, container_type: "Text"): LoroText;
+    getOrCreateContainer(key: string, container_type: "Tree"): LoroTree;
+    getOrCreateContainer(key: string, container_type: string): never;
+
     setContainer(key: string, container_type: "Map"): LoroMap;
     setContainer(key: string, container_type: "List"): LoroList;
     setContainer(key: string, container_type: "Text"): LoroText;
@@ -241,7 +260,7 @@ declare module "loro-wasm" {
     subscribe(txn: Loro, listener: Listener): number;
   }
 
-  interface LoroTreeNode{
+  interface LoroTreeNode {
     readonly data: LoroMap;
     createNode(): LoroTreeNode;
     setAsRoot(): void;

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -51,6 +51,19 @@ it("basic example", () => {
   });
 });
 
+it("get or create on Map", () => {
+  const docA = new Loro();
+  const map = docA.getMap("map");
+  const container = map.getOrCreateContainer("list", "List");
+  container.insert(0, 1);
+  container.insert(0, 2);
+  const text = map.getOrCreateContainer("text", "Text");
+  text.insert(0, "Hello");
+  expect(docA.toJson()).toStrictEqual({
+    map: { list: [2, 1], text: "Hello" },
+  });
+});
+
 it("basic sync example", () => {
   const docA = new Loro();
   const docB = new Loro();


### PR DESCRIPTION
# Example Usage

```ts
const docA = new Loro();
const map = docA.getMap("map");
const container = map.getOrCreateContainer("list", "List");
container.insert(0, 1);
container.insert(0, 2);
const text = map.getOrCreateContainer("text", "Text");
text.insert(0, "Hello");
expect(docA.toJson()).toStrictEqual({
  map: { list: [2, 1], text: "Hello" },
});
```