### PR TITLE
Feat fork

### DIFF
--- a/.changeset/funny-rivers-sin.md
+++ b/.changeset/funny-rivers-sin.md
@@ -1,0 +1,6 @@
+---
+"loro-wasm": patch
+"loro-crdt": patch
+---
+
+Add `.fork()` to duplicate the doc

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -63,6 +63,24 @@ impl SharedArena {
         }
     }
 
+    pub fn fork(&self) -> Self {
+        Self {
+            inner: Arc::new(InnerSharedArena {
+                container_idx_to_id: Mutex::new(
+                    self.inner.container_idx_to_id.lock().unwrap().clone(),
+                ),
+                depth: Mutex::new(self.inner.depth.lock().unwrap().clone()),
+                container_id_to_idx: Mutex::new(
+                    self.inner.container_id_to_idx.lock().unwrap().clone(),
+                ),
+                parents: Mutex::new(self.inner.parents.lock().unwrap().clone()),
+                values: Mutex::new(self.inner.values.lock().unwrap().clone()),
+                root_c_idx: Mutex::new(self.inner.root_c_idx.lock().unwrap().clone()),
+                str: Mutex::new(self.inner.str.lock().unwrap().clone()),
+            }),
+        }
+    }
+
     pub fn register_container(&self, id: &ContainerID) -> ContainerIdx {
         let mut container_id_to_idx = self.inner.container_id_to_idx.lock().unwrap();
         if let Some(&idx) = container_id_to_idx.get(id) {

--- a/crates/loro-internal/src/arena/str_arena.rs
+++ b/crates/loro-internal/src/arena/str_arena.rs
@@ -5,7 +5,7 @@ use append_only_bytes::{AppendOnlyBytes, BytesSlice};
 use crate::container::richtext::richtext_state::unicode_to_utf8_index;
 const INDEX_INTERVAL: u32 = 128;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct StrArena {
     bytes: AppendOnlyBytes,
     unicode_indexes: Vec<Index>,

--- a/crates/loro-internal/src/configure.rs
+++ b/crates/loro-internal/src/configure.rs
@@ -21,6 +21,26 @@ impl Default for Configure {
 }
 
 impl Configure {
+    pub fn fork(&self) -> Self {
+        Self {
+            text_style_config: Arc::new(RwLock::new(
+                self.text_style_config.read().unwrap().clone(),
+            )),
+            record_timestamp: Arc::new(AtomicBool::new(
+                self.record_timestamp
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            )),
+            merge_interval: Arc::new(AtomicI64::new(
+                self.merge_interval
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            )),
+            tree_position_jitter: Arc::new(AtomicU8::new(
+                self.tree_position_jitter
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            )),
+        }
+    }
+
     pub fn text_style_config(&self) -> &Arc<RwLock<StyleConfigMap>> {
         &self.text_style_config
     }

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -79,18 +79,18 @@ pub struct AppDagNode {
     pub(crate) len: usize,
 }
 
-impl Clone for OpLog {
-    fn clone(&self) -> Self {
+impl OpLog {
+    pub(crate) fn fork(&self, arena: SharedArena, configure: Configure) -> Self {
         Self {
             dag: self.dag.clone(),
-            arena: self.arena.clone(),
+            op_groups: self.op_groups.fork(arena.clone()),
+            arena,
             changes: self.changes.clone(),
-            op_groups: self.op_groups.clone(),
             next_lamport: self.next_lamport,
             latest_timestamp: self.latest_timestamp,
             pending_changes: Default::default(),
             batch_importing: false,
-            configure: self.configure.clone(),
+            configure,
         }
     }
 }

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -56,7 +56,6 @@ macro_rules! get_or_create {
     }};
 }
 
-#[derive(Clone)]
 pub struct DocState {
     pub(super) peer: PeerID,
 
@@ -274,6 +273,28 @@ impl DocState {
                 states: FxHashMap::default(),
                 weak_state: weak.clone(),
                 config,
+                global_txn,
+                in_txn: false,
+                changed_idx_in_txn: FxHashSet::default(),
+                event_recorder: Default::default(),
+            })
+        })
+    }
+
+    pub fn fork(
+        &self,
+        arena: SharedArena,
+        global_txn: Weak<Mutex<Option<Transaction>>>,
+        config: Configure,
+    ) -> Arc<Mutex<Self>> {
+        Arc::new_cyclic(|weak| {
+            Mutex::new(Self {
+                peer: DefaultRandom.next_u64(),
+                frontiers: self.frontiers.clone(),
+                states: self.states.clone(),
+                arena,
+                config,
+                weak_state: weak.clone(),
                 global_txn,
                 in_txn: false,
                 changed_idx_in_txn: FxHashSet::default(),

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -483,6 +483,30 @@ impl Loro {
         self.0.is_detached()
     }
 
+    /// Detach the document state from the latest known version.
+    ///
+    /// After detaching, all import operations will be recorded in the `OpLog` without being applied to the `DocState`.
+    /// When `detached`, the document is not editable.
+    ///
+    /// @example
+    /// ```ts
+    /// import { Loro } from "loro-crdt";
+    ///
+    /// const doc = new Loro();
+    /// doc.detach();
+    /// console.log(doc.is_detached());  // true
+    /// ```
+    pub fn detach(&self) {
+        self.0.detach()
+    }
+
+    /// Duplicate the document with a different PeerID
+    ///
+    /// The time complexity and space complexity of this operation are both O(n),
+    pub fn fork(&self) -> Self {
+        Self(Arc::new(self.0.fork()))
+    }
+
     /// Checkout the `DocState` to the latest version of `OpLog`.
     ///
     /// > The document becomes detached during a `checkout` operation.

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -43,6 +43,7 @@ pub use loro_internal::obs::SubID;
 pub use loro_internal::oplog::FrontiersNotIncluded;
 pub use loro_internal::undo;
 pub use loro_internal::version::{Frontiers, VersionVector};
+pub use loro_internal::ApplyDiff;
 pub use loro_internal::JsonSchema;
 pub use loro_internal::UndoManager as InnerUndoManager;
 pub use loro_internal::{loro_value, to_value};
@@ -73,6 +74,14 @@ impl LoroDoc {
         let doc = InnerLoroDoc::default();
         doc.start_auto_commit();
 
+        LoroDoc { doc }
+    }
+
+    /// Duplicate the document with a different PeerID
+    ///
+    /// The time complexity and space complexity of this operation are both O(n),
+    pub fn fork(&self) -> Self {
+        let doc = self.doc.fork();
         LoroDoc { doc }
     }
 

--- a/loro-js/tests/basic.test.ts
+++ b/loro-js/tests/basic.test.ts
@@ -460,3 +460,18 @@ it("get elem by path", () => {
   map1.set("key1", 1);
   expect(doc.getByPath("map/key1")).toBe(1);
 });
+
+it("fork", () => {
+  const doc = new Loro();
+  const map = doc.getMap("map");
+  map.set("key", 1);
+  const doc2 = doc.fork();
+  const map2 = doc2.getMap("map");
+  expect(map2.get("key")).toBe(1);
+  expect(doc2.toJSON()).toStrictEqual({ map: { key: 1 } });
+  map2.set("key", 2);
+  expect(doc.toJSON()).toStrictEqual({ map: { key: 1 } });
+  expect(doc2.toJSON()).toStrictEqual({ map: { key: 2 } });
+  doc.import(doc2.exportSnapshot());
+  expect(doc.toJSON()).toStrictEqual({ map: { key: 2 } });
+});


### PR DESCRIPTION
Add a new `.fork()` method to quickly duplicate the doc with a new `PeerID`.


```ts
const doc = new Loro();
const map = doc.getMap("map");
map.set("key", 1);
const doc2 = doc.fork();
const map2 = doc2.getMap("map");
expect(map2.get("key")).toBe(1);
expect(doc2.toJSON()).toStrictEqual({ map: { key: 1 } });
map2.set("key", 2);
expect(doc.toJSON()).toStrictEqual({ map: { key: 1 } });
expect(doc2.toJSON()).toStrictEqual({ map: { key: 2 } });
doc.import(doc2.exportSnapshot());
expect(doc.toJSON()).toStrictEqual({ map: { key: 2 } });

```