### PR TITLE
fix: upgrade wasm-bindgen to fix str free err

### DIFF
--- a/.github/workflows/release_wasm.yml
+++ b/.github/workflows/release_wasm.yml
@@ -40,7 +40,7 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - uses: jetli/wasm-bindgen-action@v0.2.0
         with:
-          version: "0.2.90"
+          version: "0.2.92"
       - uses: Swatinem/rust-cache@v2
       - name: Build WASM release-build
         run: pnpm release-wasm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - uses: jetli/wasm-bindgen-action@v0.2.0
         with:
-          version: "0.2.90"
+          version: "0.2.92"
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 3. **Node**: Install from the Node.js website.
 4. **pnpm**: Run `npm i -g pnpm` for global installation.
 5. **Rust Target**: Add with `rustup target add wasm32-unknown-unknown`.
-6. **wasm-bindgen-cli**: Install version 0.2.90 via `cargo install wasm-bindgen-cli --version 0.2.90`.
+6. **wasm-bindgen-cli**: Install version 0.2.92 via `cargo install wasm-bindgen-cli --version 0.2.92`.
 6. **wasm-opt**: Install using `cargo install wasm-opt --locked`.
 7. **wasm-snip**: Install using `cargo install wasm-snip`.
 8. **cargo-nextest**: Install using `cargo install cargo-nextest --locked`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,9 +2190,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote 1.0.35",
  "wasm-bindgen-macro-support",
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2 1.0.75",
  "quote 1.0.35",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"

--- a/crates/loro-common/Cargo.toml
+++ b/crates/loro-common/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["crdt", "local-first"]
 rle = { path = "../rle", version = "0.5.1", package = "loro-rle" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.43"
-wasm-bindgen = { version = "=0.2.90", optional = true }
+wasm-bindgen = { version = "=0.2.92", optional = true }
 fxhash = "0.2.1"
 enum-as-inner = "0.6.0"
 string_cache = "0.8"

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -28,7 +28,7 @@ num = "0.4.0"
 rand = { version = "0.8.5" }
 arbitrary = { version = "1", optional = true }
 tabled = { version = "0.10.0", optional = true }
-wasm-bindgen = { version = "=0.2.90", optional = true }
+wasm-bindgen = { version = "=0.2.92", optional = true }
 serde-wasm-bindgen = { version = "0.5.0", optional = true }
 js-sys = { version = "0.3.60", optional = true }
 serde_json = { version = "1" }

--- a/crates/loro-wasm/Cargo.toml
+++ b/crates/loro-wasm/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 js-sys = "0.3.60"
 loro-internal = { path = "../loro-internal", features = ["wasm"] }
-wasm-bindgen = "=0.2.90"
+wasm-bindgen = "=0.2.92"
 serde-wasm-bindgen = { version = "0.5.0" }
 wasm-bindgen-derive = "0.2.1"
 console_error_panic_hook = { version = "0.1.6", optional = true }

--- a/loro-js/tests/richtext.test.ts
+++ b/loro-js/tests/richtext.test.ts
@@ -280,4 +280,10 @@ describe("richtext", () => {
     const ans = doc.getCursorPos(pos3!);
     expect(ans.offset).toBe(3);
   });
+
+  it("Insert cursed str", () => {
+    const doc = new Loro();
+    const text = doc.getText("text");
+    text.insert(0, `“aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`);
+  });
 });


### PR DESCRIPTION
This is a bug triggered by wasm-bindgen. It's fixed already https://github.com/rustwasm/wasm-bindgen/pull/3808.

The bevaior is when you insert `'“aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'` to a LoroText in JS, it panics with the following error message:

```
005573b2:0x1426a5 panicked at /rust/deps/dlmalloc-0.2.6/src/dlmalloc.rs:1198:13:
assertion failed: psize <= size + max_overhead

Stack:

Error
    at __wbg_new_abda76e883ba8a5f (https://local.kymyth.com:5173/node_modules/.vite/deps/loro-crdt.js?v=e1fe92cd:4264:15)
    at wasm://wasm/005573b2:wasm-function[2447]:0x142628
    at wasm://wasm/005573b2:wasm-function[842]:0xe17f0
    at wasm://wasm/005573b2:wasm-function[1916]:0x13738f
    at wasm://wasm/005573b2:wasm-function[1854]:0x135167
    at wasm://wasm/005573b2:wasm-function[2303]:0x13fb40
    at wasm://wasm/005573b2:wasm-function[1139]:0x106da7
    at _LoroText.insert (https://local.kymyth.com:5173/node_modules/.vite/deps/loro-crdt.js?v=e1fe92cd:3125:12)
    at https://local.kymyth.com:5173/src/components/editor-crdt.tsx:25:22
    at iterChanges (https://local.kymyth.com:5173/node_modules/.vite/deps/chunk-7JK3LPOR.js?v=65bcb074:1074:7)
```