### PR TITLE
refactor: use Replace instead of insert+del in DeltaItem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ version = "0.4.0"
 dependencies = [
  "either",
  "enum-as-inner 0.6.0",
+ "generic-btree",
  "loro-delta",
  "loro-internal",
  "serde_json",
@@ -847,12 +848,15 @@ name = "loro-delta"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "color-backtrace 0.6.1",
  "criterion",
+ "ctor 0.2.7",
  "enum-as-inner 0.5.1",
  "generic-btree",
  "heapless 0.8.0",
  "rand",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "generic-btree"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37228ca04c3a6294efe79086912232d515e9f7f535aa7155856487567d88468"
+checksum = "c05c413c5992bd92a1e5ef505afdcf14fad30115a52118dcc246636466c04672"
 dependencies = [
  "arref",
  "fxhash",

--- a/crates/delta/Cargo.toml
+++ b/crates/delta/Cargo.toml
@@ -15,6 +15,9 @@ enum-as-inner = "0.5.1"
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
 rand = { version = "0.8.5" }
+tracing-subscriber = "0.3.18"
+color-backtrace = "0.6.1"
+ctor = "0.2"
 
 
 [[bench]]

--- a/crates/delta/Cargo.toml
+++ b/crates/delta/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 arrayvec = "0.7.4"
-generic-btree = { version = "0.10.2" }
+generic-btree = { version = "^0.10.3" }
 heapless = "0.8.0"
 tracing = "0.1.40"
 enum-as-inner = "0.5.1"

--- a/crates/delta/src/array_vec.rs
+++ b/crates/delta/src/array_vec.rs
@@ -74,9 +74,10 @@ impl<V: Debug + Clone, const C: usize, Attr: DeltaAttr> DeltaRope<ArrayVec<V, C>
         let mut rope = DeltaRope::new();
         rope.insert_values(
             0,
-            ArrayVec::from_many(iter).map(|x| crate::DeltaItem::Insert {
+            ArrayVec::from_many(iter).map(|x| crate::DeltaItem::Replace {
                 value: x,
                 attr: Default::default(),
+                delete: 0,
             }),
         );
 

--- a/crates/delta/src/delta_item.rs
+++ b/crates/delta/src/delta_item.rs
@@ -2,13 +2,32 @@ use generic_btree::rle::{CanRemove, TryInsert};
 
 use super::*;
 
-impl<V: DeltaValue, Attr> DeltaItem<V, Attr> {
+impl<V: DeltaValue, Attr: DeltaAttr> DeltaItem<V, Attr> {
     /// The real length of the item in the delta
     pub fn delta_len(&self) -> usize {
         match self {
-            DeltaItem::Delete(len) => *len,
             DeltaItem::Retain { len, .. } => *len,
-            DeltaItem::Insert { value, .. } => value.rle_len(),
+            DeltaItem::Replace {
+                value,
+                attr,
+                delete,
+            } => value.rle_len() + delete,
+        }
+    }
+
+    pub fn new_delete(len: usize) -> Self {
+        DeltaItem::Replace {
+            value: Default::default(),
+            attr: Default::default(),
+            delete: len,
+        }
+    }
+
+    pub fn new_insert(value: V, attr: Attr) -> Self {
+        DeltaItem::Replace {
+            value,
+            attr,
+            delete: 0,
         }
     }
 }
@@ -17,9 +36,8 @@ impl<V: DeltaValue, Attr> HasLength for DeltaItem<V, Attr> {
     /// This would treat the len of the Delete as 0
     fn rle_len(&self) -> usize {
         match self {
-            DeltaItem::Delete(_) => 0,
             DeltaItem::Retain { len, .. } => *len,
-            DeltaItem::Insert { value, .. } => value.rle_len(),
+            DeltaItem::Replace { value, delete, .. } => value.rle_len(),
         }
     }
 }
@@ -27,18 +45,19 @@ impl<V: DeltaValue, Attr> HasLength for DeltaItem<V, Attr> {
 impl<V: Mergeable, Attr: PartialEq> Mergeable for DeltaItem<V, Attr> {
     fn can_merge(&self, rhs: &Self) -> bool {
         match (self, rhs) {
-            (DeltaItem::Delete(_), DeltaItem::Delete(_)) => true,
             (DeltaItem::Retain { attr: attr1, .. }, DeltaItem::Retain { attr: attr2, .. }) => {
                 attr1 == attr2
             }
             (
-                DeltaItem::Insert {
+                DeltaItem::Replace {
                     value: value1,
                     attr: attr1,
+                    delete: del1,
                 },
-                DeltaItem::Insert {
+                DeltaItem::Replace {
                     value: value2,
                     attr: attr2,
+                    delete: del2,
                 },
             ) => value1.can_merge(value2) && attr1 == attr2,
             _ => false,
@@ -47,14 +66,23 @@ impl<V: Mergeable, Attr: PartialEq> Mergeable for DeltaItem<V, Attr> {
 
     fn merge_right(&mut self, rhs: &Self) {
         match (self, rhs) {
-            (DeltaItem::Delete(a), DeltaItem::Delete(b)) => {
-                *a += *b;
-            }
             (DeltaItem::Retain { len: len1, .. }, DeltaItem::Retain { len: len2, .. }) => {
                 *len1 += len2
             }
-            (DeltaItem::Insert { value: value1, .. }, DeltaItem::Insert { value: value2, .. }) => {
+            (
+                DeltaItem::Replace {
+                    value: value1,
+                    delete: del1,
+                    ..
+                },
+                DeltaItem::Replace {
+                    value: value2,
+                    delete: del2,
+                    ..
+                },
+            ) => {
                 value1.merge_right(value2);
+                *del1 += *del2;
             }
             _ => unreachable!(),
         }
@@ -62,14 +90,23 @@ impl<V: Mergeable, Attr: PartialEq> Mergeable for DeltaItem<V, Attr> {
 
     fn merge_left(&mut self, left: &Self) {
         match (self, left) {
-            (DeltaItem::Delete(a), DeltaItem::Delete(b)) => {
-                *a += *b;
-            }
             (DeltaItem::Retain { len: len1, .. }, DeltaItem::Retain { len: len2, .. }) => {
                 *len1 += len2
             }
-            (DeltaItem::Insert { value: value1, .. }, DeltaItem::Insert { value: value2, .. }) => {
+            (
+                DeltaItem::Replace {
+                    value: value1,
+                    delete: del1,
+                    ..
+                },
+                DeltaItem::Replace {
+                    value: value2,
+                    delete: del2,
+                    ..
+                },
+            ) => {
                 value1.merge_left(value2);
+                *del1 += del2;
             }
             _ => unreachable!(),
         }
@@ -79,10 +116,6 @@ impl<V: Mergeable, Attr: PartialEq> Mergeable for DeltaItem<V, Attr> {
 impl<V: DeltaValue, Attr: Clone> Sliceable for DeltaItem<V, Attr> {
     fn _slice(&self, range: std::ops::Range<usize>) -> Self {
         match self {
-            DeltaItem::Delete(d) => {
-                assert!(range.end <= *d);
-                DeltaItem::Delete(range.len())
-            }
             DeltaItem::Retain { len, attr } => {
                 assert!(range.end <= *len);
                 DeltaItem::Retain {
@@ -90,11 +123,16 @@ impl<V: DeltaValue, Attr: Clone> Sliceable for DeltaItem<V, Attr> {
                     attr: attr.clone(),
                 }
             }
-            DeltaItem::Insert { value, attr } => {
+            DeltaItem::Replace {
+                value,
+                attr,
+                delete,
+            } => {
                 let value = value._slice(range.clone());
-                DeltaItem::Insert {
+                DeltaItem::Replace {
                     value,
                     attr: attr.clone(),
+                    delete: *delete,
                 }
             }
         }
@@ -107,10 +145,6 @@ impl<V: DeltaValue, Attr: Clone + PartialEq> TryInsert for DeltaItem<V, Attr> {
         Self: Sized,
     {
         match (self, elem) {
-            (DeltaItem::Delete(a), DeltaItem::Delete(b)) => {
-                *a += b;
-                Ok(())
-            }
             (
                 DeltaItem::Retain { len, attr },
                 DeltaItem::Retain {
@@ -129,30 +163,34 @@ impl<V: DeltaValue, Attr: Clone + PartialEq> TryInsert for DeltaItem<V, Attr> {
                 }
             }
             (
-                DeltaItem::Insert {
+                DeltaItem::Replace {
                     value: l_value,
                     attr: l_attr,
+                    delete: l_delete,
                 },
-                DeltaItem::Insert {
+                DeltaItem::Replace {
                     value: r_value,
                     attr: r_attr,
+                    delete: r_delete,
                 },
             ) => {
                 if l_attr == &r_attr {
                     match l_value.try_insert(pos, r_value) {
                         Ok(_) => return Ok(()),
                         Err(v) => {
-                            return Err(DeltaItem::Insert {
+                            return Err(DeltaItem::Replace {
                                 value: v,
                                 attr: l_attr.clone(),
+                                delete: *l_delete + r_delete,
                             })
                         }
                     }
                 }
 
-                Err(DeltaItem::Insert {
+                Err(DeltaItem::Replace {
                     value: r_value,
                     attr: r_attr,
+                    delete: r_delete,
                 })
             }
             (_, a) => Err(a),
@@ -163,9 +201,21 @@ impl<V: DeltaValue, Attr: Clone + PartialEq> TryInsert for DeltaItem<V, Attr> {
 impl<V: DeltaValue, Attr: Clone> CanRemove for DeltaItem<V, Attr> {
     fn can_remove(&self) -> bool {
         match self {
-            DeltaItem::Delete(len) => *len == 0,
             DeltaItem::Retain { len, .. } => *len == 0,
-            DeltaItem::Insert { value, .. } => value.rle_len() == 0,
+            DeltaItem::Replace {
+                value,
+                attr,
+                delete,
+            } => value.rle_len() == 0 && *delete == 0,
+        }
+    }
+}
+
+impl<V: DeltaValue, Attr: DeltaAttr> Default for DeltaItem<V, Attr> {
+    fn default() -> Self {
+        DeltaItem::Retain {
+            len: 0,
+            attr: Default::default(),
         }
     }
 }

--- a/crates/delta/src/delta_rope/rle_tree.rs
+++ b/crates/delta/src/delta_rope/rle_tree.rs
@@ -95,17 +95,17 @@ impl<V: DeltaValue + Debug, Attr: DeltaAttr + Debug> BTreeTrait for DeltaTreeTra
 
     fn get_elem_cache(elem: &Self::Elem) -> Self::Cache {
         match elem {
-            DeltaItem::Delete(d) => Len {
-                new_len: 0,
-                old_len: *d as isize,
-            },
             DeltaItem::Retain { len, attr } => Len {
                 new_len: *len as isize,
                 old_len: *len as isize,
             },
-            DeltaItem::Insert { value, attr } => Len {
+            DeltaItem::Replace {
+                value,
+                attr,
+                delete,
+            } => Len {
                 new_len: value.rle_len() as isize,
-                old_len: 0,
+                old_len: *delete as isize,
             },
         }
     }

--- a/crates/delta/src/delta_trait.rs
+++ b/crates/delta/src/delta_trait.rs
@@ -2,7 +2,10 @@ use generic_btree::rle::{HasLength, Mergeable, Sliceable, TryInsert};
 use std::hash::{BuildHasher, Hash};
 use std::{collections::HashMap, fmt::Debug};
 
-pub trait DeltaValue: HasLength + Sliceable + Mergeable + TryInsert + Debug + Clone {}
+pub trait DeltaValue:
+    HasLength + Sliceable + Mergeable + TryInsert + Debug + Clone + Default
+{
+}
 
 pub trait DeltaAttr: Clone + PartialEq + Debug + Default {
     fn compose(&mut self, other: &Self);

--- a/crates/delta/src/lib.rs
+++ b/crates/delta/src/lib.rs
@@ -29,7 +29,20 @@ pub struct DeltaRopeBuilder<V: DeltaValue, Attr: DeltaAttr> {
 
 #[derive(Debug, Clone, PartialEq, Eq, EnumAsInner)]
 pub enum DeltaItem<V, Attr> {
-    Retain { len: usize, attr: Attr },
-    Insert { value: V, attr: Attr },
-    Delete(usize),
+    Retain {
+        len: usize,
+        attr: Attr,
+    },
+    /// This is the combined of a delete and an insert.
+    ///
+    /// They are two separate operations in the original Quill Delta format.
+    /// But the order of two neighboring delete and insert operations can be
+    /// swapped without changing the result. So Quill requires that the insert
+    /// always comes before the delete. So it creates room for invalid deltas
+    /// by the type system. Using Replace is a way to avoid this.
+    Replace {
+        value: V,
+        attr: Attr,
+        delete: usize,
+    },
 }

--- a/crates/delta/src/text_delta.rs
+++ b/crates/delta/src/text_delta.rs
@@ -23,9 +23,10 @@ impl<Attr: DeltaAttr> TextDelta<Attr> {
 
         self.insert_values(
             index,
-            TextChunk::from_long_str(s).map(|chunk| DeltaItem::Insert {
+            TextChunk::from_long_str(s).map(|chunk| DeltaItem::Replace {
                 value: chunk,
                 attr: Default::default(),
+                delete: 0,
             }),
         );
     }
@@ -64,9 +65,8 @@ impl<Attr: DeltaAttr> TextDelta<Attr> {
         let mut ans = String::with_capacity(self.len());
         for item in self.iter() {
             match item {
-                crate::DeltaItem::Delete(_) => return None,
                 crate::DeltaItem::Retain { .. } => return None,
-                crate::DeltaItem::Insert { value, .. } => {
+                crate::DeltaItem::Replace { value, .. } => {
                     ans.push_str(&value.0);
                 }
             }

--- a/crates/delta/src/utf16.rs
+++ b/crates/delta/src/utf16.rs
@@ -121,4 +121,13 @@ impl<S: AsRef<str> + Sliceable + TryInsert> TryInsert for AsUtf16Index<S> {
     }
 }
 
+impl<S: AsRef<str> + DeltaValue> Default for AsUtf16Index<S> {
+    fn default() -> Self {
+        Self {
+            s: S::default(),
+            utf16_len: 0,
+        }
+    }
+}
+
 impl<S: AsRef<str> + DeltaValue> DeltaValue for AsUtf16Index<S> {}

--- a/crates/delta/tests/test_text_delta.rs
+++ b/crates/delta/tests/test_text_delta.rs
@@ -4,6 +4,24 @@ use loro_delta::{
     text_delta::{TextChunk, TextDelta},
     DeltaRopeBuilder,
 };
+use tracing_subscriber::fmt::format::FmtSpan;
+
+#[ctor::ctor]
+fn init_color_backtrace() {
+    color_backtrace::install();
+    use tracing_subscriber::{prelude::*, registry::Registry};
+    if option_env!("DEBUG").is_some() {
+        tracing::subscriber::set_global_default(
+            Registry::default().with(
+                tracing_subscriber::fmt::Layer::default()
+                    .with_file(true)
+                    .with_line_number(true)
+                    .with_span_events(FmtSpan::ACTIVE),
+            ),
+        )
+        .unwrap();
+    }
+}
 
 #[test]
 fn text_delta() {

--- a/crates/delta/tests/text_delta.rs
+++ b/crates/delta/tests/text_delta.rs
@@ -81,8 +81,7 @@ fn compose_long_delete() {
         a,
         DeltaRopeBuilder::new()
             .retain(2, ())
-            .delete(9)
-            .insert(TextChunk::try_from_str("34567890").unwrap(), ())
+            .replace(TextChunk::try_from_str("34567890").unwrap(), (), 9)
             .build()
     );
 }

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -16,9 +16,9 @@ fxhash = { workspace = true }
 enum_dispatch = { workspace = true }
 enum-as-inner = { workspace = true }
 rand = "0.8.5"
-tracing-subscriber = "0.3.18"
-color-backtrace = "0.6.1"
-ctor = "0.2"
 
 [dev-dependencies]
 arbtest = "^0.2.0"
+tracing-subscriber = "0.3.18"
+color-backtrace = "0.6.1"
+ctor = "0.2"

--- a/crates/fuzz/fuzz/Cargo.lock
+++ b/crates/fuzz/fuzz/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "append-only-bytes"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,21 +43,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bitflags"
@@ -131,30 +101,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "color-backtrace"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150fd80a270c0671379f388c8204deb6a746bb4eac8a6c03fe2460b2c0127ea0"
-dependencies = [
- "backtrace",
- "termcolor",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
-name = "ctor"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
-dependencies = [
- "quote",
- "syn 2.0.50",
-]
 
 [[package]]
 name = "darling"
@@ -270,8 +220,6 @@ name = "fuzz"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "color-backtrace",
- "ctor",
  "debug-log",
  "enum-as-inner 0.5.1",
  "enum_dispatch",
@@ -280,7 +228,6 @@ dependencies = [
  "rand",
  "tabled",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -303,8 +250,6 @@ dependencies = [
 [[package]]
 name = "generic-btree"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37228ca04c3a6294efe79086912232d515e9f7f535aa7155856487567d88468"
 dependencies = [
  "arref",
  "fxhash",
@@ -324,12 +269,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "hash32"
@@ -424,12 +363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,17 +396,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
 name = "loro"
 version = "0.4.0"
 dependencies = [
  "either",
  "enum-as-inner 0.6.0",
+ "generic-btree",
  "loro-delta",
  "loro-internal",
 ]
@@ -574,21 +502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
-name = "memchr"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,16 +512,6 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
 
 [[package]]
 name = "num"
@@ -697,25 +600,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "papergrid"
@@ -881,12 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,15 +849,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -1085,15 +958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,16 +975,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.50",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1152,32 +1006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1199,12 +1027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,37 +1037,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-targets"

--- a/crates/fuzz/src/container/text.rs
+++ b/crates/fuzz/src/container/text.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use loro::{Container, ContainerID, ContainerType, LoroDoc, LoroText};
+use tracing::trace;
 
 use crate::{
     actions::{Actionable, FromGenericAction, GenericAction},

--- a/crates/fuzz/src/crdt_fuzzer.rs
+++ b/crates/fuzz/src/crdt_fuzzer.rs
@@ -5,7 +5,6 @@ use fxhash::FxHashSet;
 use loro::{ContainerType, Frontiers};
 use tabled::TableIteratorExt;
 use tracing::info_span;
-use tracing_subscriber::fmt::format::FmtSpan;
 
 use crate::array_mut_ref;
 

--- a/crates/fuzz/tests/test.rs
+++ b/crates/fuzz/tests/test.rs
@@ -583,7 +583,6 @@ fn list_delete_change_to_diff_assert() {
         ],
     )
 }
-
 #[test]
 fn delta_err_2() {
     test_multi_sites(
@@ -1010,6 +1009,89 @@ fn delta_err_2() {
                     value: I32(-16777216),
                     bool: true,
                     key: 45,
+                    pos: 0,
+                    length: 0,
+                    prop: 0,
+                }),
+            },
+        ],
+    )
+}
+
+#[test]
+fn delta_err_3() {
+    test_multi_sites(
+        5,
+        vec![
+            FuzzTarget::Map,
+            FuzzTarget::List,
+            FuzzTarget::Tree,
+            FuzzTarget::Text,
+        ],
+        &mut [
+            Handle {
+                site: 0,
+                target: 0,
+                container: 11,
+                action: Generic(GenericAction {
+                    value: I32(-65475),
+                    bool: true,
+                    key: 67108863,
+                    pos: 72057594037871521,
+                    length: 217020518514230020,
+                    prop: 280883327347844581,
+                }),
+            },
+            Sync { from: 163, to: 215 },
+            Handle {
+                site: 0,
+                target: 0,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: I32(257),
+                    bool: false,
+                    key: 0,
+                    pos: 0,
+                    length: 7936,
+                    prop: 18446743017316026880,
+                }),
+            },
+            Handle {
+                site: 133,
+                target: 0,
+                container: 199,
+                action: Generic(GenericAction {
+                    value: Container(Tree),
+                    bool: false,
+                    key: 2717908991,
+                    pos: 2155061665,
+                    length: 18446463698227810304,
+                    prop: 9476562641788076031,
+                }),
+            },
+            Sync { from: 255, to: 255 },
+            SyncAll,
+            Handle {
+                site: 0,
+                target: 0,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: Container(Tree),
+                    bool: true,
+                    key: 791643507,
+                    pos: 18446744073709551568,
+                    length: 2965947086361162589,
+                    prop: 18446744070104864675,
+                }),
+            },
+            Handle {
+                site: 0,
+                target: 0,
+                container: 199,
+                action: Generic(GenericAction {
+                    value: I32(-1547197533),
+                    bool: true,
+                    key: 4294912471,
                     pos: 0,
                     length: 0,
                     prop: 0,

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -37,7 +37,7 @@ append-only-bytes = { version = "0.1.12", features = ["u32_range"] }
 itertools = "0.11.0"
 enum_dispatch = { workspace = true }
 im = "15.1.0"
-generic-btree = { version = "0.10.2" }
+generic-btree = { version = "^0.10.3" }
 getrandom = "0.2.10"
 once_cell = "1.18.0"
 leb128 = "0.2.5"

--- a/crates/loro-internal/examples/event.rs
+++ b/crates/loro-internal/examples/event.rs
@@ -15,7 +15,7 @@ fn main() {
             match &container_diff.diff {
                 Diff::List(list) => {
                     for item in list.iter() {
-                        if let loro_delta::DeltaItem::Insert { value, .. } = item {
+                        if let loro_delta::DeltaItem::Replace { value, .. } = item {
                             for v in value.iter() {
                                 match v {
                                     ValueOrHandler::Handler(h) => {

--- a/crates/loro-internal/fuzz/Cargo.lock
+++ b/crates/loro-internal/fuzz/Cargo.lock
@@ -210,8 +210,6 @@ dependencies = [
 [[package]]
 name = "generic-btree"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37228ca04c3a6294efe79086912232d515e9f7f535aa7155856487567d88468"
 dependencies = [
  "arref",
  "fxhash",

--- a/crates/loro-internal/src/fuzz/richtext.rs
+++ b/crates/loro-internal/src/fuzz/richtext.rs
@@ -88,7 +88,7 @@ impl Actor {
                         let mut txn = text_doc.txn().unwrap();
                         let text_h = text_doc.get_text("text");
                         // println!("diff {:?}", text_diff);
-                        let text_deltas = text_diff.iter().map(TextDelta::from).collect::<Vec<_>>();
+                        let text_deltas = TextDelta::from_text_diff(text_diff.iter());
                         // println!(
                         //     "\n{} before {:?}",
                         //     text_doc.peer_id(),

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -353,7 +353,7 @@ pub enum TextDelta {
 }
 
 impl TextDelta {
-    pub fn from_text_diff<'a>(mut diff: impl Iterator<Item = &'a TextDiffItem>) -> Vec<TextDelta> {
+    pub fn from_text_diff<'a>(diff: impl Iterator<Item = &'a TextDiffItem>) -> Vec<TextDelta> {
         let mut ans = Vec::with_capacity(diff.size_hint().0);
         for iter in diff {
             match iter {

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -18,6 +18,7 @@ use crate::{
 use append_only_bytes::BytesSlice;
 use enum_as_inner::EnumAsInner;
 use fxhash::FxHashMap;
+use generic_btree::rle::HasLength;
 use loro_common::{
     ContainerID, ContainerType, Counter, IdFull, InternalString, LoroError, LoroResult,
     LoroTreeError, LoroValue, PeerID, TreeID, ID,
@@ -351,19 +352,36 @@ pub enum TextDelta {
     },
 }
 
-impl From<&TextDiffItem> for TextDelta {
-    fn from(value: &TextDiffItem) -> Self {
-        match value {
-            loro_delta::DeltaItem::Retain { len, attr } => TextDelta::Retain {
-                retain: *len,
-                attributes: attr.to_option_map(),
-            },
-            loro_delta::DeltaItem::Insert { value, attr } => TextDelta::Insert {
-                insert: value.to_string(),
-                attributes: attr.to_option_map(),
-            },
-            loro_delta::DeltaItem::Delete(delete) => TextDelta::Delete { delete: *delete },
+impl TextDelta {
+    pub fn from_text_diff<'a>(mut diff: impl Iterator<Item = &'a TextDiffItem>) -> Vec<TextDelta> {
+        let mut ans = Vec::with_capacity(diff.size_hint().0);
+        for iter in diff {
+            match iter {
+                loro_delta::DeltaItem::Retain { len, attr } => {
+                    ans.push(TextDelta::Retain {
+                        retain: *len,
+                        attributes: attr.to_option_map(),
+                    });
+                }
+                loro_delta::DeltaItem::Replace {
+                    value,
+                    attr,
+                    delete,
+                } => {
+                    if value.rle_len() > 0 {
+                        ans.push(TextDelta::Insert {
+                            insert: value.to_string(),
+                            attributes: attr.to_option_map(),
+                        });
+                    }
+                    if *delete > 0 {
+                        ans.push(TextDelta::Delete { delete: *delete });
+                    }
+                }
+            }
         }
+
+        ans
     }
 }
 

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1204,9 +1204,10 @@ impl SubContainerDiffPatch {
         match state_diff {
             Diff::List(list) => {
                 for delta in list.iter() {
-                    if let loro_delta::DeltaItem::Insert {
+                    if let loro_delta::DeltaItem::Replace {
                         value: values,
                         attr,
+                        ..
                     } = delta
                     {
                         for v in values.iter() {

--- a/crates/loro-internal/src/utils/string_slice.rs
+++ b/crates/loro-internal/src/utils/string_slice.rs
@@ -214,9 +214,9 @@ impl TryInsert for StringSlice {
             Variant::Owned(s) => {
                 if s.capacity() >= s.len() + elem.len_bytes() {
                     let pos = if cfg!(feature = "wasm") {
-                        utf16_to_utf8_index(self.as_str(), pos).unwrap()
+                        utf16_to_utf8_index(s.as_str(), pos).unwrap()
                     } else {
-                        unicode_to_utf8_index(self.as_str(), pos).unwrap()
+                        unicode_to_utf8_index(s.as_str(), pos).unwrap()
                     };
                     s.insert_str(pos, elem.as_str());
                     Ok(())
@@ -314,8 +314,15 @@ impl Sliceable for StringSlice {
     }
 }
 
-impl loro_delta::delta_trait::DeltaValue for StringSlice {}
+impl Default for StringSlice {
+    fn default() -> Self {
+        StringSlice {
+            bytes: Variant::Owned(String::with_capacity(32)),
+        }
+    }
+}
 
+impl loro_delta::delta_trait::DeltaValue for StringSlice {}
 pub fn unicode_range_to_byte_range(s: &str, start: usize, end: usize) -> (usize, usize) {
     debug_assert!(start <= end);
     let start_unicode_index = start;

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -127,7 +127,7 @@ fn handler_in_event() {
             .iter()
             .next()
             .unwrap()
-            .as_insert()
+            .as_replace()
             .unwrap()
             .0
             .iter()

--- a/crates/loro/Cargo.toml
+++ b/crates/loro/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crdt", "local-first"]
 
 [dependencies]
 loro-internal = { path = "../loro-internal", version = "0.4.0" }
-generic-btree = "0.10"
+generic-btree = { version = "0.10.3" }
 enum-as-inner = "0.6.0"
 either = "1.9.0"
 delta = { path = "../delta", package = "loro-delta" }

--- a/crates/loro/Cargo.toml
+++ b/crates/loro/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["crdt", "local-first"]
 
 [dependencies]
 loro-internal = { path = "../loro-internal", version = "0.4.0" }
+generic-btree = "0.10"
 enum-as-inner = "0.6.0"
 either = "1.9.0"
 delta = { path = "../delta", package = "loro-delta" }


### PR DESCRIPTION
Refactor [DeltaItem] to Introduce [Replace]Variant for Enhanced Operation Semantics

This commit introduces the [Replace] variant within the [DeltaItem] enum, serving as a unified representation of delete and insert operations. In the original Quill Delta format, delete and insert are distinct operations. However, their sequential order can be interchanged without affecting the overall outcome. Quill mandates that an insert operation precedes a delete to maintain consistency. This requirement, however, introduces the potential for generating invalid deltas through the type system. The introduction of the [Replace] variant addresses this issue by encapsulating both operations into a single, atomic action, thereby streamlining the operational semantics and eliminating the possibility of generating invalid deltas due to operation ordering.