### PR TITLE
feat: refine undo impl

### DIFF
--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -7,7 +7,6 @@ use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::mem::take;
 use std::rc::Rc;
-use tracing::debug;
 
 use crate::change::{get_sys_timestamp, Change, Lamport, Timestamp};
 use crate::configure::Configure;

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -154,6 +154,14 @@ impl ListState {
         }
     }
 
+    pub fn contains_child_container(&self, id: &ContainerID) -> bool {
+        let Some(&leaf) = self.child_container_to_leaf.get(id) else {
+            return false;
+        };
+
+        self.list.get_elem(leaf).is_some()
+    }
+
     pub fn get_child_container_index(&self, id: &ContainerID) -> Option<usize> {
         let leaf = *self.child_container_to_leaf.get(id)?;
         self.list.get_elem(leaf)?;
@@ -470,6 +478,10 @@ impl ContainerState for ListState {
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {
         self.get_child_container_index(id).map(Index::Seq)
+    }
+
+    fn contains_child(&self, id: &ContainerID) -> bool {
+        self.contains_child_container(id)
     }
 
     fn get_child_containers(&self) -> Vec<ContainerID> {

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -130,22 +130,27 @@ impl ContainerState for MapState {
     }
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {
-        let s = tracing::span!(tracing::Level::INFO, "Get child index ", id = ?id);
-        let _e = s.enter();
         for (key, value) in self.map.iter() {
-            let s = tracing::span!(tracing::Level::INFO, "Key Value", key = ?key, value = ?value);
-            let _e = s.enter();
             if let Some(LoroValue::Container(x)) = &value.value {
-                tracing::info!("Cmp {:?} with {:?}", &x, &id);
                 if x == id {
-                    tracing::info!("Same");
                     return Some(Index::Key(key.clone()));
                 }
-                tracing::info!("Diff");
             }
         }
 
         None
+    }
+
+    fn contains_child(&self, id: &ContainerID) -> bool {
+        for (_, value) in self.map.iter() {
+            if let Some(LoroValue::Container(x)) = &value.value {
+                if x == id {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     fn get_child_containers(&self) -> Vec<ContainerID> {

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -467,6 +467,10 @@ mod inner {
             ans
         }
 
+        pub fn contains_child_container(&self, id: &ContainerID) -> bool {
+            self.get_child_index(id, IndexType::ForUser).is_some()
+        }
+
         #[inline]
         pub fn get_list_item_by_id(&self, id: IdLp) -> Option<&ListItem> {
             self.id_to_list_leaf
@@ -1281,6 +1285,10 @@ impl ContainerState for MovableListState {
         self.inner
             .get_child_index(id, IndexType::ForUser)
             .map(Index::Seq)
+    }
+
+    fn contains_child(&self, id: &ContainerID) -> bool {
+        self.inner.contains_child_container(id)
     }
 
     #[allow(unused)]

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -594,6 +594,10 @@ impl ContainerState for RichtextState {
         Vec::new()
     }
 
+    fn contains_child(&self, _id: &ContainerID) -> bool {
+        false
+    }
+
     #[doc = " Get a list of ops that can be used to restore the state to the current state"]
     fn encode_snapshot(&self, mut encoder: StateSnapshotEncoder) -> Vec<u8> {
         let iter: &mut dyn Iterator<Item = &RichtextStateChunk>;

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -1020,6 +1020,15 @@ impl ContainerState for TreeState {
         }
     }
 
+    fn contains_child(&self, id: &ContainerID) -> bool {
+        let id = id.as_normal().unwrap();
+        let tree_id = TreeID {
+            peer: *id.0,
+            counter: *id.1,
+        };
+        self.trees.contains_key(&tree_id) && !self.is_node_deleted(&tree_id)
+    }
+
     fn get_child_containers(&self) -> Vec<ContainerID> {
         self.trees
             .keys()

--- a/crates/loro-internal/src/state/unknown_state.rs
+++ b/crates/loro-internal/src/state/unknown_state.rs
@@ -82,6 +82,10 @@ impl ContainerState for UnknownState {
         None
     }
 
+    fn contains_child(&self, _id: &ContainerID) -> bool {
+        false
+    }
+
     #[allow(unused)]
     fn get_child_containers(&self) -> Vec<ContainerID> {
         vec![]

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -16,6 +16,7 @@ use loro_internal::{
         Handler, ListHandler, MapHandler, TextDelta, TextHandler, TreeHandler, ValueOrHandler,
     },
     id::{Counter, TreeID, ID},
+    loro::CommitOptions,
     obs::SubID,
     version::Frontiers,
     ContainerType, DiffEvent, HandlerTrait, LoroDoc, LoroValue, MovableListHandler,
@@ -156,7 +157,7 @@ extern "C" {
     #[wasm_bindgen(typescript_type = "{ update?: Cursor, offset: number, side: Side }")]
     pub type JsCursorQueryAns;
     #[wasm_bindgen(
-        typescript_type = "{ mergeInterval?: number, maxUndoSteps?: number } | undefined"
+        typescript_type = "{ mergeInterval?: number, maxUndoSteps?: number, excludeOriginPrefixes?: string[] } | undefined"
     )]
     pub type JsUndoConfig;
 }
@@ -546,8 +547,10 @@ impl Loro {
     /// If you commit a new change with a timestamp that is less than the existing one,
     /// the largest existing timestamp will be used instead.
     pub fn commit(&self, origin: Option<String>, timestamp: Option<f64>) {
-        self.0
-            .commit_with(origin.map(|x| x.into()), timestamp.map(|x| x as i64), true);
+        let mut options = CommitOptions::default();
+        options.set_origin(origin.as_deref());
+        options.set_timestamp(timestamp.map(|x| x as i64));
+        self.0.commit_with(options);
     }
 
     /// Get a LoroText by container id.
@@ -3312,9 +3315,22 @@ impl UndoManager {
             .unwrap_or(JsValue::from_f64(1000.0))
             .as_f64()
             .unwrap_or(1000.0) as i64;
+        let exclude_origin_prefixes =
+            Reflect::get(&config, &JsValue::from_str("excludeOriginPrefixes"))
+                .ok()
+                .and_then(|val| val.dyn_into::<js_sys::Array>().ok())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|val| val.as_string())
+                        .collect::<Vec<String>>()
+                })
+                .unwrap_or_default();
         let mut undo = InnerUndoManager::new(&doc.0);
         undo.set_max_undo_steps(max_undo_steps);
         undo.set_merge_interval(merge_interval);
+        for prefix in exclude_origin_prefixes {
+            undo.add_exclude_origin_prefix(&prefix);
+        }
         UndoManager {
             undo,
             doc: doc.0.clone(),
@@ -3354,6 +3370,17 @@ impl UndoManager {
     /// Otherwise, the undo steps will be merged if the interval between the two steps is less than the given interval.
     pub fn setMergeInterval(&mut self, interval: f64) {
         self.undo.set_merge_interval(interval as i64);
+    }
+
+    /// If a local event's origin matches the given prefix, it will not be recorded in the
+    /// undo stack.
+    pub fn addExcludeOriginPrefix(&mut self, prefix: String) {
+        self.undo.add_exclude_origin_prefix(&prefix)
+    }
+
+    /// Check if the undo manager is bound to the given document.
+    pub fn checkBinding(&self, doc: &Loro) -> bool {
+        Arc::ptr_eq(&self.doc, &doc.0)
     }
 }
 

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -3,7 +3,6 @@
 #![warn(missing_debug_implementations)]
 use either::Either;
 use event::{DiffEvent, Subscriber};
-use loro_internal::change::Timestamp;
 use loro_internal::container::IntoContainerId;
 use loro_internal::cursor::CannotFindRelativePosition;
 use loro_internal::cursor::Cursor;
@@ -12,8 +11,7 @@ use loro_internal::cursor::Side;
 use loro_internal::encoding::ImportBlobMetadata;
 use loro_internal::handler::HandlerTrait;
 use loro_internal::handler::ValueOrHandler;
-use loro_internal::loro::CommitWhenDrop;
-use loro_internal::loro_common::IdSpan;
+use loro_internal::loro::CommitOptions;
 use loro_internal::LoroDoc as InnerLoroDoc;
 use loro_internal::OpLog;
 
@@ -266,17 +264,12 @@ impl LoroDoc {
     /// There is a transaction behind every operation.
     /// It will automatically commit when users invoke export or import.
     /// The event will be sent after a transaction is committed
-    pub fn commit_with(
-        &self,
-        origin: Option<&str>,
-        timestamp: Option<Timestamp>,
-        immediate_renew: bool,
-    ) {
-        self.doc
-            .commit_with(origin.map(|x| x.into()), timestamp, immediate_renew)
+    pub fn commit_with(&self, options: CommitOptions) {
+        self.doc.commit_with(options)
     }
 
-    /// Whether the document is in detached mode, where the [loro_internal::DocState] is not synchronized with the latest version of the [loro_internal::OpLog].
+    /// Whether the document is in detached mode, where the [loro_internal::DocState] is not
+    /// synchronized with the latest version of the [loro_internal::OpLog].
     pub fn is_detached(&self) -> bool {
         self.doc.is_detached()
     }
@@ -474,12 +467,6 @@ impl LoroDoc {
         cursor: &Cursor,
     ) -> Result<PosQueryResult, CannotFindRelativePosition> {
         self.doc.query_pos(cursor)
-    }
-
-    /// Undo the operations between the given id_span. It can be used even in a collaborative environment.
-    pub fn undo(&self, id_span: IdSpan) -> LoroResult<CommitWhenDrop> {
-        self.doc
-            .undo_internal(id_span, &mut Default::default(), None, &mut |_| {})
     }
 }
 
@@ -1829,7 +1816,9 @@ pub struct UndoManager(InnerUndoManager);
 impl UndoManager {
     /// Create a new UndoManager.
     pub fn new(doc: &LoroDoc) -> Self {
-        Self(InnerUndoManager::new(&doc.doc))
+        let mut inner = InnerUndoManager::new(&doc.doc);
+        inner.set_max_undo_steps(100);
+        Self(inner)
     }
 
     /// Undo the last change made by the peer.
@@ -1855,5 +1844,21 @@ impl UndoManager {
     /// Whether the undo manager can redo.
     pub fn can_redo(&self) -> bool {
         self.0.can_redo()
+    }
+
+    /// If a local event's origin matches the given prefix, it will not be recorded in the
+    /// undo stack.
+    pub fn add_exclude_origin_prefix(&mut self, prefix: &str) {
+        self.0.add_exclude_origin_prefix(prefix)
+    }
+
+    /// Set the maximum number of undo steps. The default value is 100.
+    pub fn set_max_undo_steps(&mut self, size: usize) {
+        self.0.set_max_undo_steps(size)
+    }
+
+    /// Set the merge interval in ms. The default value is 0, which means no merge.
+    pub fn set_merge_interval(&mut self, interval: i64) {
+        self.0.set_merge_interval(interval)
     }
 }


### PR DESCRIPTION
- Add "unfo" origin for undo and redo event
- Allow users to skip certain local operations
- Skip undo/redo ops that're not visible to users