### PR TITLE
refactor!: Add prelim support, making creating sub container easier

### DIFF
--- a/crates/examples/src/draw.rs
+++ b/crates/examples/src/draw.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use bench_utils::{draw::DrawAction, Action};
-use loro::{ContainerID, ContainerType};
+use loro::{ContainerID, LoroList, LoroMap, LoroText};
 
 use crate::{run_actions_fuzz_in_async_mode, ActorTrait};
 
@@ -41,26 +41,13 @@ impl ActorTrait for DrawActor {
     fn apply_action(&mut self, action: &mut Self::ActionKind) {
         match action {
             DrawAction::CreatePath { points } => {
-                let path = self.paths.insert_container(0, ContainerType::Map).unwrap();
-                let path_map = path.into_map().unwrap();
-                let pos_map = path_map
-                    .insert_container("pos", ContainerType::Map)
-                    .unwrap()
-                    .into_map()
-                    .unwrap();
+                let path_map = self.paths.insert_container(0, LoroMap::new()).unwrap();
+                let pos_map = path_map.insert_container("pos", LoroMap::new()).unwrap();
                 pos_map.insert("x", 0).unwrap();
                 pos_map.insert("y", 0).unwrap();
-                let path = path_map
-                    .insert_container("path", ContainerType::List)
-                    .unwrap()
-                    .into_list()
-                    .unwrap();
+                let path = path_map.insert_container("path", LoroList::new()).unwrap();
                 for p in points {
-                    let map = path
-                        .push_container(ContainerType::Map)
-                        .unwrap()
-                        .into_map()
-                        .unwrap();
+                    let map = path.push_container(LoroMap::new()).unwrap();
                     map.insert("x", p.x).unwrap();
                     map.insert("y", p.y).unwrap();
                 }
@@ -68,29 +55,18 @@ impl ActorTrait for DrawActor {
                 self.id_to_obj.insert(len, path_map.id());
             }
             DrawAction::Text { text, pos, size } => {
-                let text_container = self
-                    .texts
-                    .insert_container(0, ContainerType::Map)
-                    .unwrap()
-                    .into_map()
-                    .unwrap();
+                let text_container = self.texts.insert_container(0, LoroMap::new()).unwrap();
                 let text_inner = text_container
-                    .insert_container("text", ContainerType::Text)
-                    .unwrap()
-                    .into_text()
+                    .insert_container("text", LoroText::new())
                     .unwrap();
                 text_inner.insert(0, text).unwrap();
                 let map = text_container
-                    .insert_container("pos", ContainerType::Map)
-                    .unwrap()
-                    .into_map()
+                    .insert_container("pos", LoroMap::new())
                     .unwrap();
                 map.insert("x", pos.x).unwrap();
                 map.insert("y", pos.y).unwrap();
                 let map = text_container
-                    .insert_container("size", ContainerType::Map)
-                    .unwrap()
-                    .into_map()
+                    .insert_container("size", LoroMap::new())
                     .unwrap();
                 map.insert("x", size.x).unwrap();
                 map.insert("y", size.y).unwrap();
@@ -99,21 +75,12 @@ impl ActorTrait for DrawActor {
                 self.id_to_obj.insert(len, text_container.id());
             }
             DrawAction::CreateRect { pos, .. } => {
-                let rect = self.rects.insert_container(0, ContainerType::Map).unwrap();
-                let rect_map = rect.into_map().unwrap();
-                let pos_map = rect_map
-                    .insert_container("pos", ContainerType::Map)
-                    .unwrap()
-                    .into_map()
-                    .unwrap();
+                let rect_map = self.rects.insert_container(0, LoroMap::new()).unwrap();
+                let pos_map = rect_map.insert_container("pos", LoroMap::new()).unwrap();
                 pos_map.insert("x", pos.x).unwrap();
                 pos_map.insert("y", pos.y).unwrap();
 
-                let size_map = rect_map
-                    .insert_container("size", ContainerType::Map)
-                    .unwrap()
-                    .into_map()
-                    .unwrap();
+                let size_map = rect_map.insert_container("size", LoroMap::new()).unwrap();
                 size_map.insert("width", pos.x).unwrap();
                 size_map.insert("height", pos.y).unwrap();
 

--- a/crates/examples/src/sheet.rs
+++ b/crates/examples/src/sheet.rs
@@ -1,4 +1,4 @@
-use loro::LoroDoc;
+use loro::{LoroDoc, LoroMap};
 
 pub fn init_sheet() -> LoroDoc {
     let doc = LoroDoc::new();
@@ -6,7 +6,7 @@ pub fn init_sheet() -> LoroDoc {
     let cols = doc.get_list("cols");
     let rows = doc.get_list("rows");
     for _ in 0..bench_utils::sheet::SheetAction::MAX_ROW {
-        rows.push_container(loro::ContainerType::Map).unwrap();
+        rows.push_container(LoroMap::new()).unwrap();
     }
 
     for i in 0..bench_utils::sheet::SheetAction::MAX_COL {

--- a/crates/fuzz/src/container/list.rs
+++ b/crates/fuzz/src/container/list.rs
@@ -105,7 +105,7 @@ impl Actionable for ListAction {
                 let pos = *pos as usize;
                 match value {
                     FuzzValue::Container(c) => {
-                        let container = list.insert_container(pos, *c).unwrap();
+                        let container = list.insert_container(pos, Container::new(*c)).unwrap();
                         Some(container)
                     }
                     FuzzValue::I32(v) => {

--- a/crates/fuzz/src/container/map.rs
+++ b/crates/fuzz/src/container/map.rs
@@ -119,7 +119,7 @@ impl Actionable for MapAction {
                         None
                     }
                     FuzzValue::Container(c) => {
-                        let container = handler.insert_container(key, *c).unwrap();
+                        let container = handler.insert_container(key, Container::new(*c)).unwrap();
                         Some(container)
                     }
                 }

--- a/crates/fuzz/src/container/tree.rs
+++ b/crates/fuzz/src/container/tree.rs
@@ -169,7 +169,7 @@ impl Actionable for TreeAction {
                         None
                     }
                     FuzzValue::Container(c) => {
-                        let container = meta.insert_container(k, *c).unwrap();
+                        let container = meta.insert_container(k, Container::new(*c)).unwrap();
                         Some(container)
                     }
                 }

--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -45,6 +45,8 @@ pub enum LoroError {
     InvalidFrontierIdNotFound(ID),
     #[error("Cannot import when the doc is in a transaction")]
     ImportWhenInTxn,
+    #[error("The given method ({method}) is not allowed when the container is detached. You should insert the container to the doc first.")]
+    MisuseDettachedContainer { method: &'static str },
 }
 
 #[derive(Error, Debug)]

--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -49,6 +49,8 @@ pub enum LoroError {
     MisuseDettachedContainer { method: &'static str },
     #[error("Not implemented: {0}")]
     NotImplemented(&'static str),
+    #[error("Reattach a container that is already attached")]
+    ReattachAttachedContainer,
 }
 
 #[derive(Error, Debug)]

--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -47,6 +47,8 @@ pub enum LoroError {
     ImportWhenInTxn,
     #[error("The given method ({method}) is not allowed when the container is detached. You should insert the container to the doc first.")]
     MisuseDettachedContainer { method: &'static str },
+    #[error("Not implemented: {0}")]
+    NotImplemented(&'static str),
 }
 
 #[derive(Error, Debug)]

--- a/crates/loro-internal/benches/event.rs
+++ b/crates/loro-internal/benches/event.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 #[cfg(feature = "test_utils")]
 mod event {
     use super::*;
-    use loro_common::ContainerType;
+    
     use loro_internal::{ListHandler, LoroDoc};
     use std::sync::Arc;
 

--- a/crates/loro-internal/benches/event.rs
+++ b/crates/loro-internal/benches/event.rs
@@ -10,9 +10,7 @@ mod event {
         let mut ans = vec![];
         for idx in 0..children_num {
             let child_handler = handler
-                .insert_container(idx, ContainerType::List)
-                .unwrap()
-                .into_list()
+                .insert_container(idx, ListHandler::new_detached())
                 .unwrap();
             ans.push(child_handler);
         }

--- a/crates/loro-internal/examples/event.rs
+++ b/crates/loro-internal/examples/event.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use loro_common::ContainerType;
+
 use loro_internal::{
     delta::DeltaItem,
     event::Diff,

--- a/crates/loro-internal/examples/event.rs
+++ b/crates/loro-internal/examples/event.rs
@@ -5,7 +5,7 @@ use loro_internal::{
     delta::DeltaItem,
     event::Diff,
     handler::{Handler, ValueOrHandler},
-    LoroDoc, ToJson,
+    ListHandler, LoroDoc, MapHandler, TextHandler, ToJson, TreeHandler,
 };
 
 fn main() {
@@ -30,12 +30,12 @@ fn main() {
                                             let text = h
                                                 .as_map()
                                                 .unwrap()
-                                                .insert_container("text", ContainerType::Text)
+                                                .insert_container(
+                                                    "text",
+                                                    TextHandler::new_detached(),
+                                                )
                                                 .unwrap();
-                                            text.as_text()
-                                                .unwrap()
-                                                .insert(0, "created from event")
-                                                .unwrap();
+                                            text.insert(0, "created from event").unwrap();
                                         }
                                     }
                                     ValueOrHandler::Value(value) => {
@@ -54,10 +54,14 @@ fn main() {
         }
     }));
     list.insert(0, "abc").unwrap();
-    list.insert_container(1, ContainerType::List).unwrap();
-    list.insert_container(2, ContainerType::Map).unwrap();
-    list.insert_container(3, ContainerType::Text).unwrap();
-    list.insert_container(4, ContainerType::Tree).unwrap();
+    list.insert_container(1, ListHandler::new_detached())
+        .unwrap();
+    list.insert_container(2, MapHandler::new_detached())
+        .unwrap();
+    list.insert_container(3, TextHandler::new_detached())
+        .unwrap();
+    list.insert_container(4, TreeHandler::new_detached())
+        .unwrap();
     doc.commit_then_renew();
     assert_eq!(
         doc.get_deep_value().to_json(),

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -1099,9 +1099,7 @@ mod cursor_cache {
 
                 let offset = pos - c.pos;
                 let leaf = tree.get_leaf(c.leaf.into());
-                let Some(s) = leaf.elem().as_str() else {
-                    return None;
-                };
+                let s = leaf.elem().as_str()?;
 
                 let Some(offset) = pos_to_unicode_index(s, offset, pos_type) else {
                     continue;

--- a/crates/loro-internal/src/fuzz.rs
+++ b/crates/loro-internal/src/fuzz.rs
@@ -548,7 +548,8 @@ pub fn test_multi_sites(site_num: u8, actions: &mut [Action]) {
         let _e = s.enter();
         let diff = site
             .get_text("text")
-            .with_state(|s| s.to_diff(site.arena(), &site.get_global_txn(), &site.weak_state()));
+            .with_state(|s| Ok(s.to_diff(site.arena(), &site.get_global_txn(), &site.weak_state())))
+            .unwrap();
         let mut diff = diff.into_text().unwrap();
         compact(&mut diff);
         let mut text = text.lock().unwrap();

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -588,7 +588,11 @@ impl Actionable for Vec<Actor> {
                     }
                     FuzzValue::Container(c) => {
                         let handler = &container
-                            .insert_container_with_txn(&mut txn, &key.to_string(), *c)
+                            .insert_container_with_txn(
+                                &mut txn,
+                                &key.to_string(),
+                                Handler::new_unattached(*c),
+                            )
                             .unwrap();
                         let idx = handler.container_idx();
                         actor.add_new_container(idx, handler.id().clone(), *c);
@@ -630,7 +634,11 @@ impl Actionable for Vec<Actor> {
                     }
                     FuzzValue::Container(c) => {
                         let handler = &container
-                            .insert_container_with_txn(&mut txn, *key as usize, *c)
+                            .insert_container_with_txn(
+                                &mut txn,
+                                *key as usize,
+                                Handler::new_unattached(*c),
+                            )
                             .unwrap();
                         let idx = handler.container_idx();
                         actor.add_new_container(idx, handler.id().clone(), *c);

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -341,7 +341,7 @@ trait Actionable {
 }
 
 impl Actor {
-    fn add_new_container(&mut self, idx: ContainerIdx, id: ContainerID, type_: ContainerType) {
+    fn add_new_container(&mut self, _idx: ContainerIdx, id: ContainerID, type_: ContainerType) {
         let txn = self.loro.get_global_txn();
         let handler = Handler::new_attached(
             id,

--- a/crates/loro-internal/src/fuzz/recursive_refactored.rs
+++ b/crates/loro-internal/src/fuzz/recursive_refactored.rs
@@ -343,7 +343,7 @@ trait Actionable {
 impl Actor {
     fn add_new_container(&mut self, idx: ContainerIdx, id: ContainerID, type_: ContainerType) {
         let txn = self.loro.get_global_txn();
-        let handler = Handler::new(
+        let handler = Handler::new_attached(
             id,
             self.loro.arena().clone(),
             txn,

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -16,7 +16,7 @@ use crate::{
     arena::SharedArena,
     change::Timestamp,
     configure::Configure,
-    container::{idx::ContainerIdx, richtext::config::StyleConfigMap, IntoContainerId},
+    container::{richtext::config::StyleConfigMap, IntoContainerId},
     dag::DagUtils,
     encoding::{
         decode_snapshot, export_snapshot, parse_header_and_body, EncodeMode, ParsedHeaderAndBody,
@@ -620,12 +620,6 @@ impl LoroDoc {
     #[inline]
     pub fn diagnose_size(&self) {
         self.oplog().lock().unwrap().diagnose_size();
-    }
-
-    #[inline]
-    fn get_container_idx<I: IntoContainerId>(&self, id: I, c_type: ContainerType) -> ContainerIdx {
-        let id = id.into_container_id(&self.arena, c_type);
-        self.arena.register_container(&id)
     }
 
     #[inline]

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -561,7 +561,7 @@ impl LoroDoc {
     #[inline]
     pub fn get_text<I: IntoContainerId>(&self, id: I) -> TextHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Text);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.get_global_txn(),
@@ -576,7 +576,7 @@ impl LoroDoc {
     #[inline]
     pub fn get_list<I: IntoContainerId>(&self, id: I) -> ListHandler {
         let id = id.into_container_id(&self.arena, ContainerType::List);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.get_global_txn(),
@@ -591,7 +591,7 @@ impl LoroDoc {
     #[inline]
     pub fn get_map<I: IntoContainerId>(&self, id: I) -> MapHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Map);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.get_global_txn(),
@@ -606,7 +606,7 @@ impl LoroDoc {
     #[inline]
     pub fn get_tree<I: IntoContainerId>(&self, id: I) -> TreeHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Tree);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.get_global_txn(),

--- a/crates/loro-internal/src/oplog/dag.rs
+++ b/crates/loro-internal/src/oplog/dag.rs
@@ -166,12 +166,8 @@ impl AppDag {
     pub fn frontiers_to_vv(&self, frontiers: &Frontiers) -> Option<VersionVector> {
         let mut vv: VersionVector = Default::default();
         for id in frontiers.iter() {
-            let Some(rle) = self.map.get(&id.peer) else {
-                return None;
-            };
-            let Some(x) = rle.get_by_atom_index(id.counter) else {
-                return None;
-            };
+            let rle = self.map.get(&id.peer)?;
+            let x = rle.get_by_atom_index(id.counter)?;
             vv.extend_to_include_vv(x.element.vv.iter());
             vv.extend_to_include_last_id(*id);
         }

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -693,6 +693,7 @@ impl DocState {
     }
 
     #[inline(always)]
+    #[allow(unused)]
     pub(crate) fn with_state<F, R>(&mut self, idx: ContainerIdx, f: F) -> R
     where
         F: FnOnce(&State) -> R,

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -379,7 +379,7 @@ impl Transaction {
     /// if it's str it will use Root container, which will not be None
     pub fn get_text<I: IntoContainerId>(&self, id: I) -> TextHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Text);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.global_txn.clone(),
@@ -393,7 +393,7 @@ impl Transaction {
     /// if it's str it will use Root container, which will not be None
     pub fn get_list<I: IntoContainerId>(&self, id: I) -> ListHandler {
         let id = id.into_container_id(&self.arena, ContainerType::List);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.global_txn.clone(),
@@ -407,7 +407,7 @@ impl Transaction {
     /// if it's str it will use Root container, which will not be None
     pub fn get_map<I: IntoContainerId>(&self, id: I) -> MapHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Map);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.global_txn.clone(),
@@ -421,7 +421,7 @@ impl Transaction {
     /// if it's str it will use Root container, which will not be None
     pub fn get_tree<I: IntoContainerId>(&self, id: I) -> TreeHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Tree);
-        Handler::new(
+        Handler::new_attached(
             id,
             self.arena.clone(),
             self.global_txn.clone(),

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -431,11 +431,6 @@ impl Transaction {
         .unwrap()
     }
 
-    fn get_container_idx<I: IntoContainerId>(&self, id: I, c_type: ContainerType) -> ContainerIdx {
-        let id = id.into_container_id(&self.arena, c_type);
-        self.arena.register_container(&id)
-    }
-
     pub fn get_value_by_idx(&self, idx: ContainerIdx) -> LoroValue {
         self.state.lock().unwrap().get_value_by_idx(idx)
     }

--- a/crates/loro-internal/tests/autocommit.rs
+++ b/crates/loro-internal/tests/autocommit.rs
@@ -1,5 +1,5 @@
 use loro_common::ID;
-use loro_internal::{version::Frontiers, HandlerTrait, LoroDoc, ToJson};
+use loro_internal::{version::Frontiers, HandlerTrait, LoroDoc, TextHandler, ToJson};
 use serde_json::json;
 
 #[test]
@@ -32,9 +32,9 @@ fn auto_commit_list() {
     list_a.insert(0, "hello").unwrap();
     assert_eq!(list_a.get_value().to_json_value(), json!(["hello"]));
     let text_a = list_a
-        .insert_container(0, loro_common::ContainerType::Text)
+        .insert_container(0, TextHandler::new_detached())
         .unwrap();
-    let text = text_a.into_text().unwrap();
+    let text = text_a;
     text.insert(0, "world").unwrap();
     let value = doc_a.get_deep_value();
     assert_eq!(value.to_json_value(), json!({"list": ["world", "hello"]}))

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -183,7 +183,7 @@ fn list() {
 
     let cid = map.id();
     let id = a.get_list("list").get(1);
-    assert_eq!(id.as_ref().unwrap().as_container().unwrap(), cid);
+    assert_eq!(id.as_ref().unwrap().as_container().unwrap(), &cid);
     let map = a.get_map(id.unwrap().into_container().unwrap());
     let new_pos = a.get_map(map.get("pos").unwrap().into_container().unwrap());
     assert_eq!(
@@ -220,7 +220,7 @@ fn richtext_mark_event() {
     a.commit_then_stop();
     let b = LoroDoc::new_auto_commit();
     b.subscribe(
-        a.get_text("text").id(),
+        &a.get_text("text").id(),
         Arc::new(|e| {
             let delta = e.events[0].diff.as_text().unwrap();
             assert_eq!(

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -7,14 +7,15 @@ use loro_internal::handler::{Handler, ValueOrHandler};
 use loro_internal::{LoroDoc, LoroValue};
 use wasm_bindgen::JsValue;
 
-use crate::{Container, LoroList, LoroMap, LoroText, LoroTree};
+use crate::{Container, JsContainer, LoroList, LoroMap, LoroText, LoroTree};
 use wasm_bindgen::__rt::IntoJsResult;
 use wasm_bindgen::convert::RefFromWasmAbi;
 
 /// Convert a `JsValue` to `T` by constructor's name.
 ///
 /// more details can be found in https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-656293288
-pub(crate) fn js_to_container(js: JsValue) -> Result<Container, JsValue> {
+pub(crate) fn js_to_container(js: JsContainer) -> Result<Container, JsValue> {
+    let js: JsValue = js.into();
     if !js.is_object() {
         return Err(JsValue::from_str(&format!(
             "Value supplied is not an object, but {:?}",

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -7,61 +7,57 @@ use loro_internal::handler::{Handler, ValueOrHandler};
 use loro_internal::{LoroDoc, LoroValue};
 use wasm_bindgen::JsValue;
 
-use crate::{LoroList, LoroMap, LoroText, LoroTree};
+use crate::{Container, LoroList, LoroMap, LoroText, LoroTree};
 use wasm_bindgen::__rt::IntoJsResult;
-use wasm_bindgen::convert::FromWasmAbi;
+use wasm_bindgen::convert::RefFromWasmAbi;
 
 /// Convert a `JsValue` to `T` by constructor's name.
 ///
 /// more details can be found in https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-656293288
-pub(crate) fn js_to_any<T: FromWasmAbi<Abi = u32>>(
-    js: JsValue,
-    struct_name: &str,
-) -> Result<T, JsValue> {
+pub(crate) fn js_to_container(js: JsValue) -> Result<Container, JsValue> {
     if !js.is_object() {
-        return Err(JsValue::from_str(
-            format!("Value supplied as {} is not an object", struct_name).as_str(),
-        ));
+        return Err(JsValue::from_str(&format!(
+            "Value supplied is not an object, but {:?}",
+            js
+        )));
     }
     let ctor_name = Object::get_prototype_of(&js).constructor().name();
-    if ctor_name == struct_name {
-        let ptr = Reflect::get(&js, &JsValue::from_str("ptr"))?;
-        let ptr_u32: u32 = ptr.as_f64().ok_or(JsValue::NULL)? as u32;
-        let obj = unsafe { T::from_abi(ptr_u32) };
-        Ok(obj)
-    } else {
-        return Err(JsValue::from_str(
-            format!(
-                "Value ctor_name is {} but the required struct name is {}",
-                ctor_name, struct_name
-            )
-            .as_str(),
-        ));
-    }
-}
+    let Ok(ptr) = Reflect::get(&js, &JsValue::from_str("__wbg_ptr")) else {
+        return Err(JsValue::from_str("Cannot find pointer field"));
+    };
+    let ptr_u32: u32 = ptr.as_f64().unwrap() as u32;
+    let ctor_name = ctor_name
+        .as_string()
+        .ok_or(JsValue::from_str("Constructor name is not a string"))?;
+    let container = match ctor_name.as_str() {
+        "LoroText" => {
+            let obj = unsafe { LoroText::ref_from_abi(ptr_u32) };
+            Container::Text(obj.clone())
+        }
+        "LoroMap" => {
+            let obj = unsafe { LoroMap::ref_from_abi(ptr_u32) };
+            Container::Map(obj.clone())
+        }
+        "LoroList" => {
+            let obj = unsafe { LoroList::ref_from_abi(ptr_u32) };
+            Container::List(obj.clone())
+        }
+        "LoroTree" => {
+            let obj = unsafe { LoroTree::ref_from_abi(ptr_u32) };
+            Container::Tree(obj.clone())
+        }
+        _ => {
+            return Err(JsValue::from_str(
+                format!(
+                    "Value ctor_name is {} but the valid container name is LoroMap, LoroList, LoroText or LoroTree",
+                    ctor_name
+                )
+                .as_str(),
+            ));
+        }
+    };
 
-impl TryFrom<JsValue> for LoroText {
-    type Error = JsValue;
-
-    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
-        js_to_any(value, "LoroText")
-    }
-}
-
-impl TryFrom<JsValue> for LoroList {
-    type Error = JsValue;
-
-    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
-        js_to_any(value, "LoroList")
-    }
-}
-
-impl TryFrom<JsValue> for LoroMap {
-    type Error = JsValue;
-
-    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
-        js_to_any(value, "LoroMap")
-    }
+    Ok(container)
 }
 
 pub(crate) fn resolved_diff_to_js(value: &Diff, doc: &Arc<LoroDoc>) -> JsValue {
@@ -130,7 +126,7 @@ fn delta_item_to_js(item: DeltaItem<Vec<ValueOrHandler>, ()>, doc: &Arc<LoroDoc>
             for (i, v) in value.into_iter().enumerate() {
                 let value = match v {
                     ValueOrHandler::Value(v) => convert(v),
-                    ValueOrHandler::Handler(h) => handler_to_js_value(h, doc.clone()),
+                    ValueOrHandler::Handler(h) => handler_to_js_value(h, Some(doc.clone())),
                 };
                 arr.set(i as u32, value);
             }
@@ -198,7 +194,7 @@ fn map_delta_to_js(value: &ResolvedMapDelta, doc: &Arc<LoroDoc>) -> JsValue {
         let value = if let Some(value) = value.value.clone() {
             match value {
                 ValueOrHandler::Value(v) => convert(v),
-                ValueOrHandler::Handler(h) => handler_to_js_value(h, doc.clone()),
+                ValueOrHandler::Handler(h) => handler_to_js_value(h, Some(doc.clone())),
             }
         } else {
             JsValue::null()
@@ -210,7 +206,7 @@ fn map_delta_to_js(value: &ResolvedMapDelta, doc: &Arc<LoroDoc>) -> JsValue {
     obj.into_js_result().unwrap()
 }
 
-pub(crate) fn handler_to_js_value(handler: Handler, doc: Arc<LoroDoc>) -> JsValue {
+pub(crate) fn handler_to_js_value(handler: Handler, doc: Option<Arc<LoroDoc>>) -> JsValue {
     match handler {
         Handler::Text(t) => LoroText { handler: t, doc }.into(),
         Handler::Map(m) => LoroMap { handler: m, doc }.into(),

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1278,7 +1278,7 @@ impl LoroText {
     /// Get the container id of the text.
     #[wasm_bindgen(js_name = "id", method, getter)]
     pub fn id(&self) -> JsContainerID {
-        let value: JsValue = self.handler.id().into();
+        let value: JsValue = (&self.handler.id()).into();
         value.into()
     }
 
@@ -1516,7 +1516,7 @@ impl LoroMap {
     /// The container id of this handler.
     #[wasm_bindgen(js_name = "id", method, getter)]
     pub fn id(&self) -> JsContainerID {
-        let value: JsValue = self.handler.id().into();
+        let value: JsValue = (&self.handler.id()).into();
         value.into()
     }
 
@@ -1711,7 +1711,7 @@ impl LoroList {
     /// Get the id of this container.
     #[wasm_bindgen(js_name = "id", method, getter)]
     pub fn id(&self) -> JsContainerID {
-        let value: JsValue = self.handler.id().into();
+        let value: JsValue = (&self.handler.id()).into();
         value.into()
     }
 
@@ -2089,7 +2089,7 @@ impl LoroTree {
     /// Get the id of the container.
     #[wasm_bindgen(js_name = "id", method, getter)]
     pub fn id(&self) -> JsContainerID {
-        let value: JsValue = self.handler.id().into();
+        let value: JsValue = (&self.handler.id()).into();
         value.into()
     }
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -98,6 +98,14 @@ extern "C" {
     pub type JsValueOrContainerOrUndefined;
     #[wasm_bindgen(typescript_type = "Container | undefined")]
     pub type JsContainerOrUndefined;
+    #[wasm_bindgen(typescript_type = "LoroText | undefined")]
+    pub type JsLoroTextOrUndefined;
+    #[wasm_bindgen(typescript_type = "LoroMap | undefined")]
+    pub type JsLoroMapOrUndefined;
+    #[wasm_bindgen(typescript_type = "LoroList | undefined")]
+    pub type JsLoroListOrUndefined;
+    #[wasm_bindgen(typescript_type = "LoroTree | undefined")]
+    pub type JsLoroTreeOrUndefined;
     #[wasm_bindgen(typescript_type = "[string, Value | Container]")]
     pub type MapEntry;
     #[wasm_bindgen(typescript_type = "{[key: string]: { expand: 'before'|'after'|'none'|'both' }}")]
@@ -1366,6 +1374,26 @@ impl LoroText {
             JsContainerOrUndefined::from(JsValue::UNDEFINED)
         }
     }
+
+    /// Whether the container is attached to a docuemnt.
+    ///
+    /// If it's detached, the operations on the container will not be persisted.
+    #[wasm_bindgen(js_name = "isAttached")]
+    pub fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    /// Get the attached container associated with this.
+    ///
+    /// Returns an attached `Container` that equals to this or created by this, otherwise `undefined`.
+    #[wasm_bindgen(js_name = "getAttached")]
+    pub fn get_attached(&self) -> JsLoroTextOrUndefined {
+        if let Some(h) = self.handler.get_attached() {
+            handler_to_js_value(Handler::Text(h), self.doc.clone()).into()
+        } else {
+            JsValue::UNDEFINED.into()
+        }
+    }
 }
 
 /// The handler of a map container.
@@ -1661,6 +1689,25 @@ impl LoroMap {
             JsContainerOrUndefined::from(JsValue::UNDEFINED)
         }
     }
+
+    /// Whether the container is attached to a docuemnt.
+    ///
+    /// If it's detached, the operations on the container will not be persisted.
+    #[wasm_bindgen(js_name = "isAttached")]
+    pub fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    /// Get the attached container associated with this.
+    ///
+    /// Returns an attached `Container` that equals to this or created by this, otherwise `undefined`.
+    #[wasm_bindgen(js_name = "getAttached")]
+    pub fn get_attached(&self) -> JsLoroMapOrUndefined {
+        let Some(h) = self.handler.get_attached() else {
+            return JsValue::UNDEFINED.into();
+        };
+        handler_to_js_value(Handler::Map(h), self.doc.clone()).into()
+    }
 }
 
 impl Default for LoroMap {
@@ -1907,6 +1954,26 @@ impl LoroList {
             handler_to_js_value(p, self.doc.clone()).into()
         } else {
             JsContainerOrUndefined::from(JsValue::UNDEFINED)
+        }
+    }
+
+    /// Whether the container is attached to a docuemnt.
+    ///
+    /// If it's detached, the operations on the container will not be persisted.
+    #[wasm_bindgen(js_name = "isAttached")]
+    pub fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    /// Get the attached container associated with this.
+    ///
+    /// Returns an attached `Container` that equals to this or created by this, otherwise `undefined`.
+    #[wasm_bindgen(js_name = "getAttached")]
+    pub fn get_attached(&self) -> JsLoroListOrUndefined {
+        if let Some(h) = self.handler.get_attached() {
+            handler_to_js_value(Handler::List(h), self.doc.clone()).into()
+        } else {
+            JsValue::UNDEFINED.into()
         }
     }
 }
@@ -2289,6 +2356,26 @@ impl LoroTree {
             handler_to_js_value(p, self.doc.clone()).into()
         } else {
             JsContainerOrUndefined::from(JsValue::UNDEFINED)
+        }
+    }
+
+    /// Whether the container is attached to a docuemnt.
+    ///
+    /// If it's detached, the operations on the container will not be persisted.
+    #[wasm_bindgen(js_name = "isAttached")]
+    pub fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    /// Get the attached container associated with this.
+    ///
+    /// Returns an attached `Container` that equals to this or created by this, otherwise `undefined`.
+    #[wasm_bindgen(js_name = "getAttached")]
+    pub fn get_attached(&self) -> JsLoroTreeOrUndefined {
+        if let Some(h) = self.handler.get_attached() {
+            handler_to_js_value(Handler::Tree(h), self.doc.clone()).into()
+        } else {
+            JsValue::UNDEFINED.into()
         }
     }
 }

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -810,9 +810,9 @@ impl Loro {
     /// const doc = new Loro();
     /// const list = doc.getList("list");
     /// list.insert(0, "Hello");
-    /// const text = list.insertContainer(0, "Text");
+    /// const text = list.insertContainer(0, new LoroText());
     /// text.insert(0, "Hello");
-    /// const map = list.insertContainer(1, "Map");
+    /// const map = list.insertContainer(1, new LoroMap());
     /// map.set("foo", "bar");
     /// /*
     /// {"list": ["Hello", {"foo": "bar"}]}
@@ -1586,7 +1586,7 @@ impl LoroMap {
     /// const doc = new Loro();
     /// const map = doc.getMap("map");
     /// map.set("foo", "bar");
-    /// const text = map.setContainer("text", "Text");
+    /// const text = map.setContainer("text", new LoroText());
     /// text.insert(0, "Hello");
     /// console.log(map.getDeepValue());  // {"foo": "bar", "text": "Hello"}
     /// ```
@@ -1604,8 +1604,8 @@ impl LoroMap {
     /// const doc = new Loro();
     /// const map = doc.getMap("map");
     /// map.set("foo", "bar");
-    /// const text = map.setContainer("text", "Text");
-    /// const list = map.setContainer("list", "List");
+    /// const text = map.setContainer("text", new LoroText());
+    /// const list = map.setContainer("list", new LoroText());
     /// ```
     #[wasm_bindgen(js_name = "setContainer")]
     pub fn insert_container(&mut self, key: &str, child: JsValue) -> JsResult<JsContainer> {
@@ -1821,7 +1821,7 @@ impl LoroList {
     /// list.insert(0, 100);
     /// list.insert(1, "foo");
     /// list.insert(2, true);
-    /// list.insertContainer(3, "Text");
+    /// list.insertContainer(3, new LoroText());
     /// console.log(list.value);  // [100, "foo", true, LoroText];
     /// ```
     #[wasm_bindgen(js_name = "toArray", method)]
@@ -1852,7 +1852,7 @@ impl LoroList {
     /// const doc = new Loro();
     /// const list = doc.getList("list");
     /// list.insert(0, 100);
-    /// const text = list.insertContainer(1, "Text");
+    /// const text = list.insertContainer(1, new LoroText());
     /// text.insert(0, "Hello");
     /// console.log(list.getDeepValue());  // [100, "Hello"];
     /// ```
@@ -1871,7 +1871,7 @@ impl LoroList {
     /// const doc = new Loro();
     /// const list = doc.getList("list");
     /// list.insert(0, 100);
-    /// const text = list.insertContainer(1, "Text");
+    /// const text = list.insertContainer(1, new LoroText());
     /// text.insert(0, "Hello");
     /// console.log(list.getDeepValue());  // [100, "Hello"];
     /// ```

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1396,6 +1396,12 @@ impl LoroText {
     }
 }
 
+impl Default for LoroText {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// The handler of a map container.
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -1493,14 +1499,12 @@ impl LoroMap {
     /// const bar = map.get("foo");
     /// ```
     #[wasm_bindgen(js_name = "getOrCreateContainer")]
-    pub fn get_or_create_container(
-        &self,
-        key: &str,
-        container_type: &str,
-    ) -> JsResult<JsContainerOrUndefined> {
-        let type_: ContainerType = container_type.try_into()?;
-        let v = self.handler.get_or_create_container_(key, type_)?;
-        Ok(handler_to_js_value(v, self.doc.clone()).into())
+    pub fn get_or_create_container(&self, key: &str, child: JsContainer) -> JsResult<JsContainer> {
+        let child = convert::js_to_container(child)?;
+        let handler = self
+            .handler
+            .get_or_create_container(key, child.to_handler())?;
+        Ok(handler_to_js_value(handler, self.doc.clone()).into())
     }
 
     /// Get the keys of the map.
@@ -1608,7 +1612,7 @@ impl LoroMap {
     /// const list = map.setContainer("list", new LoroText());
     /// ```
     #[wasm_bindgen(js_name = "setContainer")]
-    pub fn insert_container(&mut self, key: &str, child: JsValue) -> JsResult<JsContainer> {
+    pub fn insert_container(&mut self, key: &str, child: JsContainer) -> JsResult<JsContainer> {
         let child = convert::js_to_container(child)?;
         let c = self.handler.insert_container(key, child.to_handler())?;
         Ok(handler_to_js_value(c, self.doc.clone()).into())
@@ -1876,7 +1880,7 @@ impl LoroList {
     /// console.log(list.getDeepValue());  // [100, "Hello"];
     /// ```
     #[wasm_bindgen(js_name = "insertContainer")]
-    pub fn insert_container(&mut self, index: usize, child: JsValue) -> JsResult<JsContainer> {
+    pub fn insert_container(&mut self, index: usize, child: JsContainer) -> JsResult<JsContainer> {
         let child = js_to_container(child)?;
         let c = self.handler.insert_container(index, child.to_handler())?;
         Ok(handler_to_js_value(c, self.doc.clone()).into())

--- a/crates/loro/README.md
+++ b/crates/loro/README.md
@@ -11,7 +11,7 @@ PS: Version control is forthcoming. Time travel functionality is already accessi
 ## Map/List/Text
 
 ```rust
-use loro::{LoroDoc, ToJson, LoroValue};
+use loro::{LoroDoc, LoroList, LoroText, LoroValue, ToJson};
 use serde_json::json;
 
 let doc = LoroDoc::new();
@@ -21,16 +21,10 @@ map.insert("true", true).unwrap();
 map.insert("null", LoroValue::Null).unwrap();
 map.insert("deleted", LoroValue::Null).unwrap();
 map.delete("deleted").unwrap();
-let list = map
-    .insert_container("list", loro_internal::ContainerType::List).unwrap()
-    .into_list()
-    .unwrap();
-list.insert(0, "List");
-list.insert(1, 9);
-let text = map
-    .insert_container("text", loro_internal::ContainerType::Text).unwrap()
-    .into_text()
-    .unwrap();
+let list = map.insert_container("list", LoroList::new()).unwrap();
+list.insert(0, "List").unwrap();
+list.insert(1, 9).unwrap();
+let text = map.insert_container("text", LoroText::new()).unwrap();
 text.insert(0, "Hello world!").unwrap();
 assert_eq!(
     doc.get_deep_value().to_json_value(),

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -364,6 +364,11 @@ pub trait ContainerTrait: SealedTrait {
     fn to_container(&self) -> Container;
     fn to_handler(&self) -> Self::Handler;
     fn from_handler(handler: Self::Handler) -> Self;
+    fn is_attached(&self) -> bool;
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    fn get_attached(&self) -> Option<Self>
+    where
+        Self: Sized;
 }
 
 /// LoroList container. It's used to model array.
@@ -402,6 +407,14 @@ impl ContainerTrait for LoroList {
 
     fn from_handler(handler: Self::Handler) -> Self {
         Self { handler }
+    }
+
+    fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    fn get_attached(&self) -> Option<Self> {
+        self.handler.get_attached().map(Self::from_handler)
     }
 }
 
@@ -570,6 +583,14 @@ impl ContainerTrait for LoroMap {
     fn from_handler(handler: Self::Handler) -> Self {
         Self { handler }
     }
+
+    fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    fn get_attached(&self) -> Option<Self> {
+        self.handler.get_attached().map(Self::from_handler)
+    }
 }
 
 impl LoroMap {
@@ -677,6 +698,14 @@ impl ContainerTrait for LoroText {
 
     fn from_handler(handler: Self::Handler) -> Self {
         Self { handler }
+    }
+
+    fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    fn get_attached(&self) -> Option<Self> {
+        self.handler.get_attached().map(Self::from_handler)
     }
 }
 
@@ -844,6 +873,14 @@ impl ContainerTrait for LoroTree {
 
     fn from_handler(handler: Self::Handler) -> Self {
         Self { handler }
+    }
+
+    fn is_attached(&self) -> bool {
+        self.handler.is_attached()
+    }
+
+    fn get_attached(&self) -> Option<Self> {
+        self.handler.get_attached().map(Self::from_handler)
     }
 }
 
@@ -1026,6 +1063,24 @@ impl ContainerTrait for Container {
             InnerHandler::Map(x) => Container::Map(LoroMap { handler: x }),
             InnerHandler::List(x) => Container::List(LoroList { handler: x }),
             InnerHandler::Tree(x) => Container::Tree(LoroTree { handler: x }),
+        }
+    }
+
+    fn is_attached(&self) -> bool {
+        match self {
+            Container::List(x) => x.is_attached(),
+            Container::Map(x) => x.is_attached(),
+            Container::Text(x) => x.is_attached(),
+            Container::Tree(x) => x.is_attached(),
+        }
+    }
+
+    fn get_attached(&self) -> Option<Self> {
+        match self {
+            Container::List(x) => x.get_attached().map(Container::List),
+            Container::Map(x) => x.get_attached().map(Container::Map),
+            Container::Text(x) => x.get_attached().map(Container::Text),
+            Container::Tree(x) => x.get_attached().map(Container::Tree),
         }
     }
 }

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -1,18 +1,16 @@
 use std::{cmp::Ordering, sync::Arc};
 
-use loro::{FrontiersNotIncluded, LoroDoc, LoroError, ToJson};
+use loro::{FrontiersNotIncluded, LoroDoc, LoroError, LoroMap, LoroText, ToJson};
 use loro_internal::{handler::TextDelta, id::ID, LoroResult};
 use serde_json::json;
 
 #[test]
 fn list_checkout() -> Result<(), LoroError> {
     let doc = LoroDoc::new();
-    doc.get_list("list")
-        .insert_container(0, loro::ContainerType::Map)?;
+    doc.get_list("list").insert_container(0, LoroMap::new())?;
     doc.commit();
     let f0 = doc.state_frontiers();
-    doc.get_list("list")
-        .insert_container(0, loro::ContainerType::Text)?;
+    doc.get_list("list").insert_container(0, LoroText::new())?;
     doc.commit();
     let f1 = doc.state_frontiers();
     doc.get_list("list").delete(1, 1)?;
@@ -263,10 +261,7 @@ fn map() -> LoroResult<()> {
     map.insert("null", LoroValue::Null)?;
     map.insert("deleted", LoroValue::Null)?;
     map.delete("deleted")?;
-    let text = map
-        .insert_container("text", loro_internal::ContainerType::Text)?
-        .into_text()
-        .unwrap();
+    let text = map.insert_container("text", LoroText::new())?;
     text.insert(0, "Hello world!")?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, sync::Arc};
 
 use loro::{FrontiersNotIncluded, LoroDoc, LoroError, LoroList, LoroMap, LoroText, ToJson};
-use loro_internal::{handler::TextDelta, id::ID, op::ListSlice, LoroResult};
+use loro_internal::{handler::TextDelta, id::ID, LoroResult};
 use serde_json::json;
 
 #[test]

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, sync::Arc};
 
 use loro::{FrontiersNotIncluded, LoroDoc, LoroError, LoroList, LoroMap, LoroText, ToJson};
-use loro_internal::{handler::TextDelta, id::ID, LoroResult};
+use loro_internal::{handler::TextDelta, id::ID, op::ListSlice, LoroResult};
 use serde_json::json;
 
 #[test]
@@ -437,4 +437,18 @@ fn prelim_support() -> LoroResult<()> {
         })
     );
     Ok(())
+}
+
+#[test]
+fn init_example() {
+    // create meta/users/0/new_user/{name: string, bio: Text}
+    let doc = LoroDoc::new();
+    let meta = doc.get_map("meta");
+    let user = meta
+        .get_or_create_container("users", LoroList::new())
+        .unwrap()
+        .insert_container(0, LoroMap::new())
+        .unwrap();
+    user.insert("name", "new_user").unwrap();
+    user.insert_container("bio", LoroText::new()).unwrap();
 }

--- a/crates/loro/tests/readme.rs
+++ b/crates/loro/tests/readme.rs
@@ -1,5 +1,6 @@
 #[test]
 fn readme_basic() {
+    use loro::ContainerTrait;
     use loro::{LoroDoc, LoroList, LoroText, LoroValue, ToJson};
     use serde_json::json;
 
@@ -13,8 +14,10 @@ fn readme_basic() {
     let list = map.insert_container("list", LoroList::new()).unwrap();
     list.insert(0, "List").unwrap();
     list.insert(1, 9).unwrap();
-    let text = map.insert_container("text", LoroText::new()).unwrap();
-    text.insert(0, "Hello world!").unwrap();
+    let old_text = LoroText::new();
+    old_text.insert(0, "Hello ").unwrap();
+    let text = map.insert_container("text", old_text.clone()).unwrap();
+    text.insert(6, "world!").unwrap();
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
@@ -24,6 +27,20 @@ fn readme_basic() {
                 "null": null,
                 "list": ["List", 9],
                 "text": "Hello world!"
+            }
+        })
+    );
+    let new_text = old_text.get_attached().unwrap();
+    new_text.insert(0, "New ").unwrap();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({
+            "map": {
+                "key": "value",
+                "true": true,
+                "null": null,
+                "list": ["List", 9],
+                "text": "New Hello world!"
             }
         })
     );

--- a/crates/loro/tests/readme.rs
+++ b/crates/loro/tests/readme.rs
@@ -1,0 +1,30 @@
+#[test]
+fn readme_basic() {
+    use loro::{LoroDoc, LoroList, LoroText, LoroValue, ToJson};
+    use serde_json::json;
+
+    let doc = LoroDoc::new();
+    let map = doc.get_map("map");
+    map.insert("key", "value").unwrap();
+    map.insert("true", true).unwrap();
+    map.insert("null", LoroValue::Null).unwrap();
+    map.insert("deleted", LoroValue::Null).unwrap();
+    map.delete("deleted").unwrap();
+    let list = map.insert_container("list", LoroList::new()).unwrap();
+    list.insert(0, "List").unwrap();
+    list.insert(1, 9).unwrap();
+    let text = map.insert_container("text", LoroText::new()).unwrap();
+    text.insert(0, "Hello world!").unwrap();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({
+            "map": {
+                "key": "value",
+                "true": true,
+                "null": null,
+                "list": ["List", 9],
+                "text": "Hello world!"
+            }
+        })
+    );
+}

--- a/loro-js/package.json
+++ b/loro-js/package.json
@@ -38,6 +38,6 @@
     "typescript": "^5.0.2",
     "vite": "^4.2.1",
     "vite-plugin-wasm": "^3.2.2",
-    "vitest": "^1.0.4"
+    "vitest": "^1.4.0"
   }
 }

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -1,17 +1,17 @@
 export * from "loro-wasm";
 import {
   Container,
+  ContainerID,
   Delta,
+  Loro,
+  LoroList,
+  LoroMap,
   LoroText,
   LoroTree,
   LoroTreeNode,
   OpId,
-  Value,
-  ContainerID,
-  Loro,
-  LoroList,
-  LoroMap,
   TreeID,
+  Value,
 } from "loro-wasm";
 
 Loro.prototype.getTypedMap = function (...args) {
@@ -179,14 +179,10 @@ export function isContainer(value: any): value is Container {
  */
 export function getType<T>(
   value: T,
-): T extends LoroText
-  ? "Text"
-  : T extends LoroMap
-  ? "Map"
-  : T extends LoroTree
-  ? "Tree"
-  : T extends LoroList
-  ? "List"
+): T extends LoroText ? "Text"
+  : T extends LoroMap ? "Map"
+  : T extends LoroTree ? "Tree"
+  : T extends LoroList ? "List"
   : "Json" {
   if (isContainer(value)) {
     return value.kind();
@@ -210,11 +206,7 @@ declare module "loro-wasm" {
   }
 
   interface LoroList<T extends any[] = any[]> {
-    insertContainer(pos: number, container: "Map"): LoroMap;
-    insertContainer(pos: number, container: "List"): LoroList;
-    insertContainer(pos: number, container: "Text"): LoroText;
-    insertContainer(pos: number, container: "Tree"): LoroTree;
-    insertContainer(pos: number, container: string): never;
+    insertContainer<C extends Container>(pos: number, child: C): C;
 
     get(index: number): undefined | Value | Container;
     getTyped<Key extends keyof T & number>(loro: Loro, index: Key): T[Key];
@@ -231,11 +223,7 @@ declare module "loro-wasm" {
     getOrCreateContainer(key: string, container_type: "Tree"): LoroTree;
     getOrCreateContainer(key: string, container_type: string): never;
 
-    setContainer(key: string, container_type: "Map"): LoroMap;
-    setContainer(key: string, container_type: "List"): LoroList;
-    setContainer(key: string, container_type: "Text"): LoroText;
-    setContainer(key: string, container_type: "Tree"): LoroTree;
-    setContainer(key: string, container_type: string): never;
+    setContainer<C extends Container>(key: string, child: C): C;
 
     get(key: string): undefined | Value | Container;
     getTyped<Key extends keyof T & string>(txn: Loro, key: Key): T[Key];

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -211,6 +211,7 @@ declare module "loro-wasm" {
     get(index: number): undefined | Value | Container;
     getTyped<Key extends keyof T & number>(loro: Loro, index: Key): T[Key];
     insertTyped<Key extends keyof T & number>(pos: Key, value: T[Key]): void;
+    insert(pos: number, value: Container): never;
     insert(pos: number, value: Value): void;
     delete(pos: number, len: number): void;
     subscribe(txn: Loro, listener: Listener): number;

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -410,11 +410,18 @@ it("prelim support", () => {
   const map = new LoroMap();
   map.set("3", 2);
   const list = new LoroList();
-  list.insert(0, map);
+  list.insertContainer(0, map);
   // map should still be valid
   map.set("9", 9);
   // the type of setContainer/insertContainer changed
   const text = map.setContainer("text", new LoroText());
+  {
+    // Changes will be reflected in the container tree
+    text.insert(0, "Heello");
+    expect(list.toJson()).toStrictEqual([{ "3": 2, "9": 9, text: "Heello" }]);
+    text.delete(1, 1);
+    expect(list.toJson()).toStrictEqual([{ "3": 2, "9": 9, text: "Hello" }]);
+  }
   const doc = new Loro();
   const rootMap = doc.getMap("map");
   rootMap.setContainer("test", map); // new way to create sub-container
@@ -423,15 +430,15 @@ it("prelim support", () => {
   const attachedText = text.getAttached()!;
   expect(text.isAttached()).toBeFalsy();
   expect(attachedText.isAttached()).toBeTruthy();
-  text.insert(0, "Detached");
-  attachedText.insert(0, "Attached");
-  expect(text.toString()).toBe("Detached");
+  text.insert(0, "Detached ");
+  attachedText.insert(0, "Attached ");
+  expect(text.toString()).toBe("Detached Hello");
   expect(doc.toJson()).toStrictEqual({
     map: {
       test: {
         "3": 2,
         "9": 9,
-        text: "Attached",
+        text: "Attached Hello",
       },
     },
   });

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -6,9 +6,9 @@ import {
   LoroList,
   LoroMap,
   LoroText,
-  VersionVector,
+  Container,
+  LoroTree,
 } from "../src";
-import { Container, LoroTree } from "../dist/loro";
 
 it("basic example", () => {
   const doc = new Loro();
@@ -92,7 +92,7 @@ it("basic sync example", () => {
 
 it("basic events", () => {
   const doc = new Loro();
-  doc.subscribe((event) => { });
+  doc.subscribe((event) => {});
   const list = doc.getList("list");
 });
 
@@ -390,7 +390,7 @@ it("can control the mergeable interval", () => {
   }
 });
 
-it.only("get container parent", () => {
+it("get container parent", () => {
   const doc = new Loro();
   const m = doc.getMap("m");
   expect(m.parent()).toBeUndefined();
@@ -403,4 +403,36 @@ it.only("get container parent", () => {
   const treeNode = tree.createNode();
   const subtext = treeNode.data.setContainer("t", new LoroText());
   expect(subtext.parent()!.id).toBe(treeNode.data.id);
+});
+
+it("prelim support", () => {
+  // Now we can create a new container directly
+  const map = new LoroMap();
+  map.set("3", 2);
+  const list = new LoroList();
+  list.insert(0, map);
+  // map should still be valid
+  map.set("9", 9);
+  // the type of setContainer/insertContainer changed
+  const text = map.setContainer("text", new LoroText());
+  const doc = new Loro();
+  const rootMap = doc.getMap("map");
+  rootMap.setContainer("test", map); // new way to create sub-container
+
+  // Use getAttached() to get the attached version of text
+  const attachedText = text.getAttached()!;
+  expect(text.isAttached()).toBeFalsy();
+  expect(attachedText.isAttached()).toBeTruthy();
+  text.insert(0, "Detached");
+  attachedText.insert(0, "Attached");
+  expect(text.toString()).toBe("Detached");
+  expect(doc.toJson()).toStrictEqual({
+    map: {
+      test: {
+        "3": 2,
+        "9": 9,
+        text: "Attached",
+      },
+    },
+  });
 });

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -5,9 +5,10 @@ import {
   Loro,
   LoroList,
   LoroMap,
+  LoroText,
   VersionVector,
 } from "../src";
-import { Container } from "../dist/loro";
+import { Container, LoroTree } from "../dist/loro";
 
 it("basic example", () => {
   const doc = new Loro();
@@ -32,7 +33,7 @@ it("basic example", () => {
   });
 
   // Insert a text container to the list
-  const text = list.insertContainer(0, "Text");
+  const text = list.insertContainer(0, new LoroText());
   text.insert(0, "Hello");
   text.insert(0, "Hi! ");
 
@@ -43,7 +44,7 @@ it("basic example", () => {
   });
 
   // Insert a list container to the map
-  const list2 = map.setContainer("test", "List");
+  const list2 = map.setContainer("test", new LoroList());
   list2.insert(0, 1);
   expect(doc.toJson()).toStrictEqual({
     list: ["Hi! Hello", "C"],
@@ -91,7 +92,7 @@ it("basic sync example", () => {
 
 it("basic events", () => {
   const doc = new Loro();
-  doc.subscribe((event) => {});
+  doc.subscribe((event) => { });
   const list = doc.getList("list");
 });
 
@@ -99,7 +100,7 @@ describe("list", () => {
   it("insert containers", () => {
     const doc = new Loro();
     const list = doc.getList("list");
-    const map = list.insertContainer(0, "Map");
+    const map = list.insertContainer(0, new LoroMap());
     map.set("key", "value");
     const v = list.get(0) as LoroMap;
     console.log(v);
@@ -113,7 +114,7 @@ describe("list", () => {
     list.insert(0, 1);
     list.insert(1, 2);
     expect(list.toArray()).toStrictEqual([1, 2]);
-    list.insertContainer(2, "Text");
+    list.insertContainer(2, new LoroText());
     const t = list.toArray()[2];
     expect(isContainer(t)).toBeTruthy();
     expect(getType(t)).toBe("Text");
@@ -125,7 +126,7 @@ describe("map", () => {
   it("get child container", () => {
     const doc = new Loro();
     const map = doc.getMap("map");
-    const list = map.setContainer("key", "List");
+    const list = map.setContainer("key", new LoroList());
     list.insert(0, 1);
     expect(map.get("key") instanceof LoroList).toBeTruthy();
     expect((map.get("key") as LoroList).toJson()).toStrictEqual([1]);
@@ -228,7 +229,7 @@ describe("map", () => {
   it("entries should return container handlers", () => {
     const doc = new Loro();
     const map = doc.getMap("map");
-    map.setContainer("text", "Text");
+    map.setContainer("text", new LoroText());
     map.set("foo", "bar");
     const entries = map.entries();
     expect((entries[0][1]! as Container).kind() === "Text").toBeTruthy();
@@ -389,17 +390,17 @@ it("can control the mergeable interval", () => {
   }
 });
 
-it("get container parent", () => {
+it.only("get container parent", () => {
   const doc = new Loro();
   const m = doc.getMap("m");
   expect(m.parent()).toBeUndefined();
-  const list = m.setContainer("t", "List");
+  const list = m.setContainer("t", new LoroList());
   expect(list.parent()!.id).toBe(m.id);
-  const text = list.insertContainer(0, "Text");
+  const text = list.insertContainer(0, new LoroText());
   expect(text.parent()!.id).toBe(list.id);
-  const tree = list.insertContainer(1, "Tree");
+  const tree = list.insertContainer(1, new LoroTree());
   expect(tree.parent()!.id).toBe(list.id);
   const treeNode = tree.createNode();
-  const subtext = treeNode.data.setContainer("t", "Text");
+  const subtext = treeNode.data.setContainer("t", new LoroText());
   expect(subtext.parent()!.id).toBe(treeNode.data.id);
 });

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import {
+  Container,
   getType,
   isContainer,
   Loro,
   LoroList,
   LoroMap,
   LoroText,
-  Container,
   LoroTree,
 } from "../src";
 
@@ -55,10 +55,10 @@ it("basic example", () => {
 it("get or create on Map", () => {
   const docA = new Loro();
   const map = docA.getMap("map");
-  const container = map.getOrCreateContainer("list", "List");
+  const container = map.getOrCreateContainer("list", new LoroList());
   container.insert(0, 1);
   container.insert(0, 2);
-  const text = map.getOrCreateContainer("text", "Text");
+  const text = map.getOrCreateContainer("text", new LoroText());
   text.insert(0, "Hello");
   expect(docA.toJson()).toStrictEqual({
     map: { list: [2, 1], text: "Hello" },

--- a/loro-js/tests/event.test.ts
+++ b/loro-js/tests/event.test.ts
@@ -5,6 +5,8 @@ import {
   ListDiff,
   Loro,
   LoroEventBatch,
+  LoroList,
+  LoroMap,
   LoroText,
   MapDiff,
   TextDiff,
@@ -32,14 +34,14 @@ describe("event", () => {
       lastEvent = event;
     });
     const map = loro.getMap("map");
-    const subMap = map.setContainer("sub", "Map");
+    const subMap = map.setContainer("sub", new LoroMap());
     subMap.set("0", "1");
     loro.commit();
     await oneMs();
     expect(lastEvent?.events[1].path).toStrictEqual(["map", "sub"]);
-    const list = subMap.setContainer("list", "List");
+    const list = subMap.setContainer("list", new LoroList());
     list.insert(0, "2");
-    const text = list.insertContainer(1, "Text");
+    const text = list.insertContainer(1, new LoroText());
     loro.commit();
     await oneMs();
     text.insert(0, "3");
@@ -184,11 +186,11 @@ describe("event", () => {
         times += 1;
       });
 
-      const subMap = map.setContainer("sub", "Map");
+      const subMap = map.setContainer("sub", new LoroMap());
       loro.commit();
       await oneMs();
       expect(times).toBe(1);
-      const text = subMap.setContainer("k", "Text");
+      const text = subMap.setContainer("k", new LoroText());
       loro.commit();
       await oneMs();
       expect(times).toBe(2);
@@ -213,7 +215,7 @@ describe("event", () => {
         times += 1;
       });
 
-      const text = list.insertContainer(0, "Text");
+      const text = list.insertContainer(0, new LoroText());
       loro.commit();
       await oneMs();
       expect(times).toBe(1);
@@ -294,7 +296,7 @@ describe("event", () => {
           first = false;
         }
       });
-      list.insertContainer(0, "Text");
+      list.insertContainer(0, new LoroText());
       loro.commit();
       await oneMs();
       expect(loro.toJson().list[0]).toBe("abc");
@@ -318,8 +320,8 @@ describe("event", () => {
       }
     });
 
-    list.insertContainer(0, "Map");
-    const t = list.insertContainer(0, "Text");
+    list.insertContainer(0, new LoroMap());
+    const t = list.insertContainer(0, new LoroText());
     t.insert(0, "He");
     t.insert(2, "llo");
     doc.commit();

--- a/loro-js/tests/misc.test.ts
+++ b/loro-js/tests/misc.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  Loro,
-  LoroList,
-  LoroMap,
-  VersionVector,
-} from "../src";
+import { Loro, LoroList, LoroMap, LoroText, VersionVector } from "../src";
 import { expectTypeOf } from "vitest";
 
 function assertEquals(a: any, b: any) {
@@ -188,7 +183,7 @@ describe("wasm", () => {
   b.set("ab", 123);
   loro.commit();
 
-  const bText = b.setContainer("hh", "Text");
+  const bText = b.setContainer("hh", new LoroText());
   loro.commit();
 
   it("map get", () => {
@@ -222,7 +217,7 @@ describe("type", () => {
   it("test recursive map type", () => {
     const loro = new Loro<{ map: LoroMap<{ map: LoroMap<{ name: "he" }> }> }>();
     const map = loro.getTypedMap("map");
-    map.setContainer("map", "Map");
+    map.setContainer("map", new LoroMap());
 
     const subMap = map.getTyped(loro, "map");
     const name = subMap.getTyped(loro, "name");
@@ -260,7 +255,7 @@ describe("tree", () => {
     assertEquals(child.parent()!.id, root.id);
   });
 
-  it("move",()=>{
+  it("move", () => {
     const root = tree.createNode();
     const child = root.createNode();
     const child2 = root.createNode();
@@ -268,7 +263,7 @@ describe("tree", () => {
     child2.moveTo(child);
     assertEquals(child2.parent()!.id, child.id);
     assertEquals(child.children()[0].id, child2.id);
-  })
+  });
 
   it("meta", () => {
     const root = tree.createNode();

--- a/loro-js/tests/version.test.ts
+++ b/loro-js/tests/version.test.ts
@@ -63,7 +63,7 @@ describe("Frontiers", () => {
   });
 });
 
-it.only("peer id repr should be consistent", () => {
+it("peer id repr should be consistent", () => {
   const doc = new Loro();
   const id = doc.peerIdStr;
   doc.getText("text").insert(0, "hello");

--- a/loro-js/tests/version.test.ts
+++ b/loro-js/tests/version.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Loro, OpId, VersionVector } from "../src";
+import { Loro, LoroMap, OpId, VersionVector } from "../src";
 
 describe("Frontiers", () => {
   it("two clients", () => {
@@ -40,32 +40,50 @@ describe("Frontiers", () => {
     doc1.getText("text").insert(0, "01234");
     doc1.commit();
 
-    expect(() => { doc1.cmpFrontiers([{ peer: "1", counter: 1 }], [{ peer: "2", counter: 10 }]) }).toThrow();
-    expect(doc1.cmpFrontiers([], [{ peer: "1", counter: 1 }])).toBe(-1)
-    expect(doc1.cmpFrontiers([], [])).toBe(0)
-    expect(doc1.cmpFrontiers([{ peer: "1", counter: 4 }], [{ peer: "2", counter: 3 }])).toBe(-1)
-    expect(doc1.cmpFrontiers([{ peer: "1", counter: 5 }], [{ peer: "2", counter: 3 }])).toBe(1)
-  })
+    expect(() => {
+      doc1.cmpFrontiers([{ peer: "1", counter: 1 }], [{
+        peer: "2",
+        counter: 10,
+      }]);
+    }).toThrow();
+    expect(doc1.cmpFrontiers([], [{ peer: "1", counter: 1 }])).toBe(-1);
+    expect(doc1.cmpFrontiers([], [])).toBe(0);
+    expect(
+      doc1.cmpFrontiers([{ peer: "1", counter: 4 }], [{
+        peer: "2",
+        counter: 3,
+      }]),
+    ).toBe(-1);
+    expect(
+      doc1.cmpFrontiers([{ peer: "1", counter: 5 }], [{
+        peer: "2",
+        counter: 3,
+      }]),
+    ).toBe(1);
+  });
 });
 
-it('peer id repr should be consistent', () => {
+it.only("peer id repr should be consistent", () => {
   const doc = new Loro();
   const id = doc.peerIdStr;
   doc.getText("text").insert(0, "hello");
   doc.commit();
   const f = doc.frontiers();
   expect(f[0].peer).toBe(id);
-  const map = doc.getList("list").insertContainer(0, "Map");
+  const child = new LoroMap();
+  console.dir(child);
+  const map = doc.getList("list").insertContainer(0, child);
+  console.dir(child);
   const mapId = map.id;
-  const peerIdInContainerId = mapId.split(":")[1].split("@")[1]
+  const peerIdInContainerId = mapId.split(":")[1].split("@")[1];
   expect(peerIdInContainerId).toBe(id);
   doc.commit();
   expect(doc.version().get(id)).toBe(6);
   expect(doc.version().toJSON().get(id)).toBe(6);
   const m = doc.getMap(mapId);
   m.set("0", 1);
-  expect(map.get("0")).toBe(1)
-})
+  expect(map.get("0")).toBe(1);
+});
 
 describe("Version", () => {
   const a = new Loro();
@@ -83,13 +101,17 @@ describe("Version", () => {
       const vv = new Map();
       vv.set("0", 3);
       vv.set("1", 2);
-      expect((a.version().toJSON())).toStrictEqual(vv);
-      expect((a.version().toJSON())).toStrictEqual(vv);
-      expect(a.vvToFrontiers(new VersionVector(vv))).toStrictEqual(a.frontiers());
+      expect(a.version().toJSON()).toStrictEqual(vv);
+      expect(a.version().toJSON()).toStrictEqual(vv);
+      expect(a.vvToFrontiers(new VersionVector(vv))).toStrictEqual(
+        a.frontiers(),
+      );
       const v = a.version();
       const temp = a.vvToFrontiers(v);
       expect(temp).toStrictEqual(a.frontiers());
-      expect(a.frontiers()).toStrictEqual([{ peer: "0", counter: 2 }] as OpId[]);
+      expect(a.frontiers()).toStrictEqual(
+        [{ peer: "0", counter: 2 }] as OpId[],
+      );
     }
   });
 

--- a/loro-js/tsconfig.json
+++ b/loro-js/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,7 +8,6 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
     "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
@@ -23,7 +21,6 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
@@ -42,12 +39,10 @@
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -55,7 +50,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -72,7 +67,6 @@
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
@@ -80,7 +74,6 @@
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
@@ -101,7 +94,6 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: registry.npmmirror.com/@typescript-eslint/parser@6.2.0(eslint@8.46.0)(typescript@5.0.3)
       '@vitest/ui':
         specifier: ^1.0.4
-        version: 1.0.4(vitest@1.0.4)
+        version: 1.0.4(vitest@1.4.0)
       esbuild:
         specifier: ^0.18.20
         version: registry.npmmirror.com/esbuild@0.18.20
@@ -101,8 +101,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(vite@4.2.1)
       vitest:
-        specifier: ^1.0.4
-        version: 1.0.4(@vitest/ui@1.0.4)
+        specifier: ^1.4.0
+        version: 1.4.0(@vitest/ui@1.0.4)
 
 packages:
 
@@ -1256,37 +1256,37 @@ packages:
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
-  /@vitest/expect@1.0.4:
-    resolution: {integrity: sha512-/NRN9N88qjg3dkhmFcCBwhn/Ie4h064pY3iv7WLRsDJW7dXnEgeoa8W9zy7gIPluhz6CkgqiB3HmpIXgmEY5dQ==}
+  /@vitest/expect@1.4.0:
+    resolution: {integrity: sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==}
     dependencies:
-      '@vitest/spy': 1.0.4
-      '@vitest/utils': 1.0.4
+      '@vitest/spy': 1.4.0
+      '@vitest/utils': 1.4.0
       chai: 4.3.10
     dev: true
 
-  /@vitest/runner@1.0.4:
-    resolution: {integrity: sha512-rhOQ9FZTEkV41JWXozFM8YgOqaG9zA7QXbhg5gy6mFOVqh4PcupirIJ+wN7QjeJt8S8nJRYuZH1OjJjsbxAXTQ==}
+  /@vitest/runner@1.4.0:
+    resolution: {integrity: sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==}
     dependencies:
-      '@vitest/utils': 1.0.4
+      '@vitest/utils': 1.4.0
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@1.0.4:
-    resolution: {integrity: sha512-vkfXUrNyNRA/Gzsp2lpyJxh94vU2OHT1amoD6WuvUAA12n32xeVZQ0KjjQIf8F6u7bcq2A2k969fMVxEsxeKYA==}
+  /@vitest/snapshot@1.4.0:
+    resolution: {integrity: sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.0.4:
-    resolution: {integrity: sha512-9ojTFRL1AJVh0hvfzAQpm0QS6xIS+1HFIw94kl/1ucTfGCaj1LV/iuJU4Y6cdR03EzPDygxTHwE1JOm+5RCcvA==}
+  /@vitest/spy@1.4.0:
+    resolution: {integrity: sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/ui@1.0.4(vitest@1.0.4):
+  /@vitest/ui@1.0.4(vitest@1.4.0):
     resolution: {integrity: sha512-gd4p6e7pjukSe4joWS5wpnm/JcEfzCZUYkYWQOORqJK1mDJ0MOaXa/9BbPOEVO5TcvdnKvFJUdJpFHnqoyYwZA==}
     peerDependencies:
       vitest: ^1.0.0
@@ -1298,7 +1298,7 @@ packages:
       pathe: 1.1.1
       picocolors: 1.0.0
       sirv: 2.0.3
-      vitest: 1.0.4(@vitest/ui@1.0.4)
+      vitest: 1.4.0(@vitest/ui@1.0.4)
     dev: true
 
   /@vitest/utils@1.0.4:
@@ -1309,8 +1309,17 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /acorn-walk@8.3.1:
-    resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
+  /@vitest/utils@1.4.0:
+    resolution: {integrity: sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -1465,7 +1474,7 @@ packages:
       check-error: 1.0.3
       deep-eql: 4.1.3
       get-func-name: 2.0.2
-      loupe: 2.3.6
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
@@ -1835,6 +1844,12 @@ packages:
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.0
     dev: true
 
   /execa@8.0.1:
@@ -2322,6 +2337,10 @@ packages:
     requiresBuild: true
     dev: true
 
+  /js-tokens@9.0.0:
+    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+    dev: true
+
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -2392,13 +2411,6 @@ packages:
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-    dev: true
-
-  /loupe@2.3.6:
-    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
-    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
-    dependencies:
-      get-func-name: 2.0.2
     dev: true
 
   /loupe@2.3.7:
@@ -3159,10 +3171,10 @@ packages:
       min-indent: 1.0.1
     dev: true
 
-  /strip-literal@1.3.0:
-    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+  /strip-literal@2.1.0:
+    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
     dependencies:
-      acorn: 8.10.0
+      js-tokens: 9.0.0
     dev: true
 
   /supports-color@5.5.0:
@@ -3194,8 +3206,8 @@ packages:
     resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
     dev: true
 
-  /tinypool@0.8.1:
-    resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
+  /tinypool@0.8.3:
+    resolution: {integrity: sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -3336,8 +3348,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@1.0.4:
-    resolution: {integrity: sha512-9xQQtHdsz5Qn8hqbV7UKqkm8YkJhzT/zr41Dmt5N7AlD8hJXw/Z7y0QiD5I8lnTthV9Rvcvi0QW7PI0Fq83ZPg==}
+  /vite-node@1.4.0:
+    resolution: {integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -3489,15 +3501,15 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.0.4(@vitest/ui@1.0.4):
-    resolution: {integrity: sha512-s1GQHp/UOeWEo4+aXDOeFBJwFzL6mjycbQwwKWX2QcYfh/7tIerS59hWQ20mxzupTJluA2SdwiBuWwQHH67ckg==}
+  /vitest@1.4.0(@vitest/ui@1.0.4):
+    resolution: {integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
+      '@vitest/browser': 1.4.0
+      '@vitest/ui': 1.4.0
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3514,14 +3526,13 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@vitest/expect': 1.0.4
-      '@vitest/runner': 1.0.4
-      '@vitest/snapshot': 1.0.4
-      '@vitest/spy': 1.0.4
-      '@vitest/ui': 1.0.4(vitest@1.0.4)
-      '@vitest/utils': 1.0.4
-      acorn-walk: 8.3.1
-      cac: 6.7.14
+      '@vitest/expect': 1.4.0
+      '@vitest/runner': 1.4.0
+      '@vitest/snapshot': 1.4.0
+      '@vitest/spy': 1.4.0
+      '@vitest/ui': 1.0.4(vitest@1.4.0)
+      '@vitest/utils': 1.4.0
+      acorn-walk: 8.3.2
       chai: 4.3.10
       debug: 4.3.4
       execa: 8.0.1
@@ -3530,11 +3541,11 @@ packages:
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.6.0
-      strip-literal: 1.3.0
+      strip-literal: 2.1.0
       tinybench: 2.5.1
-      tinypool: 0.8.1
+      tinypool: 0.8.3
       vite: 5.0.7
-      vite-node: 1.0.4
+      vite-node: 1.4.0
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
This PR includes a BREAKING CHANGE.

This PR enables you to create containers before attaching them to the document, making the API more intuitive and straightforward.

A container can be either attached to a document or detached. When it's detached, its history/state is not persisted. You can attach a container to a document by inserting it into an existing attached container. Once a container is attached, its state, along with all of its descendants's states, will be recreated in the document. After attaching, the container and its descendants will each have their corresponding "attached" version of themselves.

When a detached container x is attached to a document, you can use `x.getAttached()` to obtain the corresponding attached container.

# Examples

JS

```js
// Now we can create a new container directly
const map = new LoroMap();
map.set("3", 2);
const list = new LoroList();
list.insert(0, map);
// map should still be valid
map.set("9", 9);
// the type of setContainer/insertContainer changed
const text = map.setContainer("text", new LoroText());
const doc = new Loro();
const rootMap = doc.getMap("map");
rootMap.setContainer("test", map); // new way to create sub-container

// Use getAttached() to get the attached version of text
const attachedText = text.getAttached()!;
expect(text.isAttached()).toBeFalsy();
expect(attachedText.isAttached()).toBeTruthy();
text.insert(0, "Detached");
attachedText.insert(0, "Attached");
expect(text.toString()).toBe("Detached");
expect(doc.toJson()).toStrictEqual({
  map: {
    test: {
      "3": 2,
      "9": 9,
      text: "Attached",
    },
  },
});

```

Rust

```rust
use loro::ContainerTrait;
use loro::{LoroDoc, LoroList, LoroText, LoroValue, ToJson};
use serde_json::json;

let doc = LoroDoc::new();
let map = doc.get_map("map");
map.insert("key", "value").unwrap();
map.insert("true", true).unwrap();
map.insert("null", LoroValue::Null).unwrap();
map.insert("deleted", LoroValue::Null).unwrap();
map.delete("deleted").unwrap();
let list = map.insert_container("list", LoroList::new()).unwrap();
list.insert(0, "List").unwrap();
list.insert(1, 9).unwrap();
let old_text = LoroText::new();
old_text.insert(0, "Hello ").unwrap();
let text = map.insert_container("text", old_text.clone()).unwrap();
text.insert(6, "world!").unwrap();
assert_eq!(
    doc.get_deep_value().to_json_value(),
    json!({
        "map": {
            "key": "value",
            "true": true,
            "null": null,
            "list": ["List", 9],
            "text": "Hello world!"
        }
    })
);
let new_text = old_text.get_attached().unwrap();
new_text.insert(0, "New ").unwrap();
assert_eq!(
    doc.get_deep_value().to_json_value(),
    json!({
        "map": {
            "key": "value",
            "true": true,
            "null": null,
            "list": ["List", 9],
            "text": "New Hello world!"
        }
    })
);

```

## Compared with the old version

Target:  Create a new user `{name: string, bio: TextContainer}` at `meta/users/0`

In the new version,

```rust
// create meta/users/0/new_user/{name: string, bio: Text}
let doc = LoroDoc::new();
let meta = doc.get_map("meta");
let user = meta
    .get_or_create_container("users", LoroList::new())
    .unwrap()
    .insert_container(0, LoroMap::new())
    .unwrap();
user.insert("name", "new_user").unwrap();
user.insert_container("bio", LoroText::new()).unwrap();
```

In the old version,

```rust
let doc = LoroDoc::new();
let map = doc.get_map("meta");
let list = if let Some(Either::Right(Container::List(list))) = map.get("users") {
    list
} else {
    map.insert_container("users", loro::ContainerType::List)
        .unwrap()
        .into_list()
        .unwrap()
};
let user = list
    .insert_container(0, loro::ContainerType::Map)
    .unwrap()
    .into_map()
    .unwrap();
user.insert("name", "Alice").unwrap();
user.insert_container("bio", loro::ContainerType::Text)
    .unwrap()
    .into_text()
    .unwrap()
    .insert(0, "Hello world!")
    .unwrap();
```
