### PR TITLE
refactor(ts): make method types better

### DIFF
--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -2685,8 +2685,41 @@ export type ContainerID =
 export type TreeID = `${number}@${PeerID}`;
 
 interface Loro {
+    /** 
+     * Export updates from the specific version to the current version
+     * 
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     * 
+     *  const doc = new Loro();
+     *  const text = doc.getText("text");
+     *  text.insert(0, "Hello");
+     *  // get all updates of the doc
+     *  const updates = doc.exportFrom();
+     *  const version = doc.oplogVersion();
+     *  text.insert(5, " World");
+     *  // get updates from specific version to the latest version
+     *  const updates2 = doc.exportFrom(version);
+     *  ```
+     */
     exportFrom(version?: VersionVector): Uint8Array;
-    getContainerById(id: ContainerID): LoroText | LoroMap | LoroList;
+    /**
+     * 
+     *  Get the container corresponding to the container id
+     * 
+     * 
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     * 
+     *  const doc = new Loro();
+     *  let text = doc.getText("text");
+     *  const textId = text.id;
+     *  text = doc.getContainerById(textId);
+     *  ```
+     */
+    getContainerById(id: ContainerID): Container;
 }
 
 /**

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -543,7 +543,7 @@ impl Loro {
     /// const doc = new Loro();
     /// const map = doc.getMap("map");
     /// ```
-    #[wasm_bindgen(js_name = "getMap")]
+    #[wasm_bindgen(js_name = "getMap", skip_typescript)]
     pub fn get_map(&self, cid: &JsIntoContainerID) -> JsResult<LoroMap> {
         let map = self
             .0
@@ -566,7 +566,7 @@ impl Loro {
     /// const doc = new Loro();
     /// const list = doc.getList("list");
     /// ```
-    #[wasm_bindgen(js_name = "getList")]
+    #[wasm_bindgen(js_name = "getList", skip_typescript)]
     pub fn get_list(&self, cid: &JsIntoContainerID) -> JsResult<LoroList> {
         let list = self
             .0
@@ -589,7 +589,7 @@ impl Loro {
     /// const doc = new Loro();
     /// const tree = doc.getTree("tree");
     /// ```
-    #[wasm_bindgen(js_name = "getTree")]
+    #[wasm_bindgen(js_name = "getTree", skip_typescript)]
     pub fn get_tree(&self, cid: &JsIntoContainerID) -> JsResult<LoroTree> {
         let tree = self
             .0
@@ -1498,7 +1498,7 @@ impl LoroMap {
     /// map.set("foo", "bar");
     /// map.set("foo", "baz");
     /// ```
-    #[wasm_bindgen(js_name = "set")]
+    #[wasm_bindgen(js_name = "set", skip_typescript)]
     pub fn insert(&mut self, key: &str, value: JsLoroValue) -> JsResult<()> {
         let v: JsValue = value.into();
         self.handler.insert(key, v)?;
@@ -1536,6 +1536,7 @@ impl LoroMap {
     /// map.set("foo", "bar");
     /// const bar = map.get("foo");
     /// ```
+    #[wasm_bindgen(skip_typescript)]
     pub fn get(&self, key: &str) -> JsValueOrContainerOrUndefined {
         let v = self.handler.get_(key);
         (match v {
@@ -1831,6 +1832,7 @@ impl LoroList {
     /// list.insert(2, true);
     /// console.log(list.value);  // [100, "foo", true];
     /// ```
+    #[wasm_bindgen(skip_typescript)]
     pub fn insert(&mut self, index: usize, value: JsLoroValue) -> JsResult<()> {
         let v: JsValue = value.into();
         self.handler.insert(index, v)?;
@@ -1866,6 +1868,7 @@ impl LoroList {
     /// console.log(list.get(0));  // 100
     /// console.log(list.get(1));  // undefined
     /// ```
+    #[wasm_bindgen(skip_typescript)]
     pub fn get(&self, index: usize) -> JsValueOrContainerOrUndefined {
         let Some(v) = self.handler.get_(index) else {
             return JsValue::UNDEFINED.into();
@@ -1900,7 +1903,7 @@ impl LoroList {
     /// list.insertContainer(3, new LoroText());
     /// console.log(list.value);  // [100, "foo", true, LoroText];
     /// ```
-    #[wasm_bindgen(js_name = "toArray", method)]
+    #[wasm_bindgen(js_name = "toArray", method, skip_typescript)]
     pub fn to_array(&mut self) -> Vec<JsValueOrContainer> {
         let mut arr: Vec<JsValueOrContainer> = Vec::with_capacity(self.length());
         self.handler.for_each(|x| {

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -172,12 +172,54 @@ declare module "loro-wasm" {
   interface Loro<
     T extends Record<string, Container> = Record<string, Container>,
   > {
+    /**
+     * Get a LoroMap by container id
+     *
+     * The object returned is a new js object each time because it need to cross
+     * the WASM boundary.
+     *
+     * @example
+     * ```ts
+     * import { Loro } from "loro-crdt";
+     *
+     * const doc = new Loro();
+     * const map = doc.getMap("map");
+     * ```
+     */
     getMap<Key extends keyof T>(
       name: Key,
     ): T[Key] extends LoroMap ? T[Key] : LoroMap;
