### PR TITLE
refactor: add concrete type for each different container

### DIFF
--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -123,6 +123,14 @@ extern "C" {
     pub type JsPartialOrd;
     #[wasm_bindgen(typescript_type = "'Tree'|'Map'|'List'|'Text'")]
     pub type JsContainerKind;
+    #[wasm_bindgen(typescript_type = "'Text'")]
+    pub type JsTextStr;
+    #[wasm_bindgen(typescript_type = "'Tree'")]
+    pub type JsTreeStr;
+    #[wasm_bindgen(typescript_type = "'Map'")]
+    pub type JsMapStr;
+    #[wasm_bindgen(typescript_type = "'List'")]
+    pub type JsListStr;
     #[wasm_bindgen(typescript_type = "ImportBlobMetadata")]
     pub type JsImportBlobMetadata;
 }
@@ -1222,7 +1230,7 @@ impl LoroText {
     }
 
     /// "Text"
-    pub fn kind(&self) -> JsContainerKind {
+    pub fn kind(&self) -> JsTextStr {
         JsValue::from_str("Text").into()
     }
 
@@ -1473,7 +1481,7 @@ impl LoroMap {
     }
 
     /// "Map"
-    pub fn kind(&self) -> JsContainerKind {
+    pub fn kind(&self) -> JsMapStr {
         JsValue::from_str("Map").into()
     }
 
@@ -1806,7 +1814,7 @@ impl LoroList {
     }
 
     /// "List"
-    pub fn kind(&self) -> JsContainerKind {
+    pub fn kind(&self) -> JsListStr {
         JsValue::from_str("List").into()
     }
 
@@ -2183,7 +2191,7 @@ impl LoroTree {
     }
 
     /// "Tree"
-    pub fn kind(&self) -> JsContainerKind {
+    pub fn kind(&self) -> JsTreeStr {
         JsValue::from_str("Tree").into()
     }
 

--- a/loro-js/package.json
+++ b/loro-js/package.json
@@ -2,21 +2,14 @@
   "name": "loro-crdt",
   "version": "0.13.1",
   "description": "Loro CRDTs is a high-performance CRDT framework that makes your app state synchronized, collaborative and maintainable effortlessly.",
-  "keywords": [
-    "crdt",
-    "CRDTs",
-    "realtime",
-    "collaboration",
-    "sync",
-    "p2p"
-  ],
+  "keywords": ["crdt", "CRDTs", "realtime", "collaboration", "sync", "p2p"],
   "main": "dist/loro.js",
   "module": "dist/loro.mjs",
   "typings": "dist/loro.d.ts",
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "test": "vitest run --typecheck",
+    "test": "vitest run && npx tsc --noEmit",
     "prepublish": "pnpm run build"
   },
   "author": "Loro",

--- a/loro-js/tests/issue.test.ts
+++ b/loro-js/tests/issue.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { Loro } from "../src";
-import { Container, LoroText, OpId } from "../dist/loro";
+import { Container, LoroText, OpId } from "../src";
 import { setDebug } from "loro-wasm";
 
 it("#211", () => {

--- a/loro-js/tests/type.test.ts
+++ b/loro-js/tests/type.test.ts
@@ -1,4 +1,12 @@
-import { Loro, LoroList, LoroMap, PeerID, Value } from "../src";
+import {
+  Loro,
+  LoroList,
+  LoroMap,
+  LoroText,
+  LoroTree,
+  PeerID,
+  Value,
+} from "../src";
 import { expect, expectTypeOf, test } from "vitest";
 
 test("Container should not match Value", () => {
@@ -7,6 +15,19 @@ test("Container should not match Value", () => {
 });
 
 test("A non-numeric string is not a valid peer id", () => {
+  const doc = new Loro();
+  expectTypeOf(doc.peerIdStr).toMatchTypeOf<PeerID>();
   expectTypeOf("123" as const).toMatchTypeOf<PeerID>();
   expectTypeOf("a123" as const).not.toMatchTypeOf<PeerID>();
+});
+
+test("Expect container type", () => {
+  const list = new LoroList();
+  expectTypeOf(list.kind()).toMatchTypeOf<"List">();
+  const map = new LoroMap();
+  expectTypeOf(map.kind()).toMatchTypeOf<"Map">();
+  const text = new LoroText();
+  expectTypeOf(text.kind()).toMatchTypeOf<"Text">();
+  const tree = new LoroTree();
+  expectTypeOf(tree.kind()).toMatchTypeOf<"Tree">();
 });

--- a/loro-js/tsconfig.json
+++ b/loro-js/tsconfig.json
@@ -50,9 +50,9 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist", /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true /* Disable emitting files from a compilation. */,
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
Now we can use `.kind()` to infer the type:

```ts
function foo(c: Container) {
  if (c.kind() === "Text"){
    // TypeScript now knows it's a `LoroText` container
    ...
  }
}
```