### PR TITLE
fix: type mismatch and add type info for whether a container is attached

### DIFF
--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -92,6 +92,8 @@ extern "C" {
     pub type JsIntoVersionVector;
     #[wasm_bindgen(typescript_type = "Container")]
     pub type JsContainer;
+    #[wasm_bindgen(typescript_type = "Value")]
+    pub type JsLoroValue;
     #[wasm_bindgen(typescript_type = "Value | Container")]
     pub type JsValueOrContainer;
     #[wasm_bindgen(typescript_type = "Value | Container | undefined")]
@@ -114,6 +116,8 @@ extern "C" {
     pub type JsDelta;
     #[wasm_bindgen(typescript_type = "-1 | 1 | 0 | undefined")]
     pub type JsPartialOrd;
+    #[wasm_bindgen(typescript_type = "'Tree'|'Map'|'List'|'Text'")]
+    pub type JsContainerKind;
 }
 
 mod observer {
@@ -1183,8 +1187,8 @@ impl LoroText {
     }
 
     /// "Text"
-    pub fn kind(&self) -> JsValue {
-        JsValue::from_str("Text")
+    pub fn kind(&self) -> JsContainerKind {
+        JsValue::from_str("Text").into()
     }
 
     /// Insert some string at index.
@@ -1378,7 +1382,7 @@ impl LoroText {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached")]
+    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -1425,8 +1429,8 @@ impl LoroMap {
     }
 
     /// "Map"
-    pub fn kind(&self) -> JsValue {
-        JsValue::from_str("Map")
+    pub fn kind(&self) -> JsContainerKind {
+        JsValue::from_str("Map").into()
     }
 
     /// Set the key with the value.
@@ -1443,8 +1447,9 @@ impl LoroMap {
     /// map.set("foo", "baz");
     /// ```
     #[wasm_bindgen(js_name = "set")]
-    pub fn insert(&mut self, key: &str, value: JsValue) -> JsResult<()> {
-        self.handler.insert(key, value)?;
+    pub fn insert(&mut self, key: &str, value: JsLoroValue) -> JsResult<()> {
+        let v: JsValue = value.into();
+        self.handler.insert(key, v)?;
         Ok(())
     }
 
@@ -1498,7 +1503,7 @@ impl LoroMap {
     /// map.set("foo", "bar");
     /// const bar = map.get("foo");
     /// ```
-    #[wasm_bindgen(js_name = "getOrCreateContainer")]
+    #[wasm_bindgen(js_name = "getOrCreateContainer", skip_typescript)]
     pub fn get_or_create_container(&self, key: &str, child: JsContainer) -> JsResult<JsContainer> {
         let child = convert::js_to_container(child)?;
         let handler = self
@@ -1611,7 +1616,7 @@ impl LoroMap {
     /// const text = map.setContainer("text", new LoroText());
     /// const list = map.setContainer("list", new LoroText());
     /// ```
-    #[wasm_bindgen(js_name = "setContainer")]
+    #[wasm_bindgen(js_name = "setContainer", skip_typescript)]
     pub fn insert_container(&mut self, key: &str, child: JsContainer) -> JsResult<JsContainer> {
         let child = convert::js_to_container(child)?;
         let c = self.handler.insert_container(key, child.to_handler())?;
@@ -1697,7 +1702,7 @@ impl LoroMap {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached")]
+    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -1743,8 +1748,8 @@ impl LoroList {
     }
 
     /// "List"
-    pub fn kind(&self) -> JsValue {
-        JsValue::from_str("List")
+    pub fn kind(&self) -> JsContainerKind {
+        JsValue::from_str("List").into()
     }
 
     /// Insert a value at index.
@@ -1760,8 +1765,9 @@ impl LoroList {
     /// list.insert(2, true);
     /// console.log(list.value);  // [100, "foo", true];
     /// ```
-    pub fn insert(&mut self, index: usize, value: JsValue) -> JsResult<()> {
-        self.handler.insert(index, value)?;
+    pub fn insert(&mut self, index: usize, value: JsLoroValue) -> JsResult<()> {
+        let v: JsValue = value.into();
+        self.handler.insert(index, v)?;
         Ok(())
     }
 
@@ -1879,7 +1885,7 @@ impl LoroList {
     /// text.insert(0, "Hello");
     /// console.log(list.getDeepValue());  // [100, "Hello"];
     /// ```
-    #[wasm_bindgen(js_name = "insertContainer")]
+    #[wasm_bindgen(js_name = "insertContainer", skip_typescript)]
     pub fn insert_container(&mut self, index: usize, child: JsContainer) -> JsResult<JsContainer> {
         let child = js_to_container(child)?;
         let c = self.handler.insert_container(index, child.to_handler())?;
@@ -1964,7 +1970,7 @@ impl LoroList {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached")]
+    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -2061,7 +2067,7 @@ impl LoroTreeNode {
     }
 
     /// Get the associated metadata map container of a tree node.
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, skip_typescript)]
     pub fn data(&self) -> JsResult<LoroMap> {
         let data = self.tree.get_meta(self.id)?;
         let map = LoroMap {
@@ -2103,8 +2109,8 @@ impl LoroTree {
     }
 
     /// "Tree"
-    pub fn kind(&self) -> JsValue {
-        JsValue::from_str("Tree")
+    pub fn kind(&self) -> JsContainerKind {
+        JsValue::from_str("Tree").into()
     }
 
     /// Create a new tree node as the child of parent and return an unique tree id.
@@ -2366,7 +2372,7 @@ impl LoroTree {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached")]
+    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -2628,7 +2634,7 @@ export interface Change {
 /**
  * Data types supported by loro
  */
-export type Value =
+export type Value = 
   | ContainerID
   | string
   | number

--- a/loro-js/package.json
+++ b/loro-js/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "test": "vitest run",
+    "test": "vitest run --typecheck",
     "prepublish": "pnpm run build"
   },
   "author": "Loro",

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -12,12 +12,12 @@ import {
 
 it("basic example", () => {
   const doc = new Loro();
-  const list: LoroList = doc.getList("list");
+  const list = doc.getList("list");
   list.insert(0, "A");
   list.insert(1, "B");
   list.insert(2, "C");
 
-  const map: LoroMap = doc.getMap("map");
+  const map = doc.getMap("map");
   // map can only has string key
   map.set("key", "value");
   expect(doc.toJson()).toStrictEqual({
@@ -68,7 +68,7 @@ it("get or create on Map", () => {
 it("basic sync example", () => {
   const docA = new Loro();
   const docB = new Loro();
-  const listA: LoroList = docA.getList("list");
+  const listA = docA.getList("list");
   listA.insert(0, "A");
   listA.insert(1, "B");
   listA.insert(2, "C");
@@ -78,7 +78,7 @@ it("basic sync example", () => {
     list: ["A", "B", "C"],
   });
 
-  const listB: LoroList = docB.getList("list");
+  const listB = docB.getList("list");
   // delete 1 element at index 1
   listB.delete(1, 1);
   // A import the ops from B
@@ -331,12 +331,15 @@ it("getValueType", () => {
   const map = doc.getMap("map");
   const list = doc.getList("list");
   const tree = doc.getTree("tree");
+  const text = doc.getText("text");
   expectTypeOf(getType(map)).toEqualTypeOf<"Map">();
   expect(getType(map)).toBe("Map");
   expectTypeOf(getType(list)).toEqualTypeOf<"List">();
   expect(getType(list)).toBe("List");
   expectTypeOf(getType(tree)).toEqualTypeOf<"Tree">();
   expect(getType(tree)).toBe("Tree");
+  expectTypeOf(getType(text)).toEqualTypeOf<"Text">();
+  expect(getType(text)).toBe("Text");
 });
 
 it("enable timestamp", () => {

--- a/loro-js/tests/type.test.ts
+++ b/loro-js/tests/type.test.ts
@@ -1,0 +1,29 @@
+import { Loro, LoroList, LoroMap, Value } from "../src";
+import { expect, expectTypeOf, test } from "vitest";
+
+test("You shuold not insert a container by using `insert` function", () => {
+  const list = new LoroList();
+  expectTypeOf(list).not.toMatchTypeOf<Value>();
+});
+
+test("Container attached state", () => {
+  const list = new LoroList();
+  expect(list.isAttached()).toBe(false);
+  expectTypeOf(list.isAttached()).toMatchTypeOf<false>();
+  const doc = new Loro();
+  {
+    const map = doc.getMap("map");
+    expectTypeOf(map.isAttached()).toMatchTypeOf<true>();
+    expectTypeOf(map).toMatchTypeOf<LoroMap<any, true>>();
+  }
+  {
+    const map = new LoroMap();
+    expectTypeOf(map.isAttached()).toMatchTypeOf<false>();
+    expectTypeOf(map).toMatchTypeOf<LoroMap<any, false>>();
+  }
+  {
+    const map = list.insertContainer(0, new LoroMap());
+    expectTypeOf(map.isAttached()).toMatchTypeOf<false>();
+    expectTypeOf(map).toMatchTypeOf<LoroMap<any, false>>();
+  }
+});


### PR DESCRIPTION
Now, the type system can tell you whether a container is attached statically.

```ts
test("Container attached state", () => {
  const list = new LoroList();
  expect(list.isAttached()).toBe(false);
  expectTypeOf(list.isAttached()).toMatchTypeOf<false>();
  const doc = new Loro();
  {
    const map = doc.getMap("map");
    expectTypeOf(map.isAttached()).toMatchTypeOf<true>();
    expectTypeOf(map).toMatchTypeOf<LoroMap<any, true>>();
  }
  {
    const map = new LoroMap();
    expectTypeOf(map.isAttached()).toMatchTypeOf<false>();
    expectTypeOf(map).toMatchTypeOf<LoroMap<any, false>>();
  }
  {
    const map = list.insertContainer(0, new LoroMap());
    expectTypeOf(map.isAttached()).toMatchTypeOf<false>();
    expectTypeOf(map).toMatchTypeOf<LoroMap<any, false>>();
  }
});
```