### PR TITLE
perf: make LoroValue.hash lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
  "ctor 0.2.6",
  "flate2",
  "loro 0.16.2",
+ "once_cell",
  "serde_json",
  "tabled 0.15.0",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,7 @@ dependencies = [
  "js-sys",
  "loro-rle 0.16.2",
  "nonmax",
+ "once_cell",
  "serde",
  "serde_columnar",
  "string_cache",
@@ -1420,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"

--- a/crates/bench-utils/src/json.rs
+++ b/crates/bench-utils/src/json.rs
@@ -61,12 +61,12 @@ fn normalize_value(value: &mut LoroValue) {
             }
         }
         LoroValue::List(l) => {
-            for v in Arc::make_mut(l).iter_mut() {
+            for v in Arc::make_mut(l).0.iter_mut() {
                 normalize_value(v);
             }
         }
         LoroValue::Map(m) => {
-            for (_, v) in Arc::make_mut(m).iter_mut() {
+            for (_, v) in Arc::make_mut(m).0.iter_mut() {
                 normalize_value(v);
             }
         }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+once_cell = "1.19.0"
 bench-utils = { path = "../bench-utils" }
 loro = { path = "../loro" }
 tabled = "0.15.0"

--- a/crates/fuzz/src/actor.rs
+++ b/crates/fuzz/src/actor.rs
@@ -351,34 +351,34 @@ pub fn assert_value_eq(a: &LoroValue, b: &LoroValue) {
     fn eq(a: &LoroValue, b: &LoroValue) -> bool {
         match (a, b) {
             (LoroValue::Map(a), LoroValue::Map(b)) => {
-                for (k, v) in a.iter() {
+                for (k, v) in a.0.iter() {
                     let is_empty = match v {
-                        LoroValue::String(s) => s.is_empty(),
-                        LoroValue::List(l) => l.is_empty(),
-                        LoroValue::Map(m) => m.is_empty(),
+                        LoroValue::String(s) => s.0.is_empty(),
+                        LoroValue::List(l) => l.0.is_empty(),
+                        LoroValue::Map(m) => m.0.is_empty(),
                         _ => false,
                     };
                     if is_empty {
                         continue;
                     }
 
-                    if !eq(v, b.get(k).unwrap_or(&LoroValue::Double(0.))) {
+                    if !eq(v, b.0.get(k).unwrap_or(&LoroValue::Double(0.))) {
                         return false;
                     }
                 }
 
-                for (k, v) in b.iter() {
+                for (k, v) in b.0.iter() {
                     let is_empty = match v {
-                        LoroValue::String(s) => s.is_empty(),
-                        LoroValue::List(l) => l.is_empty(),
-                        LoroValue::Map(m) => m.is_empty(),
+                        LoroValue::String(s) => s.0.is_empty(),
+                        LoroValue::List(l) => l.0.is_empty(),
+                        LoroValue::Map(m) => m.0.is_empty(),
                         _ => false,
                     };
                     if is_empty {
                         continue;
                     }
 
-                    if !eq(v, a.get(k).unwrap_or(&LoroValue::Double(0.))) {
+                    if !eq(v, a.0.get(k).unwrap_or(&LoroValue::Double(0.))) {
                         return false;
                     }
                 }
@@ -386,11 +386,11 @@ pub fn assert_value_eq(a: &LoroValue, b: &LoroValue) {
                 true
             }
             (LoroValue::List(a_list), LoroValue::List(b_list)) => {
-                if is_tree_values(a_list.as_ref()) {
-                    assert_tree_value_eq(a_list, b_list);
+                if is_tree_values(a_list.0.as_ref()) {
+                    assert_tree_value_eq(a_list.0.as_ref(), b_list.0.as_ref());
                     true
                 } else {
-                    a_list.iter().zip(b_list.iter()).all(|(a, b)| eq(a, b))
+                    a_list.0.iter().zip(b_list.0.iter()).all(|(a, b)| eq(a, b))
                 }
             }
             (a, b) => a == b,
@@ -406,7 +406,7 @@ pub fn assert_value_eq(a: &LoroValue, b: &LoroValue) {
 
 pub fn is_tree_values(value: &[LoroValue]) -> bool {
     if let Some(LoroValue::Map(map)) = value.first() {
-        let map_keys = map.as_ref().keys().cloned().collect::<FxHashSet<_>>();
+        let map_keys = map.0.keys().cloned().collect::<FxHashSet<_>>();
         return map_keys.contains("id")
             && map_keys.contains("parent")
             && map_keys.contains("meta")
@@ -431,21 +431,22 @@ struct FlatNode {
 
 impl FlatNode {
     fn from_loro_value(value: &LoroValue) -> Self {
-        let map = value.as_map().unwrap();
-        let id = map.get("id").unwrap().as_string().unwrap().to_string();
+        let map = &value.as_map().unwrap().0;
+        let id = map.get("id").unwrap().as_string().unwrap().0.to_string();
         let parent = map
             .get("parent")
             .unwrap()
             .as_string()
-            .map(|x| x.to_string());
+            .map(|x| x.0.to_string());
 
-        let meta = map.get("meta").unwrap().as_map().unwrap().as_ref().clone();
+        let meta = map.get("meta").unwrap().as_map().unwrap().0.clone();
         let index = *map.get("index").unwrap().as_i64().unwrap() as usize;
         let position = map
             .get("fractional_index")
             .unwrap()
             .as_string()
             .unwrap()
+            .0
             .to_string();
         FlatNode {
             id,
@@ -521,7 +522,7 @@ pub fn assert_tree_value_eq(a: &[LoroValue], b: &[LoroValue]) {
                     .into_iter()
                     .sorted_by_key(|(k, _)| k.clone())
                     .map(|(mut k, v)| {
-                        k.push_str(v.as_string().map_or("", |f| f.as_str()));
+                        k.push_str(v.as_string().map_or("", |f| f.0.as_str()));
                         k
                     })
                     .collect::<String>();
@@ -538,7 +539,7 @@ pub fn assert_tree_value_eq(a: &[LoroValue], b: &[LoroValue]) {
                     .into_iter()
                     .sorted_by_key(|(k, _)| k.clone())
                     .map(|(mut k, v)| {
-                        k.push_str(v.as_string().map_or("", |f| f.as_str()));
+                        k.push_str(v.as_string().map_or("", |f| f.0.as_str()));
                         k
                     })
                     .collect::<String>();

--- a/crates/fuzz/src/container/counter.rs
+++ b/crates/fuzz/src/container/counter.rs
@@ -63,7 +63,10 @@ impl ActorTrait for CounterActor {
         let counter = loro.get_counter("counter");
         let result = counter.get_value();
         let tracker = self.tracker.lock().unwrap().to_value();
-        assert_eq!(&result, tracker.into_map().unwrap().get("counter").unwrap());
+        assert_eq!(
+            &result,
+            tracker.into_map().unwrap().0.get("counter").unwrap()
+        );
 
         use loro_without_counter::LoroDoc as LoroDocWithoutCounter;
         // snapshot to snapshot

--- a/crates/fuzz/src/container/list.rs
+++ b/crates/fuzz/src/container/list.rs
@@ -75,7 +75,7 @@ impl ActorTrait for ListActor {
         let list = self.loro.get_list("list");
         let value = list.get_deep_value();
         let tracker = self.tracker.lock().unwrap().to_value();
-        assert_eq!(&value, tracker.into_map().unwrap().get("list").unwrap());
+        assert_eq!(&value, tracker.into_map().unwrap().0.get("list").unwrap());
     }
 
     fn add_new_container(&mut self, container: Container) {

--- a/crates/fuzz/src/container/map.rs
+++ b/crates/fuzz/src/container/map.rs
@@ -67,7 +67,10 @@ impl ActorTrait for MapActor {
         let map = self.loro.get_map("map");
         let value_a = map.get_deep_value();
         let value_b = self.tracker.lock().unwrap().to_value();
-        assert_eq!(&value_a, value_b.into_map().unwrap().get("map").unwrap());
+        assert_eq!(
+            &value_a,
+            value_b.into_map().unwrap().0.  get("map").unwrap()
+        );
     }
 
     fn container_len(&self) -> u8 {

--- a/crates/fuzz/src/container/movable_list.rs
+++ b/crates/fuzz/src/container/movable_list.rs
@@ -75,7 +75,7 @@ impl ActorTrait for MovableListActor {
         let tracker = self.tracker.lock().unwrap().to_value();
         assert_eq!(
             &value,
-            tracker.into_map().unwrap().get("movable_list").unwrap()
+            tracker.into_map().unwrap().0.get("movable_list").unwrap()
         );
     }
 

--- a/crates/fuzz/src/container/tree.rs
+++ b/crates/fuzz/src/container/tree.rs
@@ -136,7 +136,7 @@ impl ActorTrait for TreeActor {
         let tree = loro.get_tree("tree");
         let result = tree.get_value_with_meta();
         let tracker = self.tracker.lock().unwrap().to_value();
-        assert_eq!(&result, tracker.into_map().unwrap().get("tree").unwrap());
+        assert_eq!(&result, tracker.into_map().unwrap().0.get("tree").unwrap());
     }
 
     fn add_new_container(&mut self, container: Container) {

--- a/crates/loro-common/Cargo.toml
+++ b/crates/loro-common/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["crdt", "local-first"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+once_cell = "1.19.0"
 rle = { path = "../rle", version = "0.16.2", package = "loro-rle" }
 serde = { workspace = true }
 thiserror = "1.0.43"

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -18,7 +18,7 @@ pub use error::{LoroError, LoroResult, LoroTreeError};
 pub use fxhash::FxHashMap;
 pub use internal_string::InternalString;
 pub use span::*;
-pub use value::{to_value, LoroValue};
+pub use value::{to_value, LoroValue, LoroValueBinary};
 
 /// Unique id for each peer. It's a random u64 by default.
 pub type PeerID = u64;

--- a/crates/loro-common/src/macros.rs
+++ b/crates/loro-common/src/macros.rs
@@ -309,7 +309,7 @@ mod test {
                 .0,
             "1"
         );
-        let x = &map.get("binary").unwrap().as_binary().unwrap().0 as &[u8];
+        let x = &map.get("binary").unwrap().as_binary().unwrap() as &[u8];
         assert_eq!(x, &b"123".to_vec());
     }
 }

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -2168,11 +2168,12 @@ impl RichtextState {
                 if &attributes == last {
                     let hash_map = ans.last_mut().unwrap().as_map_mut().unwrap();
                     let s = Arc::make_mut(hash_map)
+                        .0
                         .get_mut("insert")
                         .unwrap()
                         .as_string_mut()
                         .unwrap();
-                    Arc::make_mut(s).push_str(span.text.as_str());
+                    Arc::make_mut(s).0.push_str(span.text.as_str());
                     continue;
                 }
             }
@@ -2180,18 +2181,24 @@ impl RichtextState {
             let mut value = FxHashMap::default();
             value.insert(
                 "insert".into(),
-                LoroValue::String(Arc::new(span.text.as_str().into())),
+                LoroValue::String(Arc::new((
+                    span.text.as_str().into(),
+                    once_cell::sync::OnceCell::new(),
+                ))),
             );
 
-            if !attributes.as_map().unwrap().is_empty() {
+            if !attributes.as_map().unwrap().0.is_empty() {
                 value.insert("attributes".into(), attributes.clone());
             }
 
-            ans.push(LoroValue::Map(Arc::new(value)));
+            ans.push(LoroValue::Map(Arc::new((
+                value,
+                once_cell::sync::OnceCell::new(),
+            ))));
             last_attributes = Some(attributes);
         }
 
-        LoroValue::List(Arc::new(ans))
+        LoroValue::List(Arc::new((ans, once_cell::sync::OnceCell::new())))
     }
 
     #[allow(unused)]

--- a/crates/loro-internal/src/delta/text.rs
+++ b/crates/loro-internal/src/delta/text.rs
@@ -107,7 +107,10 @@ impl StyleMeta {
     }
 
     pub(crate) fn to_value(&self) -> LoroValue {
-        LoroValue::Map(Arc::new(self.to_map_without_null_value()))
+        LoroValue::Map(Arc::new((
+            self.to_map_without_null_value(),
+            once_cell::sync::OnceCell::new(),
+        )))
     }
 
     fn to_map_without_null_value(&self) -> FxHashMap<String, LoroValue> {

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -1625,7 +1625,7 @@ struct EncodedStateInfo {
 mod test {
     use std::sync::Arc;
 
-    use loro_common::LoroValue;
+    use loro_common::{LoroValue, LoroValueBinary};
 
     use crate::fx_map;
 
@@ -1667,10 +1667,9 @@ mod test {
         test_loro_value_read_write(1.23, None);
         test_loro_value_read_write(LoroValue::Null, None);
         test_loro_value_read_write(
-            LoroValue::Binary(Arc::new((
-                Box::from(vec![123, 223, 255, 0, 1, 2, 3]),
-                once_cell::sync::OnceCell::new(),
-            ))),
+            LoroValue::Binary(LoroValueBinary::new(Box::from(vec![
+                123, 223, 255, 0, 1, 2, 3,
+            ]))),
             None,
         );
         test_loro_value_read_write("sldk;ajfas;dlkfas测试", None);

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -1667,7 +1667,10 @@ mod test {
         test_loro_value_read_write(1.23, None);
         test_loro_value_read_write(LoroValue::Null, None);
         test_loro_value_read_write(
-            LoroValue::Binary(Arc::new(vec![123, 223, 255, 0, 1, 2, 3])),
+            LoroValue::Binary(Arc::new((
+                Box::from(vec![123, 223, 255, 0, 1, 2, 3]),
+                once_cell::sync::OnceCell::new(),
+            ))),
             None,
         );
         test_loro_value_read_write("sldk;ajfas;dlkfas测试", None);
@@ -1688,11 +1691,14 @@ mod test {
         );
         test_loro_value_read_write(vec![1i32, 2, 3], None);
         test_loro_value_read_write(
-            LoroValue::Map(Arc::new(fx_map![
-                "1".into() => 123.into(),
-                "2".into() => "123".into(),
-                "3".into() => vec![true].into()
-            ])),
+            LoroValue::Map(Arc::new((
+                fx_map![
+                    "1".into() => 123.into(),
+                    "2".into() => "123".into(),
+                    "3".into() => vec![true].into()
+                ],
+                once_cell::sync::OnceCell::new(),
+            ))),
             None,
         );
     }

--- a/crates/loro-internal/src/encoding/encode_reordered.rs
+++ b/crates/loro-internal/src/encoding/encode_reordered.rs
@@ -1364,7 +1364,8 @@ fn decode_op(
             let pos = prop as usize;
             match value {
                 Value::LoroValue(arr) => {
-                    let range = shared_arena.alloc_values(arr.into_list().unwrap().iter().cloned());
+                    let range =
+                        shared_arena.alloc_values(arr.into_list().unwrap().0.iter().cloned());
                     crate::op::InnerContent::List(
                         crate::container::list::list_op::InnerListOp::Insert {
                             slice: SliceRange::new(range.start as u32..range.end as u32),
@@ -1405,7 +1406,8 @@ fn decode_op(
             let pos = prop as usize;
             match value {
                 Value::LoroValue(arr) => {
-                    let range = shared_arena.alloc_values(arr.into_list().unwrap().iter().cloned());
+                    let range =
+                        shared_arena.alloc_values(arr.into_list().unwrap().0.iter().cloned());
                     crate::op::InnerContent::List(
                         crate::container::list::list_op::InnerListOp::Insert {
                             slice: SliceRange::new(range.start as u32..range.end as u32),

--- a/crates/loro-internal/src/encoding/json_schema.rs
+++ b/crates/loro-internal/src/encoding/json_schema.rs
@@ -495,14 +495,14 @@ fn decode_op(op: op::JsonOp, arena: &SharedArena, peers: &[PeerID]) -> LoroResul
             JsonOpContent::List(list) => match list {
                 op::ListOp::Insert { pos, value } => {
                     let mut values = value.into_list().unwrap();
-                    Arc::make_mut(&mut values).iter_mut().for_each(|v| {
+                    Arc::make_mut(&mut values).0.iter_mut().for_each(|v| {
                         if let LoroValue::Container(id) = v {
                             if id.is_normal() {
                                 *id = convert_container_id(id.clone(), peers);
                             }
                         }
                     });
-                    let range = arena.alloc_values(values.iter().cloned());
+                    let range = arena.alloc_values(values.0.iter().cloned());
                     InnerContent::List(InnerListOp::Insert {
                         slice: SliceRange::new(range.start as u32..range.end as u32),
                         pos,
@@ -524,14 +524,14 @@ fn decode_op(op: op::JsonOp, arena: &SharedArena, peers: &[PeerID]) -> LoroResul
             JsonOpContent::MovableList(list) => match list {
                 op::MovableListOp::Insert { pos, value } => {
                     let mut values = value.into_list().unwrap();
-                    Arc::make_mut(&mut values).iter_mut().for_each(|v| {
+                    Arc::make_mut(&mut values).0.iter_mut().for_each(|v| {
                         if let LoroValue::Container(id) = v {
                             if id.is_normal() {
                                 *id = convert_container_id(id.clone(), peers);
                             }
                         }
                     });
-                    let range = arena.alloc_values(values.iter().cloned());
+                    let range = arena.alloc_values(values.0.iter().cloned());
                     InnerContent::List(InnerListOp::Insert {
                         slice: SliceRange::new(range.start as u32..range.end as u32),
                         pos,

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -346,7 +346,10 @@ impl HandlerTrait for TextHandler {
         match &self.inner {
             MaybeDetached::Detached(t) => {
                 let t = t.try_lock().unwrap();
-                LoroValue::String(Arc::new(t.value.to_string()))
+                LoroValue::String(Arc::new((
+                    t.value.to_string(),
+                    once_cell::sync::OnceCell::new(),
+                )))
             }
             MaybeDetached::Attached(a) => {
                 a.with_state(|state| state.as_richtext_state_mut().unwrap().get_value())
@@ -489,7 +492,7 @@ impl HandlerTrait for MapHandler {
                 for (k, v) in m.value.iter() {
                     map.insert(k.to_string(), v.to_value());
                 }
-                LoroValue::Map(Arc::new(map))
+                LoroValue::Map(Arc::new((map, once_cell::sync::OnceCell::new())))
             }
             MaybeDetached::Attached(a) => a.get_value(),
         }
@@ -503,7 +506,7 @@ impl HandlerTrait for MapHandler {
                 for (k, v) in m.value.iter() {
                     map.insert(k.to_string(), v.to_deep_value());
                 }
-                LoroValue::Map(Arc::new(map))
+                LoroValue::Map(Arc::new((map, once_cell::sync::OnceCell::new())))
             }
             MaybeDetached::Attached(a) => a.get_deep_value(),
         }
@@ -545,7 +548,7 @@ impl HandlerTrait for MapHandler {
                 let new_inner = create_handler(a, self_id);
                 let ans = new_inner.into_map().unwrap();
 
-                for (k, v) in self.get_value().into_map().unwrap().iter() {
+                for (k, v) in self.get_value().into_map().unwrap().0.iter() {
                     if let LoroValue::Container(id) = v {
                         ans.insert_container_with_txn(txn, k, create_handler(a, id.clone()))
                             .unwrap();
@@ -611,7 +614,10 @@ impl HandlerTrait for MovableListHandler {
         match &self.inner {
             MaybeDetached::Detached(a) => {
                 let a = a.try_lock().unwrap();
-                LoroValue::List(Arc::new(a.value.iter().map(|v| v.to_value()).collect()))
+                LoroValue::List(Arc::new((
+                    a.value.iter().map(|v| v.to_value()).collect(),
+                    once_cell::sync::OnceCell::new(),
+                )))
             }
             MaybeDetached::Attached(a) => a.get_value(),
         }
@@ -621,9 +627,10 @@ impl HandlerTrait for MovableListHandler {
         match &self.inner {
             MaybeDetached::Detached(a) => {
                 let a = a.try_lock().unwrap();
-                LoroValue::List(Arc::new(
+                LoroValue::List(Arc::new((
                     a.value.iter().map(|v| v.to_deep_value()).collect(),
-                ))
+                    once_cell::sync::OnceCell::new(),
+                )))
             }
             MaybeDetached::Attached(a) => a.get_deep_value(),
         }
@@ -672,7 +679,7 @@ impl HandlerTrait for MovableListHandler {
                 let new_inner = create_handler(a, self_id);
                 let ans = new_inner.into_movable_list().unwrap();
 
-                for (i, v) in self.get_value().into_list().unwrap().iter().enumerate() {
+                for (i, v) in self.get_value().into_list().unwrap().0.iter().enumerate() {
                     if let LoroValue::Container(id) = v {
                         ans.insert_container_with_txn(txn, i, create_handler(a, id.clone()))
                             .unwrap();
@@ -724,7 +731,10 @@ impl HandlerTrait for ListHandler {
         match &self.inner {
             MaybeDetached::Detached(a) => {
                 let a = a.try_lock().unwrap();
-                LoroValue::List(Arc::new(a.value.iter().map(|v| v.to_value()).collect()))
+                LoroValue::List(Arc::new((
+                    a.value.iter().map(|v| v.to_value()).collect(),
+                    once_cell::sync::OnceCell::new(),
+                )))
             }
             MaybeDetached::Attached(a) => a.get_value(),
         }
@@ -734,9 +744,10 @@ impl HandlerTrait for ListHandler {
         match &self.inner {
             MaybeDetached::Detached(a) => {
                 let a = a.try_lock().unwrap();
-                LoroValue::List(Arc::new(
+                LoroValue::List(Arc::new((
                     a.value.iter().map(|v| v.to_deep_value()).collect(),
-                ))
+                    once_cell::sync::OnceCell::new(),
+                )))
             }
             MaybeDetached::Attached(a) => a.get_deep_value(),
         }
@@ -778,7 +789,7 @@ impl HandlerTrait for ListHandler {
                 let new_inner = create_handler(a, self_id);
                 let ans = new_inner.into_list().unwrap();
 
-                for (i, v) in self.get_value().into_list().unwrap().iter().enumerate() {
+                for (i, v) in self.get_value().into_list().unwrap().0.iter().enumerate() {
                     if let LoroValue::Container(id) = v {
                         ans.insert_container_with_txn(txn, i, create_handler(a, id.clone()))
                             .unwrap();

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -3970,15 +3970,15 @@ mod test {
         loro2.import(&exported).unwrap();
         let mut txn = loro2.txn().unwrap();
         let text = txn.get_text("hello");
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello");
         text.insert_with_txn(&mut txn, 5, " world").unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello world");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello world");
         txn.commit().unwrap();
         loro.import(&loro2.export_from(&Default::default()))
             .unwrap();
         let txn = loro.txn().unwrap();
         let text = txn.get_text("hello");
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello world");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello world");
     }
 
     #[test]
@@ -3997,21 +3997,21 @@ mod test {
         loro2.import(&exported).unwrap();
         let mut txn = loro2.txn().unwrap();
         let text = txn.get_text("hello");
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello");
         text.insert_with_txn(&mut txn, 5, " world").unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello world");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello world");
         txn.commit().unwrap();
 
         loro.import(&loro2.export_from(&Default::default()))
             .unwrap();
         let txn = loro.txn().unwrap();
         let text = txn.get_text("hello");
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello world");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello world");
         txn.commit().unwrap();
 
         // test checkout
         loro.checkout(&Frontiers::from_id(ID::new(2, 1))).unwrap();
-        assert_eq!(&**text.get_value().as_string().unwrap(), "hello w");
+        assert_eq!(text.get_value().as_string().unwrap().0, "hello w");
     }
 
     #[test]
@@ -4051,7 +4051,7 @@ mod test {
         // assert has bold
         let value = handler.get_richtext_value();
         assert_eq!(value[0]["insert"], "hello".into());
-        let meta = value[0]["attributes"].as_map().unwrap();
+        let meta = &value[0]["attributes"].as_map().unwrap().0;
         assert_eq!(meta.len(), 1);
         meta.get("bold").unwrap();
 
@@ -4060,12 +4060,12 @@ mod test {
             .import(&loro.export_from(&Default::default()))
             .unwrap();
         let handler2 = loro2.get_text("richtext");
-        assert_eq!(&**handler2.get_value().as_string().unwrap(), "hello world");
+        assert_eq!(handler2.get_value().as_string().unwrap().0, "hello world");
 
         // assert has bold
         let value = handler2.get_richtext_value();
         assert_eq!(value[0]["insert"], "hello".into());
-        let meta = value[0]["attributes"].as_map().unwrap();
+        let meta = &value[0]["attributes"].as_map().unwrap().0;
         assert_eq!(meta.len(), 1);
         meta.get("bold").unwrap();
 

--- a/crates/loro-internal/src/macros.rs
+++ b/crates/loro-internal/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! fx_map {
             $(
                 m.insert($key, $value);
             )*
-            m
+            (m, once_cell::sync::OnceCell::new())
         }
     };
 }

--- a/crates/loro-internal/src/macros.rs
+++ b/crates/loro-internal/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! fx_map {
             $(
                 m.insert($key, $value);
             )*
-            (m, once_cell::sync::OnceCell::new())
+            m
         }
     };
 }

--- a/crates/loro-internal/src/obs.rs
+++ b/crates/loro-internal/src/obs.rs
@@ -258,7 +258,7 @@ mod test {
             count_cp.fetch_add(1, Ordering::SeqCst);
             let mut txn = loro.txn().unwrap();
             let text = loro.get_text("id");
-            if text.get_value().as_string().unwrap().len() > 10 {
+            if text.get_value().as_string().unwrap().0.len() > 10 {
                 return;
             }
             text.insert_with_txn(&mut txn, 0, "123").unwrap();

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -866,9 +866,12 @@ impl DocState {
             LoroValue::Container(_) => unreachable!(),
             LoroValue::List(mut list) => {
                 if list.0.iter().all(|x| !x.is_container()) {
-                    return LoroValue::Map(Arc::new(fx_map!(
-                        "cid".into() => cid_str,
-                        "value".into() => LoroValue::List(list)
+                    return LoroValue::Map(Arc::new((
+                        fx_map!(
+                            "cid".into() => cid_str,
+                            "value".into() => LoroValue::List(list)
+                        ),
+                        once_cell::sync::OnceCell::new(),
                     )));
                 }
 
@@ -885,9 +888,12 @@ impl DocState {
                     }
                 }
 
-                LoroValue::Map(Arc::new(fx_map!(
-                    "cid".into() => cid_str,
-                    "value".into() => LoroValue::List(list)
+                LoroValue::Map(Arc::new((
+                    fx_map!(
+                        "cid".into() => cid_str,
+                        "value".into() => LoroValue::List(list)
+                    ),
+                    once_cell::sync::OnceCell::new(),
                 )))
             }
             LoroValue::Map(mut map) => {
@@ -904,14 +910,20 @@ impl DocState {
                     }
                 }
 
-                LoroValue::Map(Arc::new(fx_map!(
-                    "cid".into() => cid_str,
-                    "value".into() => LoroValue::Map(map)
+                LoroValue::Map(Arc::new((
+                    fx_map!(
+                        "cid".into() => cid_str,
+                        "value".into() => LoroValue::Map(map)
+                    ),
+                    once_cell::sync::OnceCell::new(),
                 )))
             }
-            _ => LoroValue::Map(Arc::new(fx_map!(
-                "cid".into() => cid_str,
-                "value".into() => value
+            _ => LoroValue::Map(Arc::new((
+                fx_map!(
+                    "cid".into() => cid_str,
+                    "value".into() => value
+                ),
+                once_cell::sync::OnceCell::new(),
             ))),
         }
     }

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -473,7 +473,7 @@ impl ContainerState for ListState {
 
     fn get_value(&mut self) -> LoroValue {
         let ans = self.to_vec();
-        LoroValue::List(Arc::new(ans))
+        LoroValue::List(Arc::new((ans, once_cell::sync::OnceCell::new())))
     }
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -127,7 +127,7 @@ impl ContainerState for MapState {
 
     fn get_value(&mut self) -> LoroValue {
         let ans = self.to_map();
-        LoroValue::Map(Arc::new(ans))
+        LoroValue::Map(Arc::new((ans, once_cell::sync::OnceCell::new())))
     }
 
     fn get_child_index(&self, id: &ContainerID) -> Option<Index> {

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -1276,8 +1276,8 @@ impl ContainerState for MovableListState {
     }
 
     fn get_value(&mut self) -> LoroValue {
-        let list = self.get_value_inner();
-        LoroValue::List(Arc::new(list))
+        let list: Vec<LoroValue> = self.get_value_inner();
+        LoroValue::List(Arc::new((list, once_cell::sync::OnceCell::new())))
     }
 
     /// Get the index of the child container

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -632,7 +632,10 @@ impl ContainerState for RichtextState {
 
     // value is a list
     fn get_value(&mut self) -> LoroValue {
-        LoroValue::String(Arc::new(self.state.get_mut().to_string()))
+        LoroValue::String(Arc::new((
+            self.state.get_mut().to_string(),
+            once_cell::sync::OnceCell::new(),
+        )))
     }
 
     #[doc = r" Get the index of the child container"]

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -1129,7 +1129,7 @@ impl ContainerState for TreeState {
 pub(crate) fn get_meta_value(nodes: &mut Vec<LoroValue>, state: &mut DocState) {
     for node in nodes.iter_mut() {
         let map = Arc::make_mut(node.as_map_mut().unwrap());
-        let meta = map.get_mut("meta").unwrap();
+        let meta = map.0.get_mut("meta").unwrap();
         let id = meta.as_container().unwrap();
         *meta = state.get_container_deep_value(state.arena.register_container(id));
     }

--- a/crates/loro-internal/tests/autocommit.rs
+++ b/crates/loro-internal/tests/autocommit.rs
@@ -10,7 +10,7 @@ fn auto_commit() {
     let text_a = doc_a.get_text("text");
     text_a.insert(0, "hello").unwrap();
     text_a.delete(2, 2).unwrap();
-    assert_eq!(&**text_a.get_value().as_string().unwrap(), "heo");
+    assert_eq!(text_a.get_value().as_string().unwrap().0, "heo");
     let bytes = doc_a.export_from(&Default::default());
 
     let doc_b = LoroDoc::default();

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -511,22 +511,22 @@ fn test_text_checkout() {
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 0)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你");
     }
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 1)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你界");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你界");
     }
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 2)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好界");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好界");
     }
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 3)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世界");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好世界");
     }
     assert_eq!(text.len_unicode(), 4);
     assert_eq!(text.len_utf8(), 12);
@@ -534,37 +534,37 @@ fn test_text_checkout() {
 
     doc.checkout_to_latest();
     doc.with_txn(|txn| text.delete_with_txn(txn, 3, 1)).unwrap();
-    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世");
+    assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好世");
     doc.with_txn(|txn| text.delete_with_txn(txn, 2, 1)).unwrap();
-    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好");
+    assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好");
     doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 3)].as_slice()))
         .unwrap();
-    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世界");
+    assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好世界");
     doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 4)].as_slice()))
         .unwrap();
-    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世");
+    assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好世");
     doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 5)].as_slice()))
         .unwrap();
-    assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好");
+    assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好");
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 0)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你");
     }
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 1)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你界");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你界");
     }
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 2)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好界");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好界");
     }
     {
         doc.checkout(&Frontiers::from([ID::new(doc.peer_id(), 3)].as_slice()))
             .unwrap();
-        assert_eq!(text.get_value().as_string().unwrap().as_str(), "你好世界");
+        assert_eq!(text.get_value().as_string().unwrap().0.as_str(), "你好世界");
     }
 }
 
@@ -936,11 +936,20 @@ fn tree_attach() {
     doc.get_list("list").insert_container(0, tree).unwrap();
     let v = doc.get_deep_value();
     assert_eq!(
-        v.as_map().unwrap().get("list").unwrap().as_list().unwrap()[0]
+        v.as_map()
+            .unwrap()
+            .0
+            .get("list")
+            .unwrap()
             .as_list()
-            .unwrap()[0]
+            .unwrap()
+            .0[0]
+            .as_list()
+            .unwrap()
+            .0[0]
             .as_map()
             .unwrap()
+            .0
             .get("meta")
             .unwrap()
             .to_json_value(),

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -251,11 +251,11 @@ pub fn convert(value: LoroValue) -> JsValue {
         LoroValue::Bool(b) => JsValue::from_bool(b),
         LoroValue::Double(f) => JsValue::from_f64(f),
         LoroValue::I64(i) => JsValue::from_f64(i as f64),
-        LoroValue::String(s) => JsValue::from_str(&s),
+        LoroValue::String(s) => JsValue::from_str(&s.0),
         LoroValue::List(list) => {
             let list = Arc::try_unwrap(list).unwrap_or_else(|m| (*m).clone());
-            let arr = Array::new_with_length(list.len() as u32);
-            for (i, v) in list.into_iter().enumerate() {
+            let arr = Array::new_with_length(list.0.len() as u32);
+            for (i, v) in list.0.into_iter().enumerate() {
                 arr.set(i as u32, convert(v));
             }
             arr.into_js_result().unwrap()
@@ -263,7 +263,7 @@ pub fn convert(value: LoroValue) -> JsValue {
         LoroValue::Map(m) => {
             let m = Arc::try_unwrap(m).unwrap_or_else(|m| (*m).clone());
             let map = Object::new();
-            for (k, v) in m.into_iter() {
+            for (k, v) in m.0.into_iter() {
                 let str: &str = &k;
                 js_sys::Reflect::set(&map, &JsValue::from_str(str), &convert(v)).unwrap();
             }
@@ -273,9 +273,9 @@ pub fn convert(value: LoroValue) -> JsValue {
         LoroValue::Container(container_id) => JsValue::from(&container_id),
         LoroValue::Binary(binary) => {
             let binary = Arc::try_unwrap(binary).unwrap_or_else(|m| (*m).clone());
-            let arr = Uint8Array::new_with_length(binary.len() as u32);
-            for (i, v) in binary.into_iter().enumerate() {
-                arr.set_index(i as u32, v);
+            let arr = Uint8Array::new_with_length(binary.0.len() as u32);
+            for (i, v) in binary.0.into_iter().enumerate() {
+                arr.set_index(i as u32, *v);
             }
             arr.into_js_result().unwrap()
         }

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -272,10 +272,9 @@ pub fn convert(value: LoroValue) -> JsValue {
         }
         LoroValue::Container(container_id) => JsValue::from(&container_id),
         LoroValue::Binary(binary) => {
-            let binary = Arc::try_unwrap(binary).unwrap_or_else(|m| (*m).clone());
-            let arr = Uint8Array::new_with_length(binary.0.len() as u32);
-            for (i, v) in binary.0.into_iter().enumerate() {
-                arr.set_index(i as u32, *v);
+            let arr = Uint8Array::new_with_length(binary.0 .0.len() as u32);
+            for (i, v) in binary.0 .0.iter().copied().enumerate() {
+                arr.set_index(i as u32, v);
             }
             arr.into_js_result().unwrap()
         }

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1735,7 +1735,7 @@ impl LoroText {
     #[allow(clippy::inherent_to_string)]
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self) -> String {
-        self.handler.get_value().as_string().unwrap().to_string()
+        self.handler.get_value().as_string().unwrap().0.to_string()
     }
 
     /// Get the text in [Delta](https://quilljs.com/docs/delta/) format.
@@ -3330,14 +3330,14 @@ impl LoroTree {
     pub fn to_array(&mut self) -> JsResult<Array> {
         let value = self.handler.get_value().into_list().unwrap();
         let ans = Array::new();
-        for v in value.as_ref() {
+        for v in &value.as_ref().0 {
             let v = v.as_map().unwrap();
-            let id: JsValue = TreeID::try_from(v["id"].as_string().unwrap().as_str())
+            let id: JsValue = TreeID::try_from(v.0["id"].as_string().unwrap().0.as_str())
                 .unwrap()
                 .into();
             let id: JsTreeID = id.into();
-            let parent = if let LoroValue::String(p) = &v["parent"] {
-                Some(TreeID::try_from(p.as_str())?)
+            let parent = if let LoroValue::String(p) = &v.0["parent"] {
+                Some(TreeID::try_from(p.0.as_str())?)
             } else {
                 None
             };
@@ -3345,8 +3345,8 @@ impl LoroTree {
                 .map(|x| LoroTreeNode::from_tree(x, self.handler.clone(), self.doc.clone()).into())
                 .unwrap_or(JsValue::undefined())
                 .into();
-            let index = *v["index"].as_i64().unwrap() as u32;
-            let position = v["fractional_index"].as_string().unwrap();
+            let index = *v.0["index"].as_i64().unwrap() as u32;
+            let position = v.0["fractional_index"].as_string().unwrap().0.clone();
             let map: LoroMap = self.get_node_by_id(&id).unwrap().data()?;
             let obj = Object::new();
             js_sys::Reflect::set(&obj, &"id".into(), &id)?;
@@ -3355,7 +3355,7 @@ impl LoroTree {
             js_sys::Reflect::set(
                 &obj,
                 &"fractional_index".into(),
-                &JsValue::from_str(position),
+                &JsValue::from_str(&position),
             )?;
             js_sys::Reflect::set(&obj, &"meta".into(), &map.into())?;
             ans.push(&obj);

--- a/crates/loro/tests/integration_test/undo_test.rs
+++ b/crates/loro/tests/integration_test/undo_test.rs
@@ -1122,16 +1122,18 @@ fn undo_tree_move() -> LoroResult<()> {
     // a
     undo.undo(&doc_a)?;
     let a_value = tree_a.get_value().as_list().unwrap().clone();
-    assert_eq!(a_value.len(), 2);
-    assert!(a_value[0]
+    assert_eq!(a_value.0.len(), 2);
+    assert!(a_value.0[0]
         .as_map()
         .unwrap()
+        .0
         .get("parent")
         .unwrap()
         .is_null());
-    assert!(a_value[1]
+    assert!(a_value.0[1]
         .as_map()
         .unwrap()
+        .0
         .get("parent")
         .unwrap()
         .is_null());
@@ -1141,23 +1143,25 @@ fn undo_tree_move() -> LoroResult<()> {
     // b
     undo2.undo(&doc_b)?;
     let b_value = tree_b.get_value().as_list().unwrap().clone();
-    assert_eq!(b_value.len(), 0);
+    assert_eq!(b_value.0.len(), 0);
     undo.undo(&doc_a)?;
     undo.undo(&doc_a)?;
     let a_value = tree_a.get_value().as_list().unwrap().clone();
-    assert_eq!(a_value.len(), 1);
+    assert_eq!(a_value.0.len(), 1);
     assert_eq!(
-        a_value[0]
+        a_value.0[0]
             .as_map()
             .unwrap()
+            .0
             .get("id")
             .unwrap()
             .to_json_value(),
         json!("0@2")
     );
-    assert!(a_value[0]
+    assert!(a_value.0[0]
         .as_map()
         .unwrap()
+        .0
         .get("parent")
         .unwrap()
         .is_null());
@@ -1179,7 +1183,7 @@ fn undo_tree_concurrent_delete() -> LoroResult<()> {
     doc_a.import(&doc_b.export_from(&Default::default()))?;
     doc_b.import(&doc_a.export_from(&Default::default()))?;
     undo_b.undo(&doc_b)?;
-    assert!(tree_b.get_value().as_list().unwrap().is_empty());
+    assert!(tree_b.get_value().as_list().unwrap().0.is_empty());
     Ok(())
 }
 
@@ -1201,11 +1205,12 @@ fn undo_tree_concurrent_delete2() -> LoroResult<()> {
     doc_a.import(&doc_b.export_from(&Default::default()))?;
     doc_b.import(&doc_a.export_from(&Default::default()))?;
     undo_b.undo(&doc_b)?;
-    assert_eq!(tree_b.get_value().as_list().unwrap().len(), 1);
+    assert_eq!(tree_b.get_value().as_list().unwrap().0.len(), 1);
     assert_eq!(
-        tree_b.get_value().as_list().unwrap()[0]
+        tree_b.get_value().as_list().unwrap().0[0]
             .as_map()
             .unwrap()
+            .0
             .get("id")
             .unwrap()
             .to_json_value(),

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -312,7 +312,7 @@ fn travel_back_should_remove_styles() {
     });
     doc.checkout(&f).unwrap();
     assert_eq!(
-        text.to_delta().as_list().unwrap().len(),
+        text.to_delta().as_list().unwrap().0.len(),
         1,
         "should remove the bold style but got {:?}",
         text.to_delta()
@@ -667,17 +667,17 @@ fn get_container_by_str_path() {
         .unwrap();
     let v = doc.get_by_str_path("map/text/0").unwrap();
     assert_eq!(
-        v.into_value().unwrap().into_string().unwrap().to_string(),
+        v.into_value().unwrap().into_string().unwrap().0.to_string(),
         "1"
     );
     let v = doc.get_by_str_path("map/text/1").unwrap();
     assert_eq!(
-        v.into_value().unwrap().into_string().unwrap().to_string(),
+        v.into_value().unwrap().into_string().unwrap().0.to_string(),
         "2"
     );
     let v = doc.get_by_str_path("map/text/2").unwrap();
     assert_eq!(
-        v.into_value().unwrap().into_string().unwrap().to_string(),
+        v.into_value().unwrap().into_string().unwrap().0.to_string(),
         "3"
     );
 
@@ -694,6 +694,7 @@ fn get_container_by_str_path() {
             .unwrap()
             .into_string()
             .unwrap()
+            .0
             .to_string(),
         "value"
     );


### PR DESCRIPTION
# ⚠️ Warning: May contain numerous breaking changes

- made `LoroValue.hash` lazy
- use `Box<[u8]>` for `LoroValue::Binary` instead of using `Arc<Vec<u8>>`