### PR TITLE
feat: support commit message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "fxhash",
  "itertools 0.12.1",
  "loro 0.16.2",
+ "loro 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
  "loro 0.16.2 (git+https://github.com/loro-dev/loro.git?rev=90470658435ec4c62b5af59ebb82fe9e1f5aa761)",
  "num_cpus",
  "rand",
@@ -997,6 +998,19 @@ dependencies = [
 [[package]]
 name = "loro"
 version = "0.16.2"
+source = "git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7#d2b0520f8633f96146a49ec205bd5e7056880f1a"
+dependencies = [
+ "either",
+ "enum-as-inner 0.6.0",
+ "generic-btree",
+ "loro-delta 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "loro-internal 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "tracing",
+]
+
+[[package]]
+name = "loro"
+version = "0.16.2"
 source = "git+https://github.com/loro-dev/loro.git?rev=90470658435ec4c62b5af59ebb82fe9e1f5aa761#90470658435ec4c62b5af59ebb82fe9e1f5aa761"
 dependencies = [
  "either",
@@ -1023,6 +1037,22 @@ dependencies = [
  "string_cache",
  "thiserror",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "loro-common"
+version = "0.16.2"
+source = "git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7#d2b0520f8633f96146a49ec205bd5e7056880f1a"
+dependencies = [
+ "arbitrary",
+ "enum-as-inner 0.6.0",
+ "fxhash",
+ "loro-rle 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "nonmax",
+ "serde",
+ "serde_columnar",
+ "string_cache",
+ "thiserror",
 ]
 
 [[package]]
@@ -1055,6 +1085,18 @@ dependencies = [
  "rand",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "loro-delta"
+version = "0.16.2"
+source = "git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7#d2b0520f8633f96146a49ec205bd5e7056880f1a"
+dependencies = [
+ "arrayvec",
+ "enum-as-inner 0.5.1",
+ "generic-btree",
+ "heapless 0.8.0",
+ "tracing",
 ]
 
 [[package]]
@@ -1126,6 +1168,41 @@ dependencies = [
 [[package]]
 name = "loro-internal"
 version = "0.16.2"
+source = "git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7#d2b0520f8633f96146a49ec205bd5e7056880f1a"
+dependencies = [
+ "append-only-bytes",
+ "arref",
+ "either",
+ "enum-as-inner 0.5.1",
+ "enum_dispatch",
+ "fxhash",
+ "generic-btree",
+ "getrandom",
+ "im",
+ "itertools 0.12.1",
+ "leb128",
+ "loro-common 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "loro-delta 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "loro-rle 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "loro_fractional_index 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7)",
+ "md5",
+ "num",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "postcard",
+ "rand",
+ "serde",
+ "serde_columnar",
+ "serde_json",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "loro-internal"
+version = "0.16.2"
 source = "git+https://github.com/loro-dev/loro.git?rev=90470658435ec4c62b5af59ebb82fe9e1f5aa761#90470658435ec4c62b5af59ebb82fe9e1f5aa761"
 dependencies = [
  "append-only-bytes",
@@ -1178,6 +1255,19 @@ dependencies = [
 [[package]]
 name = "loro-rle"
 version = "0.16.2"
+source = "git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7#d2b0520f8633f96146a49ec205bd5e7056880f1a"
+dependencies = [
+ "append-only-bytes",
+ "arref",
+ "enum-as-inner 0.6.0",
+ "fxhash",
+ "num",
+ "smallvec",
+]
+
+[[package]]
+name = "loro-rle"
+version = "0.16.2"
 source = "git+https://github.com/loro-dev/loro.git?rev=90470658435ec4c62b5af59ebb82fe9e1f5aa761#90470658435ec4c62b5af59ebb82fe9e1f5aa761"
 dependencies = [
  "append-only-bytes",
@@ -1218,6 +1308,17 @@ version = "0.16.2"
 dependencies = [
  "criterion 0.5.1",
  "fractional_index",
+ "imbl",
+ "rand",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "loro_fractional_index"
+version = "0.16.2"
+source = "git+https://github.com/loro-dev/loro.git?tag=loro-crdt@0.16.7#d2b0520f8633f96146a49ec205bd5e7056880f1a"
+dependencies = [
  "imbl",
  "rand",
  "serde",

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 loro = { path = "../loro", features = ["counter"], package = "loro" }
 loro-without-counter = { git = "https://github.com/loro-dev/loro.git", rev = "90470658435ec4c62b5af59ebb82fe9e1f5aa761", package = "loro", default-features = false }
+loro-016 = { git = "https://github.com/loro-dev/loro.git", tag="loro-crdt@0.16.7", package = "loro"  }
 fxhash = { workspace = true }
 enum_dispatch = { workspace = true }
 enum-as-inner = { workspace = true }

--- a/crates/fuzz/tests/compatibility.rs
+++ b/crates/fuzz/tests/compatibility.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use loro::{ToJson as _, ID};
+use loro_016::ToJson as _;
+
+#[test]
+fn updates_with_commit_message_can_be_imported_to_016() {
+    let doc1 = loro::LoroDoc::new();
+    {
+        let text = doc1.get_text("text");
+        text.insert(0, "Hello, World!").unwrap();
+        doc1.set_next_commit_message("Initial text insertion");
+        doc1.commit();
+
+        let tree = doc1.get_tree("tree");
+        let root = tree.create(None).unwrap();
+        doc1.set_next_commit_message("Added tree structure");
+        doc1.commit();
+
+        doc1.set_next_commit_message("Modified text");
+        text.delete(0, 5).unwrap();
+        text.insert(7, "Loro").unwrap();
+        doc1.commit();
+
+        doc1.set_next_commit_message("Added another child to tree");
+        tree.create(root).unwrap();
+        doc1.commit();
+    }
+
+    let doc2 = loro_016::LoroDoc::new();
+    doc2.import(&doc1.export_snapshot()).unwrap();
+    assert_eq!(
+        doc2.get_deep_value().to_json(),
+        doc1.get_deep_value().to_json()
+    );
+
+    {
+        doc2.get_text("text").insert(0, "123").unwrap();
+        doc1.import(&doc2.export_from(&Default::default())).unwrap();
+    }
+
+    let doc3 = loro::LoroDoc::new();
+    doc3.import(&doc1.export_fast_snapshot()).unwrap();
+    let change_from_2 = doc3.get_change(ID::new(doc2.peer_id(), 0)).unwrap();
+    assert_eq!(change_from_2.len, 3);
+    assert_eq!(doc3.get_deep_value(), doc1.get_deep_value());
+    assert_eq!(
+        doc3.get_change(ID::new(doc1.peer_id(), 0))
+            .unwrap()
+            .message(),
+        "Initial text insertion"
+    );
+}
+
+#[test]
+fn snapshot_from_016_can_be_imported_in_cur_version() {
+    // Create a LoroDoc using loro-016
+    let doc_016 = loro_016::LoroDoc::new();
+    doc_016.set_peer_id(1).unwrap();
+
+    // Perform some operations on doc_016
+    {
+        let text = doc_016.get_text("text");
+        text.insert(0, "Hello, Loro!").unwrap();
+        doc_016.commit();
+
+        let map = doc_016.get_map("map");
+        map.insert("key", "value").unwrap();
+        doc_016.commit();
+
+        let list = doc_016.get_list("list");
+        list.push(1).unwrap();
+        list.push(2).unwrap();
+        list.push(3).unwrap();
+        doc_016.commit();
+    }
+
+    // Export a snapshot from doc_016
+    let snapshot_016 = doc_016.export_snapshot();
+
+    // Create a new LoroDoc using the current version
+    let doc_current = loro::LoroDoc::new();
+
+    // Import the snapshot from loro-016 into the current version
+    doc_current.import(&snapshot_016).unwrap();
+
+    // Verify that the imported data matches the original
+    assert_eq!(
+        doc_current.get_deep_value().to_json(),
+        doc_016.get_deep_value().to_json()
+    );
+
+    // Perform additional operations on the current version doc
+    {
+        let text = doc_current.get_text("text");
+        text.insert(11, " CRDT").unwrap();
+        doc_current.commit();
+
+        let map = doc_current.get_map("map");
+        map.insert("new_key", "new_value").unwrap();
+        doc_current.commit();
+
+        let list = doc_current.get_list("list");
+        list.push(4).unwrap();
+        doc_current.commit();
+    }
+
+    // Verify that new operations work correctly
+    assert_eq!(
+        doc_current.get_text("text").to_string(),
+        "Hello, Loro CRDT!"
+    );
+    assert_eq!(
+        doc_current
+            .get_map("map")
+            .get("new_key")
+            .unwrap()
+            .left()
+            .unwrap(),
+        loro::LoroValue::String(Arc::new("new_value".into()))
+    );
+    assert_eq!(doc_current.get_list("list").len(), 4);
+
+    // Export a snapshot from the current version
+    let snapshot_current = doc_current.export_snapshot();
+
+    // Create another LoroDoc using loro-016 and import the snapshot from the current version
+    let doc_016_reimport = loro_016::LoroDoc::new();
+    doc_016_reimport.import(&snapshot_current).unwrap();
+
+    // Verify that the reimported data in loro-016 matches the current version
+    assert_eq!(
+        doc_016_reimport.get_deep_value().to_json(),
+        doc_current.get_deep_value().to_json()
+    );
+}

--- a/crates/loro-internal/src/change.rs
+++ b/crates/loro-internal/src/change.rs
@@ -35,6 +35,7 @@ pub struct Change<O = Op> {
     /// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
     /// It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
     pub(crate) timestamp: Timestamp,
+    pub(crate) commit_msg: Option<Arc<str>>,
 }
 
 impl<O> Change<O> {
@@ -51,6 +52,7 @@ impl<O> Change<O> {
             id,
             lamport,
             timestamp,
+            commit_msg: None,
         }
     }
 
@@ -87,6 +89,10 @@ impl<O> Change<O> {
     #[inline]
     pub fn deps_on_self(&self) -> bool {
         self.deps.len() == 1 && self.deps[0].peer == self.id.peer
+    }
+
+    pub fn message(&self) -> Option<&Arc<str>> {
+        self.commit_msg.as_ref()
     }
 }
 
@@ -149,7 +155,13 @@ impl<O> Mergable for Change<O> {
     }
 }
 
-use std::fmt::Debug;
+impl<O: Mergable + HasLength + HasIndex + Debug> Change<O> {
+    pub fn len(&self) -> usize {
+        self.ops.span().as_()
+    }
+}
+
+use std::{fmt::Debug, sync::Arc};
 impl<O: Mergable + HasLength + HasIndex + Debug> HasLength for Change<O> {
     fn content_len(&self) -> usize {
         self.ops.span().as_()
@@ -211,6 +223,7 @@ impl<O: Mergable + HasLength + HasIndex + Sliceable + HasCounter + Debug> Slicea
             id: self.id.inc(from as Counter),
             lamport: self.lamport + from as Lamport,
             timestamp: self.timestamp,
+            commit_msg: self.commit_msg.clone(),
         }
     }
 }
@@ -222,11 +235,20 @@ impl DagNode for Change {
 }
 
 impl Change {
-    pub fn can_merge_right(&self, other: &Self) -> bool {
-        other.id.peer == self.id.peer
+    pub fn can_merge_right(&self, other: &Self, merge_interval: i64) -> bool {
+        if other.id.peer == self.id.peer
             && other.id.counter == self.id.counter + self.content_len() as Counter
             && other.deps.len() == 1
             && other.deps[0].peer == self.id.peer
+            && other.timestamp - self.timestamp < merge_interval
+            && self.commit_msg == other.commit_msg
+        {
+            debug_assert!(other.timestamp >= self.timestamp);
+            debug_assert!(other.lamport == self.lamport + self.len() as Lamport);
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) use id::{PeerID, ID};
 pub(crate) use loro_common::InternalString;
 
 pub use container::ContainerType;
-pub use encoding::json_schema::op::*;
+pub use encoding::json_schema::json;
 pub use loro_common::{loro_value, to_value};
 #[cfg(feature = "wasm")]
 pub use value::wasm;

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -636,6 +636,7 @@ pub(crate) fn convert_change_to_remote(
         deps: change.deps.clone(),
         lamport: change.lamport,
         timestamp: change.timestamp,
+        commit_msg: change.commit_msg.clone(),
     }
 }
 

--- a/crates/loro-internal/src/oplog/change_store.rs
+++ b/crates/loro-internal/src/oplog/change_store.rs
@@ -672,6 +672,7 @@ mod mut_inner_kv {
                 id: change.id,
                 lamport: change.lamport,
                 timestamp: change.timestamp,
+                commit_msg: change.commit_msg.clone(),
             };
 
             let mut total_len = 0;
@@ -744,6 +745,7 @@ mod mut_inner_kv {
                 id: ID::new(new_change.id.peer, ctr_end),
                 lamport: next_lamport,
                 timestamp: new_change.timestamp,
+                commit_msg: new_change.commit_msg.clone(),
             };
 
             self.insert_change(new_change, false);
@@ -1010,8 +1012,7 @@ impl ChangesBlock {
         let changes = Arc::make_mut(changes);
         match changes.last_mut() {
             Some(last)
-                if change.deps_on_self()
-                    && change.timestamp - last.timestamp < merge_interval
+                if last.can_merge_right(&change, merge_interval)
                     && (!is_full
                         || (change.ops.len() == 1
                             && last.ops.last().unwrap().is_mergable(&change.ops[0], &()))) =>

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -57,6 +57,7 @@ pub struct Transaction {
     finished: bool,
     on_commit: Option<OnCommitFn>,
     timestamp: Option<Timestamp>,
+    msg: Option<Arc<str>>,
 }
 
 impl std::fmt::Debug for Transaction {
@@ -274,6 +275,7 @@ impl Transaction {
             local_ops: RleVec::new(),
             finished: false,
             on_commit: None,
+            msg: None,
         }
     }
 
@@ -287,6 +289,10 @@ impl Transaction {
 
     pub fn set_timestamp(&mut self, time: Timestamp) {
         self.timestamp = Some(time);
+    }
+
+    pub fn set_msg(&mut self, msg: Option<Arc<str>>) {
+        self.msg = msg;
     }
 
     pub(crate) fn set_on_commit(&mut self, f: OnCommitFn) {
@@ -321,6 +327,7 @@ impl Transaction {
                 self.timestamp
                     .unwrap_or_else(|| oplog.get_timestamp_for_next_txn()),
             ),
+            commit_msg: take(&mut self.msg),
         };
 
         let diff = if state.is_recording() {

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -17,12 +17,13 @@ use loro_internal::{
         Handler, ListHandler, MapHandler, TextDelta, TextHandler, TreeHandler, ValueOrHandler,
     },
     id::{Counter, PeerID, TreeID, ID},
+    json::JsonSchema,
     loro::CommitOptions,
     obs::SubID,
     undo::{UndoItemMeta, UndoOrRedo},
     version::Frontiers,
-    ContainerType, DiffEvent, FxHashMap, HandlerTrait, JsonSchema, LoroDoc, LoroValue,
-    MovableListHandler, UndoManager as InnerUndoManager, VersionVector as InternalVersionVector,
+    ContainerType, DiffEvent, FxHashMap, HandlerTrait, LoroDoc, LoroValue, MovableListHandler,
+    UndoManager as InnerUndoManager, VersionVector as InternalVersionVector,
 };
 use rle::HasLength;
 use serde::{Deserialize, Serialize};

--- a/crates/loro/src/change_meta.rs
+++ b/crates/loro/src/change_meta.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use loro_internal::{
+    change::{Change, Lamport, Timestamp},
+    id::ID,
+    version::Frontiers,
+};
+
+/// `Change` is a grouped continuous operations that share the same id, timestamp, commit message.
+///
+/// - The id of the `Change` is the id of its first op.
+/// - The second op's id is `{ peer: change.id.peer, counter: change.id.counter + 1 }`
+///
+/// The same applies on `Lamport`:
+///
+/// - The lamport of the `Change` is the lamport of its first op.
+/// - The second op's lamport is `change.lamport + 1`
+///
+/// The length of the `Change` is how many operations it contains
+#[derive(Debug, Clone)]
+pub struct ChangeMeta {
+    pub id: ID,
+    pub lamport: Lamport,
+    pub timestamp: Timestamp,
+    pub message: Option<Arc<str>>,
+    pub deps: Frontiers,
+    pub len: usize,
+}
+
+impl ChangeMeta {
+    pub(super) fn from_change(c: &Change) -> Self {
+        Self {
+            id: c.id(),
+            lamport: c.lamport(),
+            timestamp: c.timestamp(),
+            message: c.message().cloned(),
+            deps: c.deps().clone(),
+            len: c.len(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        match self.message.as_ref() {
+            Some(m) => m,
+            None => "",
+        }
+    }
+}

--- a/crates/loro/tests/commit_message_test.rs
+++ b/crates/loro/tests/commit_message_test.rs
@@ -6,6 +6,12 @@ fn test_commit_message() {
     let text = doc.get_text("text");
     text.insert(0, "hello").unwrap();
     doc.commit_with(CommitOptions::new().commit_msg("edits"));
+    let change = doc.get_change(ID::new(doc.peer_id(), 0)).unwrap();
+    assert_eq!(change.message(), "edits");
+
+    // The commit message can be synced to other peers as well
+    let doc2 = LoroDoc::new();
+    doc2.import(&doc.export_snapshot()).unwrap();
     let change = doc.get_change(ID::new(doc.peer_id(), 1)).unwrap();
     assert_eq!(change.message(), "edits");
 }

--- a/crates/loro/tests/commit_message_test.rs
+++ b/crates/loro/tests/commit_message_test.rs
@@ -1,0 +1,150 @@
+use loro::{CommitOptions, LoroDoc, VersionVector, ID};
+
+#[test]
+fn test_commit_message() {
+    let doc = LoroDoc::new();
+    let text = doc.get_text("text");
+    text.insert(0, "hello").unwrap();
+    doc.commit_with(CommitOptions::new().commit_msg("edits"));
+    let change = doc.get_change(ID::new(doc.peer_id(), 1)).unwrap();
+    assert_eq!(change.message(), "edits");
+}
+
+#[test]
+fn changes_with_commit_message_won_t_merge() {
+    let doc = LoroDoc::new();
+    let text = doc.get_text("text");
+
+    text.insert(0, "hello").unwrap();
+    doc.commit_with(CommitOptions::new().commit_msg("edit 1"));
+
+    text.insert(5, " world").unwrap();
+    doc.commit_with(CommitOptions::new().commit_msg("edit 2"));
+
+    assert_eq!(text.to_string(), "hello world");
+
+    let change1 = doc.get_change(ID::new(doc.peer_id(), 1)).unwrap();
+    let change2 = doc.get_change(ID::new(doc.peer_id(), 6)).unwrap();
+
+    assert_eq!(change1.message(), "edit 1");
+    assert_eq!(change2.message(), "edit 2");
+}
+
+#[test]
+fn test_syncing_commit_message() {
+    let doc1 = LoroDoc::new();
+    doc1.set_peer_id(1).unwrap();
+    let text1 = doc1.get_text("text");
+
+    text1.insert(0, "hello").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("edit on doc1"));
+
+    let doc2 = LoroDoc::new();
+    doc2.set_peer_id(2).unwrap();
+
+    // Export changes from doc1 and import to doc2
+    let changes = doc1.export_from(&Default::default());
+    doc2.import(&changes).unwrap();
+
+    // Verify the commit message was synced
+    let change = doc2.get_change(ID::new(1, 1)).unwrap();
+    assert_eq!(change.message(), "edit on doc1");
+
+    // Verify the text content was also synced
+    let text2 = doc2.get_text("text");
+    assert_eq!(text2.to_string(), "hello");
+}
+
+#[test]
+fn test_commit_message_sync_via_snapshot() {
+    let doc1 = LoroDoc::new();
+    doc1.set_peer_id(1).unwrap();
+    let text1 = doc1.get_text("text");
+
+    text1.insert(0, "hello").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("first edit"));
+
+    text1.insert(5, " world").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("second edit"));
+
+    // Create a snapshot of doc1
+    let snapshot = doc1.export_snapshot();
+
+    // Create a new doc from the snapshot
+    let doc2 = LoroDoc::new();
+    doc2.import(&snapshot).unwrap();
+
+    // Verify the commit messages were preserved in the snapshot
+    let change1 = doc2.get_change(ID::new(1, 1)).unwrap();
+    let change2 = doc2.get_change(ID::new(1, 6)).unwrap();
+
+    assert_eq!(change1.message(), "first edit");
+    assert_eq!(change2.message(), "second edit");
+
+    // Verify the text content was also preserved
+    let text2 = doc2.get_text("text");
+    assert_eq!(text2.to_string(), "hello world");
+}
+
+#[test]
+fn test_commit_message_sync_via_fast_snapshot() {
+    let doc1 = LoroDoc::new();
+    let doc2 = LoroDoc::new();
+    doc1.set_peer_id(1).unwrap();
+    let text1 = doc1.get_text("text");
+
+    text1.insert(0, "hello").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("first edit"));
+
+    text1.insert(5, " world").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("second edit"));
+
+    let snapshot = doc1.export_fast_snapshot();
+    doc2.import(&snapshot).unwrap();
+
+    // Verify the commit messages were preserved in the snapshot
+    let change1 = doc2.get_change(ID::new(1, 1)).unwrap();
+    let change2 = doc2.get_change(ID::new(1, 6)).unwrap();
+
+    assert_eq!(change1.message(), "first edit");
+    assert_eq!(change2.message(), "second edit");
+
+    // Verify the text content was also preserved
+    let text2 = doc2.get_text("text");
+    assert_eq!(text2.to_string(), "hello world");
+    text2.delete(0, 10).unwrap();
+    doc2.set_next_commit_message("From text2");
+    doc1.import(&doc2.export_fast_snapshot()).unwrap();
+    let c = doc1.get_change(ID::new(doc2.peer_id(), 0)).unwrap();
+    assert_eq!(c.message(), "From text2");
+}
+
+#[test]
+fn test_commit_message_json_updates() {
+    let doc1 = LoroDoc::new();
+    let text1 = doc1.get_text("text");
+
+    text1.insert(0, "hello").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("first edit"));
+
+    text1.insert(5, " world").unwrap();
+    doc1.commit_with(CommitOptions::new().commit_msg("second edit"));
+
+    let start_vv = VersionVector::new();
+    let end_vv = doc1.oplog_vv();
+    let json_updates = doc1.export_json_updates(&start_vv, &end_vv);
+
+    let doc2 = LoroDoc::new();
+    doc2.import_json_updates(json_updates).unwrap();
+
+    // Verify the commit messages were preserved in the JSON updates
+    let change1 = doc2.get_change(ID::new(doc1.peer_id(), 1)).unwrap();
+    let change2 = doc2.get_change(ID::new(doc1.peer_id(), 6)).unwrap();
+
+    assert_eq!(change1.message(), "first edit");
+    assert_eq!(change2.message(), "second edit");
+
+    // Verify the text content was also preserved
+    let text2 = doc2.get_text("text");
+    assert_eq!(text2.to_string(), "hello world");
+}


### PR DESCRIPTION
Support adding a commit message for each `Change`. 

```rust
let doc = LoroDoc::new();
let text = doc.get_text("text");
text.insert(0, "hello").unwrap();
doc.commit_with(CommitOptions::new().commit_msg("edits"));
let change = doc.get_change(ID::new(doc.peer_id(), 0)).unwrap();
assert_eq!(change.message(), "edits");

// The commit message can be synced to other peers as well
let doc2 = LoroDoc::new();
doc2.import(&doc.export_snapshot()).unwrap();
let change = doc.get_change(ID::new(doc.peer_id(), 1)).unwrap();
assert_eq!(change.message(), "edits");
```