### PR TITLE
feat: add getParent for each handler

### DIFF
--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -101,6 +101,10 @@ pub trait HandlerTrait {
     fn with_txn<R>(&self, f: impl FnOnce(&mut Transaction) -> LoroResult<R>) -> LoroResult<R> {
         with_txn(&self.inner().txn, f)
     }
+
+    fn parent(&self) -> Option<Handler> {
+        self.inner().get_parent()
+    }
 }
 
 fn create_handler(handler: &impl HandlerTrait, id: ContainerID) -> Handler {
@@ -135,6 +139,31 @@ impl BasicHandler {
         f: impl FnOnce(&mut Transaction) -> Result<(), LoroError>,
     ) -> Result<(), LoroError> {
         with_txn(&self.txn, f)
+    }
+
+    fn get_parent(&self) -> Option<Handler> {
+        let parent_idx = self.arena.get_parent(self.container_idx)?;
+        let parent_id = self.arena.get_container_id(parent_idx).unwrap();
+        {
+            let arena = self.arena.clone();
+            let txn = self.txn.clone();
+            let state = self.state.clone();
+            let kind = parent_id.container_type();
+            let handler = BasicHandler {
+                container_idx: parent_idx,
+                id: parent_id,
+                txn,
+                arena,
+                state,
+            };
+
+            Some(match kind {
+                ContainerType::Map => Handler::Map(MapHandler { inner: handler }),
+                ContainerType::List => Handler::List(ListHandler { inner: handler }),
+                ContainerType::Tree => Handler::Tree(TreeHandler { inner: handler }),
+                ContainerType::Text => Handler::Text(TextHandler { inner: handler }),
+            })
+        }
     }
 }
 
@@ -992,7 +1021,6 @@ impl MapHandler {
     {
         let mutex = &self.inner.state.upgrade().unwrap();
         let mut doc_state = mutex.lock().unwrap();
-        let arena = doc_state.arena.clone();
         doc_state.with_state(self.inner.container_idx, |state| {
             let a = state.as_map_state().unwrap();
             for (k, v) in a.iter() {
@@ -1142,7 +1170,7 @@ impl TreeHandler {
     }
 
     /// Get the parent of the node, if the node is deleted or does not exist, return None
-    pub fn parent(&self, target: TreeID) -> Option<Option<TreeID>> {
+    pub fn get_node_parent(&self, target: TreeID) -> Option<Option<TreeID>> {
         self.with_state(|state| {
             let a = state.as_tree_state().unwrap();
             a.parent(target).map(|p| match p {

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -212,11 +212,7 @@ fn map_delta_to_js(value: &ResolvedMapDelta, doc: &Arc<LoroDoc>) -> JsValue {
 
 pub(crate) fn handler_to_js_value(handler: Handler, doc: Arc<LoroDoc>) -> JsValue {
     match handler {
-        Handler::Text(t) => LoroText {
-            handler: t,
-            _doc: doc,
-        }
-        .into(),
+        Handler::Text(t) => LoroText { handler: t, doc }.into(),
         Handler::Map(m) => LoroMap { handler: m, doc }.into(),
         Handler::List(l) => LoroList { handler: l, doc }.into(),
         Handler::Tree(t) => LoroTree { handler: t, doc }.into(),

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1785,7 +1785,6 @@ impl LoroList {
     pub fn insert_container(&mut self, index: usize, container: &str) -> JsResult<JsValue> {
         let type_: ContainerType = container.try_into()?;
         let c = self.handler.insert_container(index, type_)?;
-        let c = self.handler.insert_container(index, _type)?;
         Ok(handler_to_js_value(c, self.doc.clone()))
     }
 

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -781,7 +781,7 @@ impl LoroTree {
     /// - If the target node does not exist, return `None`.
     /// - If the target node is a root node, return `Some(None)`.
     pub fn parent(&self, target: TreeID) -> Option<Option<TreeID>> {
-        self.handler.parent(target)
+        self.handler.get_node_parent(target)
     }
 
     /// Return whether target node exists.

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -375,3 +375,18 @@ it("can control the mergeable interval", () => {
     expect(doc.getAllChanges().get("1")?.length).toBe(2);
   }
 });
+
+it("get container parent", () => {
+  const doc = new Loro();
+  const m = doc.getMap("m");
+  expect(m.parent()).toBeUndefined();
+  const list = m.setContainer("t", "List");
+  expect(list.parent()!.id).toBe(m.id);
+  const text = list.insertContainer(0, "Text");
+  expect(text.parent()!.id).toBe(list.id);
+  const tree = list.insertContainer(1, "Tree");
+  expect(tree.parent()!.id).toBe(list.id);
+  const treeNode = tree.createNode();
+  const subtext = treeNode.data.setContainer("t", "Text");
+  expect(subtext.parent()!.id).toBe(treeNode.data.id);
+});


### PR DESCRIPTION
# Example Usages

```
  const doc = new Loro();
  const m = doc.getMap("m");
  expect(m.parent()).toBeUndefined();
  const list = m.setContainer("t", "List");
  expect(list.parent()!.id).toBe(m.id);
  const text = list.insertContainer(0, "Text");
  expect(text.parent()!.id).toBe(list.id);
  const tree = list.insertContainer(1, "Tree");
  expect(tree.parent()!.id).toBe(list.id);
  const treeNode = tree.createNode();
  const subtext = treeNode.data.setContainer("t", "Text");
  expect(subtext.parent()!.id).toBe(treeNode.data.id);
```