+    /**
+     * Get a LoroList by container id
+     *
+     * The object returned is a new js object each time because it need to cross
+     * the WASM boundary.
+     *
+     * @example
+     * ```ts
+     * import { Loro } from "loro-crdt";
+     *
+     * const doc = new Loro();
+     * const list = doc.getList("list");
+     * ```
+     */
     getList<Key extends keyof T>(
       name: Key,
     ): T[Key] extends LoroList ? T[Key] : LoroList;
+    /**
+     * Get a LoroTree by container id
+     *
+     *  The object returned is a new js object each time because it need to cross
+     *  the WASM boundary.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const tree = doc.getTree("tree");
+     *  ```
+     */
     getTree<Key extends keyof T>(
       name: Key,
     ): T[Key] extends LoroTree ? T[Key] : LoroTree;
@@ -186,12 +228,73 @@ declare module "loro-wasm" {
 
   interface LoroList<T = unknown> {
     new (): LoroList<T>;
+    /**
+     *  Get elements of the list. If the value is a child container, the corresponding
+     *  `Container` will be returned.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const list = doc.getList("list");
+     *  list.insert(0, 100);
+     *  list.insert(1, "foo");
+     *  list.insert(2, true);
+     *  list.insertContainer(3, new LoroText());
+     *  console.log(list.value);  // [100, "foo", true, LoroText];
+     *  ```
+     */
     toArray(): T[];
+    /**
+     * Insert a container at the index.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const list = doc.getList("list");
+     *  list.insert(0, 100);
+     *  const text = list.insertContainer(1, new LoroText());
+     *  text.insert(0, "Hello");
+     *  console.log(list.getDeepValue());  // [100, "Hello"];
+     *  ```
+     */
     insertContainer<C extends Container>(
       pos: number,
       child: C,
     ): T extends C ? T : C;
+    /**
+     * Get the value at the index. If the value is a container, the corresponding handler will be returned.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const list = doc.getList("list");
+     *  list.insert(0, 100);
+     *  console.log(list.get(0));  // 100
+     *  console.log(list.get(1));  // undefined
+     *  ```
+     */
     get(index: number): T;
+    /**
+     *  Insert a value at index.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const list = doc.getList("list");
+     *  list.insert(0, 100);
+     *  list.insert(1, "foo");
+     *  list.insert(2, true);
+     *  console.log(list.value);  // [100, "foo", true];
+     *  ```
+     */
     insert(pos: number, value: Exclude<T, Container>): void;
     delete(pos: number, len: number): void;
     subscribe(txn: Loro, listener: Listener): number;
@@ -202,12 +305,74 @@ declare module "loro-wasm" {
     T extends Record<string, unknown> = Record<string, unknown>,
   > {
     new (): LoroMap<T>;
+    /**
+     *  Get the value of the key. If the value is a child container, the corresponding
+     *  `Container` will be returned.
+     *
+     *  The object returned is a new js object each time because it need to cross
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const map = doc.getMap("map");
+     *  map.set("foo", "bar");
+     *  const bar = map.get("foo");
+     *  ```
+     */
     getOrCreateContainer<C extends Container>(key: string, child: C): C;
+    /**
+     * Set the key with a container.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const map = doc.getMap("map");
+     *  map.set("foo", "bar");
+     *  const text = map.setContainer("text", new LoroText());
+     *  const list = map.setContainer("list", new LoroText());
+     *  ```
+     */
     setContainer<C extends Container, Key extends keyof T>(
       key: Key,
       child: C,
     ): NonNullableType<T[Key]> extends C ? NonNullableType<T[Key]> : C;
+    /**
+     *  Get the value of the key. If the value is a child container, the corresponding
+     *  `Container` will be returned.
+     *
+     *  The object/value returned is a new js object/value each time because it need to cross
+     *  the WASM boundary.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const map = doc.getMap("map");
+     *  map.set("foo", "bar");
+     *  const bar = map.get("foo");
+     *  ```
+     */
     get<Key extends keyof T>(key: Key): T[Key];
+    /**
+     * Set the key with the value.
+     *
+     *  If the value of the key is exist, the old value will be updated.
+     *
+     *  @example
+     *  ```ts
+     *  import { Loro } from "loro-crdt";
+     *
+     *  const doc = new Loro();
+     *  const map = doc.getMap("map");
+     *  map.set("foo", "bar");
+     *  map.set("foo", "baz");
+     *  ```
+     */
     set<Key extends keyof T>(key: Key, value: Exclude<T[Key], Container>): void;
     delete(key: string): void;
     subscribe(txn: Loro, listener: Listener): number;
@@ -235,6 +400,9 @@ declare module "loro-wasm" {
   interface LoroTreeNode<
     T extends Record<string, unknown> = Record<string, unknown>,
   > {
+    /**
+     * Get the associated metadata map container of a tree node.
+     */
     readonly data: LoroMap<T>;
     createNode(): LoroTreeNode<T>;
     setAsRoot(): void;

--- a/loro-js/tests/misc.test.ts
+++ b/loro-js/tests/misc.test.ts
@@ -209,39 +209,35 @@ describe("wasm", () => {
 describe("type", () => {
   it("test map type", () => {
     const loro = new Loro<{ map: LoroMap<{ name: "he" }> }>();
-    const map = loro.getTypedMap("map");
-    const v = map.getTyped(loro, "name");
+    const map = loro.getMap("map");
+    const v = map.get("name");
     expectTypeOf(v).toEqualTypeOf<"he">();
   });
 
   it("test recursive map type", () => {
     const loro = new Loro<{ map: LoroMap<{ map: LoroMap<{ name: "he" }> }> }>();
-    const map = loro.getTypedMap("map");
+    const map = loro.getMap("map");
     map.setContainer("map", new LoroMap());
 
-    const subMap = map.getTyped(loro, "map");
-    const name = subMap.getTyped(loro, "name");
+    const subMap = map.get("map");
+    const name = subMap.get("name");
     expectTypeOf(name).toEqualTypeOf<"he">();
   });
 
   it("works for list type", () => {
-    const loro = new Loro<{ list: LoroList<[string, number]> }>();
-    const list = loro.getTypedList("list");
-    list.insertTyped(0, "123");
-    list.insertTyped(1, 123);
-    const v0 = list.getTyped(loro, 0);
+    const loro = new Loro<{ list: LoroList<string> }>();
+    const list = loro.getList("list");
+    list.insert(0, "123");
+    const v0 = list.get(0);
     expectTypeOf(v0).toEqualTypeOf<string>();
-    const v1 = list.getTyped(loro, 1);
-    expectTypeOf(v1).toEqualTypeOf<number>();
   });
 
   it("test binary type", () => {
-    // const loro = new Loro<{ list: LoroList<[string, number]> }>();
-    // const list = loro.getTypedList("list");
-    // console.dir((list as any).__proto__);
-    // list.insertTyped(0, new Uint8Array(10));
-    // const v0 = list.getTyped(loro, 0);
-    // expectTypeOf(v0).toEqualTypeOf<Uint8Array>();
+    const loro = new Loro<{ list: LoroList<Uint8Array> }>();
+    const list = loro.getList("list");
+    list.insert(0, new Uint8Array(10));
+    const v0 = list.get(0);
+    expectTypeOf(v0).toEqualTypeOf<Uint8Array>();
   });
 });
 

--- a/loro-js/tests/type.test.ts
+++ b/loro-js/tests/type.test.ts
@@ -31,3 +31,35 @@ test("Expect container type", () => {
   const tree = new LoroTree();
   expectTypeOf(tree.kind()).toMatchTypeOf<"Tree">();
 });
+
+test("doc type and container type", () => {
+  const doc = new Loro<{
+    text: LoroText;
+    map: LoroMap<{
+      name?: string;
+      note?: LoroText;
+      fav?: LoroList<string>;
+      num?: LoroList<number>;
+    }>;
+  }>();
+
+  const map = doc.getMap("map");
+  expectTypeOf(map).toMatchTypeOf<
+    LoroMap<{
+      name?: string;
+      note?: LoroText;
+      fav?: LoroList<string>;
+    }>
+  >();
+  expectTypeOf(map).toMatchTypeOf<LoroMap>();
+  expectTypeOf(map).toMatchTypeOf<LoroMap<{ name?: string }>>();
+  expectTypeOf(map).not.toMatchTypeOf<LoroMap<{ name: number }>>();
+  expectTypeOf(map).not.toMatchTypeOf<LoroMap<{ a: number }>>();
+  expectTypeOf(map.get("name")).toMatchTypeOf<string | undefined>();
+  expectTypeOf(map.get("note")).toMatchTypeOf<LoroText | undefined>();
+  expectTypeOf(map.get("fav")).toMatchTypeOf<LoroList<string> | undefined>();
+  const list = map.setContainer("fav", new LoroList());
+  expectTypeOf(list.toArray()).toMatchTypeOf<string[]>();
+  const numList = map.setContainer("num", new LoroList());
+  expectTypeOf(list.toArray()).toMatchTypeOf<string[]>();
+});


### PR DESCRIPTION
The APIs like `.getTyped()` `getTypedMap()`... are removed. 

Now the following code is valid 

```ts
  const doc = new Loro();
  const t = doc.getText("t");
  expectTypeOf(getType(t)).toEqualTypeOf<"Text">();
  expect(getType(t)).toBe("Text");
  expectTypeOf(getType(123)).toEqualTypeOf<"Json">();
  expect(getType(123)).toBe("Json");
  expectTypeOf(getType(undefined)).toEqualTypeOf<"Json">();
  expect(getType(undefined)).toBe("Json");
  expectTypeOf(getType(null)).toEqualTypeOf<"Json">();
  expect(getType(null)).toBe("Json");
  expectTypeOf(getType({})).toEqualTypeOf<"Json">();
  expect(getType({})).toBe("Json");

  const map = doc.getMap("map");
  const list = doc.getList("list");
  const tree = doc.getTree("tree");
  const text = doc.getText("text");
  expectTypeOf(getType(map)).toEqualTypeOf<"Map">();
  expect(getType(map)).toBe("Map");
  expectTypeOf(getType(list)).toEqualTypeOf<"List">();
  expect(getType(list)).toBe("List");
  expectTypeOf(getType(tree)).toEqualTypeOf<"Tree">();
  expect(getType(tree)).toBe("Tree");
  expectTypeOf(getType(text)).toEqualTypeOf<"Text">();
  expect(getType(text)).toBe("Text");
```