### PR TITLE
refactor: rm isAttached type on containers

### DIFF
--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1382,7 +1382,7 @@ impl LoroText {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
+    #[wasm_bindgen(js_name = "isAttached")]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -1702,7 +1702,7 @@ impl LoroMap {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
+    #[wasm_bindgen(js_name = "isAttached")]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -1970,7 +1970,7 @@ impl LoroList {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
+    #[wasm_bindgen(js_name = "isAttached")]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }
@@ -2372,7 +2372,7 @@ impl LoroTree {
     /// Whether the container is attached to a docuemnt.
     ///
     /// If it's detached, the operations on the container will not be persisted.
-    #[wasm_bindgen(js_name = "isAttached", skip_typescript)]
+    #[wasm_bindgen(js_name = "isAttached")]
     pub fn is_attached(&self) -> bool {
         self.handler.is_attached()
     }

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -199,56 +199,51 @@ declare module "loro-wasm" {
   interface Loro<T extends Record<string, any> = Record<string, any>> {
     getTypedMap<Key extends keyof T & string>(
       name: Key,
-    ): T[Key] extends LoroMap ? SetAttached<T[Key], true> : never;
+    ): T[Key] extends LoroMap ? T[Key] : never;
     getTypedList<Key extends keyof T & string>(
       name: Key,
-    ): T[Key] extends LoroList ? SetAttached<T[Key], true> : never;
-    getMap(key: string | ContainerID): LoroMap<T[string], true>;
-    getList(key: string | ContainerID): LoroList<T[string], true>;
-    getTree(key: string | ContainerID): LoroTree<T[string], true>;
-    getText(key: string | ContainerID): LoroText<true>;
+    ): T[Key] extends LoroList ? T[Key] : never;
+    getMap(key: string | ContainerID): LoroMap<T[string]>;
+    getList(key: string | ContainerID): LoroList<T[string]>;
+    getTree(key: string | ContainerID): LoroTree<T[string]>;
+    getText(key: string | ContainerID): LoroText;
   }
 
   interface LoroList<
     T extends any[] = any[],
-    Attached extends boolean = false,
   > {
     new (): LoroList<T, false>;
     insertContainer<C extends Container>(
       pos: number,
       child: C,
-    ): SetAttached<C, Attached>;
-    get(index: number): undefined | Value | SetAttached<Container, Attached>;
+    ): C;
+    get(index: number): undefined | Value | Container;
     getTyped<Key extends keyof T & number>(loro: Loro, index: Key): T[Key];
     insertTyped<Key extends keyof T & number>(pos: Key, value: T[Key]): void;
     insert(pos: number, value: Value): void;
     delete(pos: number, len: number): void;
     subscribe(txn: Loro, listener: Listener): number;
     getAttached(): undefined | LoroList<T, true>;
-    isAttached(): Attached;
   }
 
   interface LoroMap<
     T extends Record<string, any> = Record<string, any>,
-    Attached extends boolean = false,
   > {
     new (): LoroMap<T, false>;
     getOrCreateContainer<C extends Container>(
       key: string,
       child: C,
-    ): SetAttached<C, Attached>;
+    ): C;
     setContainer<C extends Container>(
       key: string,
       child: C,
-    ): SetAttached<C, Attached>;
-    get(key: string): undefined | Value | SetAttached<Container, Attached>;
+    ): C;
+    get(key: string): undefined | Value | Container;
     getTyped<Key extends keyof T & string>(txn: Loro, key: Key): T[Key];
     set(key: string, value: Value): void;
     setTyped<Key extends keyof T & string>(key: Key, value: T[Key]): void;
     delete(key: string): void;
     subscribe(txn: Loro, listener: Listener): number;
-    getAttached(): undefined | LoroMap<T, true>;
-    isAttached(): Attached;
   }
 
   interface LoroText<Attached extends boolean = false> {
@@ -256,41 +251,28 @@ declare module "loro-wasm" {
     insert(pos: number, text: string): void;
     delete(pos: number, len: number): void;
     subscribe(txn: Loro, listener: Listener): number;
-    getAttached(): undefined | LoroText<true>;
-    isAttached(): Attached;
   }
 
   interface LoroTree<
     T extends Record<string, any> = Record<string, any>,
-    Attached extends boolean = false,
   > {
     new (): LoroTree<T, false>;
-    createNode(parent: TreeID | undefined): LoroTreeNode<T, Attached>;
+    createNode(parent: TreeID | undefined): LoroTreeNode<T>;
     move(target: TreeID, parent: TreeID | undefined): void;
     delete(target: TreeID): void;
     has(target: TreeID): boolean;
     getNodeByID(target: TreeID): LoroTreeNode;
     subscribe(txn: Loro, listener: Listener): number;
-    getAttached(): undefined | LoroTree<T, true>;
-    isAttached(): Attached;
   }
 
   interface LoroTreeNode<
     T extends Record<string, any> = Record<string, any>,
-    Attached extends boolean = false,
   > {
-    readonly data: LoroMap<T, Attached>;
-    createNode(): LoroTreeNode<T, Attached>;
+    readonly data: LoroMap<T>;
+    createNode(): LoroTreeNode<T>;
     setAsRoot(): void;
-    moveTo(parent: LoroTreeNode<T, Attached>): void;
+    moveTo(parent: LoroTreeNode<T>): void;
     parent(): LoroTreeNode | undefined;
-    children(): Array<LoroTreeNode<T, Attached>>;
+    children(): Array<LoroTreeNode<T>>;
   }
 }
-
-type SetAttached<T extends Container, Attached extends boolean> = T extends
-  LoroMap<infer U> ? LoroMap<U, Attached>
-  : T extends LoroList<infer U> ? LoroList<U, Attached>
-  : T extends LoroTree<infer U> ? LoroTree<U, Attached>
-  : T extends LoroText ? LoroText<Attached>
-  : never;

--- a/loro-js/tests/type.test.ts
+++ b/loro-js/tests/type.test.ts
@@ -5,25 +5,3 @@ test("You shuold not insert a container by using `insert` function", () => {
   const list = new LoroList();
   expectTypeOf(list).not.toMatchTypeOf<Value>();
 });
-
-test("Container attached state", () => {
-  const list = new LoroList();
-  expect(list.isAttached()).toBe(false);
-  expectTypeOf(list.isAttached()).toMatchTypeOf<false>();
-  const doc = new Loro();
-  {
-    const map = doc.getMap("map");
-    expectTypeOf(map.isAttached()).toMatchTypeOf<true>();
-    expectTypeOf(map).toMatchTypeOf<LoroMap<any, true>>();
-  }
-  {
-    const map = new LoroMap();
-    expectTypeOf(map.isAttached()).toMatchTypeOf<false>();
-    expectTypeOf(map).toMatchTypeOf<LoroMap<any, false>>();
-  }
-  {
-    const map = list.insertContainer(0, new LoroMap());
-    expectTypeOf(map.isAttached()).toMatchTypeOf<false>();
-    expectTypeOf(map).toMatchTypeOf<LoroMap<any, false>>();
-  }
-});


### PR DESCRIPTION
The type on `isAttached` is removed; it was able to infer the true/false correctly. Because it would cause downstream marking types harder.

TypeScript doesn't support type annotation on the constructor yet https://github.com/microsoft/TypeScript/issues/27594  Otherwise, we may have a perfect solution.