### PR TITLE
Feat subscribe local updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "flate",
     "fuzzer",
     "gmax",
+    "GPUI",
     "heapless",
     "Helloii",
     "Hoexllo",
@@ -50,7 +51,7 @@
     "DEBUG": "*"
   },
   "rust-analyzer.cargo.features": [
-    "test_utils",
+    // "test_utils",
     // "counter"
   ],
   "editor.defaultFormatter": "rust-lang.rust-analyzer",

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -22,6 +22,7 @@ pub use loro_common;
 pub use oplog::OpLog;
 pub use state::DocState;
 pub use undo::UndoManager;
+pub use utils::subscription::Subscription;
 pub mod awareness;
 pub mod cursor;
 mod kv_store;

--- a/crates/loro-internal/src/obs.rs
+++ b/crates/loro-internal/src/obs.rs
@@ -15,6 +15,7 @@ use super::{
     event::{DiffEvent, DocDiff},
 };
 
+pub type LocalUpdateCallback = Box<dyn Fn(&[u8]) + Send + Sync + 'static>;
 pub type Subscriber = Arc<dyn (for<'a> Fn(DiffEvent<'a>)) + Send + Sync>;
 
 #[derive(Default)]

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -372,6 +372,11 @@ impl OpLog {
     }
 
     #[inline(always)]
+    pub(crate) fn export_from_fast_in_range(&self, spans: &[IdSpan]) -> Bytes {
+        self.change_store.export_from_fast_in_range(spans)
+    }
+
+    #[inline(always)]
     pub(crate) fn decode(&mut self, data: ParsedHeaderAndBody) -> Result<(), LoroError> {
         decode_oplog(self, data)
     }

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -7,7 +7,7 @@ use std::{
 
 use enum_as_inner::EnumAsInner;
 use generic_btree::rle::{HasLength as RleHasLength, Mergeable as GBSliceable};
-use loro_common::{ContainerType, IdLp, LoroResult};
+use loro_common::{ContainerType, IdLp, IdSpan, LoroResult};
 use loro_delta::{array_vec::ArrayVec, DeltaRopeBuilder};
 use rle::{HasLength, Mergable, RleVec};
 use smallvec::{smallvec, SmallVec};
@@ -38,7 +38,8 @@ use super::{
     state::DocState,
 };
 
-pub type OnCommitFn = Box<dyn FnOnce(&Arc<Mutex<DocState>>) + Sync + Send>;
+pub(crate) type OnCommitFn =
+    Box<dyn FnOnce(&Arc<Mutex<DocState>>, &Arc<Mutex<OpLog>>, IdSpan) + Sync + Send>;
 
 pub struct Transaction {
     global_txn: Weak<Mutex<Option<Transaction>>>,
@@ -371,7 +372,7 @@ impl Transaction {
         drop(state);
         drop(oplog);
         if let Some(on_commit) = self.on_commit.take() {
-            on_commit(&self.state);
+            on_commit(&self.state, &self.oplog, self.id_span());
         }
         Ok(())
     }
@@ -501,6 +502,11 @@ impl Transaction {
             peer: self.peer,
             counter: self.next_counter,
         }
+    }
+
+    #[inline]
+    pub fn id_span(&self) -> IdSpan {
+        IdSpan::new(self.peer, self.start_counter, self.next_counter)
     }
 
     pub fn next_idlp(&self) -> IdLp {

--- a/crates/loro-internal/src/utils/mod.rs
+++ b/crates/loro-internal/src/utils/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod kv_wrapper;
 pub(crate) mod lazy;
 pub(crate) mod query_by_len;
 pub mod string_slice;
+pub(crate) mod subscription;
 pub(crate) mod utf16;

--- a/crates/loro-internal/src/utils/subscription.rs
+++ b/crates/loro-internal/src/utils/subscription.rs
@@ -1,0 +1,427 @@
+/*
+This file is modified from the original file in the following repo:
+https://github.com/zed-industries/zed
+
+
+Copyright 2022 - 2024 Zed Industries, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+
+   1. Definitions.
+
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+
+   END OF TERMS AND CONDITIONS
+
+*/
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::{fmt::Debug, mem, sync::Arc};
+
+pub(crate) struct SubscriberSet<EmitterKey, Callback>(
+    Arc<Mutex<SubscriberSetState<EmitterKey, Callback>>>,
+);
+
+impl<EmitterKey, Callback> Clone for SubscriberSet<EmitterKey, Callback> {
+    fn clone(&self) -> Self {
+        SubscriberSet(self.0.clone())
+    }
+}
+
+struct SubscriberSetState<EmitterKey, Callback> {
+    subscribers: BTreeMap<EmitterKey, Option<BTreeMap<usize, Subscriber<Callback>>>>,
+    dropped_subscribers: BTreeSet<(EmitterKey, usize)>,
+    next_subscriber_id: usize,
+}
+
+struct Subscriber<Callback> {
+    active: Arc<AtomicBool>,
+    callback: Callback,
+}
+
+impl<EmitterKey, Callback> SubscriberSet<EmitterKey, Callback>
+where
+    EmitterKey: 'static + Ord + Clone + Debug,
+    Callback: 'static,
+{
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(SubscriberSetState {
+            subscribers: Default::default(),
+            dropped_subscribers: Default::default(),
+            next_subscriber_id: 0,
+        })))
+    }
+
+    /// Inserts a new [`Subscription`] for the given `emitter_key`. By default, subscriptions
+    /// are inert, meaning that they won't be listed when calling `[SubscriberSet::remove]` or `[SubscriberSet::retain]`.
+    /// This method returns a tuple of a [`Subscription`] and an `impl FnOnce`, and you can use the latter
+    /// to activate the [`Subscription`].
+    pub fn insert(
+        &self,
+        emitter_key: EmitterKey,
+        callback: Callback,
+    ) -> (Subscription, impl FnOnce()) {
+        let active = Arc::new(AtomicBool::new(false));
+        let mut lock = self.0.lock().unwrap();
+        let subscriber_id = post_inc(&mut lock.next_subscriber_id);
+        lock.subscribers
+            .entry(emitter_key.clone())
+            .or_default()
+            .get_or_insert_with(Default::default)
+            .insert(
+                subscriber_id,
+                Subscriber {
+                    active: active.clone(),
+                    callback,
+                },
+            );
+        let this = self.0.clone();
+
+        let subscription = Subscription {
+            unsubscribe: Some(Box::new(move || {
+                let mut lock = this.lock().unwrap();
+                let Some(subscribers) = lock.subscribers.get_mut(&emitter_key) else {
+                    // remove was called with this emitter_key
+                    return;
+                };
+
+                if let Some(subscribers) = subscribers {
+                    subscribers.remove(&subscriber_id);
+                    if subscribers.is_empty() {
+                        lock.subscribers.remove(&emitter_key);
+                    }
+                    return;
+                }
+
+                // We didn't manage to remove the subscription, which means it was dropped
+                // while invoking the callback. Mark it as dropped so that we can remove it
+                // later.
+                lock.dropped_subscribers
+                    .insert((emitter_key, subscriber_id));
+            })),
+        };
+        (subscription, move || active.store(true, Ordering::Relaxed))
+    }
+
+    pub fn remove(&self, emitter: &EmitterKey) -> impl IntoIterator<Item = Callback> {
+        let mut lock = self.0.lock().unwrap();
+        let subscribers = lock.subscribers.remove(emitter);
+        subscribers
+            .unwrap_or_default()
+            .map(|s| s.into_values())
+            .into_iter()
+            .flatten()
+            .filter_map(|subscriber| {
+                if subscriber.active.load(Ordering::Relaxed) {
+                    Some(subscriber.callback)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Call the given callback for each subscriber to the given emitter.
+    /// If the callback returns false, the subscriber is removed.
+    pub fn retain<F>(&self, emitter: &EmitterKey, mut f: F)
+    where
+        F: FnMut(&mut Callback) -> bool,
+    {
+        let Some(mut subscribers) = self
+            .0
+            .lock()
+            .unwrap()
+            .subscribers
+            .get_mut(emitter)
+            .and_then(|s| s.take())
+        else {
+            return;
+        };
+
+        subscribers.retain(|_, subscriber| {
+            if subscriber.active.load(Ordering::Relaxed) {
+                f(&mut subscriber.callback)
+            } else {
+                true
+            }
+        });
+        let mut lock = self.0.lock().unwrap();
+
+        // Add any new subscribers that were added while invoking the callback.
+        if let Some(Some(new_subscribers)) = lock.subscribers.remove(emitter) {
+            subscribers.extend(new_subscribers);
+        }
+
+        // Remove any dropped subscriptions that were dropped while invoking the callback.
+        for (dropped_emitter, dropped_subscription_id) in mem::take(&mut lock.dropped_subscribers) {
+            debug_assert_eq!(*emitter, dropped_emitter);
+            subscribers.remove(&dropped_subscription_id);
+        }
+
+        if !subscribers.is_empty() {
+            lock.subscribers.insert(emitter.clone(), Some(subscribers));
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0
+            .lock()
+            .unwrap()
+            .subscribers
+            .iter()
+            .all(|x| match &x.1 {
+                Some(x) => x.is_empty(),
+                None => true,
+            })
+    }
+}
+
+fn post_inc(next_subscriber_id: &mut usize) -> usize {
+    let ans = *next_subscriber_id;
+    *next_subscriber_id += 1;
+    ans
+}
+
+/// A handle to a subscription created by GPUI. When dropped, the subscription
+/// is cancelled and the callback will no longer be invoked.
+#[must_use]
+pub struct Subscription {
+    unsubscribe: Option<Box<dyn FnOnce() + 'static>>,
+}
+
+impl Subscription {
+    /// Creates a new subscription with a callback that gets invoked when
+    /// this subscription is dropped.
+    pub fn new(unsubscribe: impl 'static + FnOnce()) -> Self {
+        Self {
+            unsubscribe: Some(Box::new(unsubscribe)),
+        }
+    }
+
+    /// Detaches the subscription from this handle. The callback will
+    /// continue to be invoked until the views or models it has been
+    /// subscribed to are dropped
+    pub fn detach(mut self) {
+        self.unsubscribe.take();
+    }
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        if let Some(unsubscribe) = self.unsubscribe.take() {
+            unsubscribe();
+        }
+    }
+}

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -13,6 +13,7 @@ use loro_internal::encoding::ImportBlobMetadata;
 use loro_internal::handler::HandlerTrait;
 use loro_internal::handler::ValueOrHandler;
 use loro_internal::json::JsonChange;
+use loro_internal::obs::LocalUpdateCallback;
 use loro_internal::undo::{OnPop, OnPush};
 use loro_internal::version::ImVersionVector;
 use loro_internal::DocState;
@@ -51,6 +52,7 @@ pub use loro_internal::oplog::FrontiersNotIncluded;
 pub use loro_internal::undo;
 pub use loro_internal::version::{Frontiers, VersionVector};
 pub use loro_internal::ApplyDiff;
+pub use loro_internal::Subscription;
 pub use loro_internal::UndoManager as InnerUndoManager;
 pub use loro_internal::{loro_value, to_value};
 pub use loro_internal::{LoroError, LoroResult, LoroValue, ToJson};
@@ -577,6 +579,11 @@ impl LoroDoc {
         self.doc.unsubscribe(id)
     }
 
+    /// Subscribe the local update of the document.
+    pub fn subscribe_local_update(&self, callback: LocalUpdateCallback) -> Subscription {
+        self.doc.subscribe_local_update(callback)
+    }
+
     /// Estimate the size of the document states in memory.
     #[inline]
     pub fn log_estimate_size(&self) {
@@ -668,6 +675,11 @@ impl LoroDoc {
         self.doc.export_fast_snapshot()
     }
 
+    /// Export the document in the given mode.
+    pub fn export(&self, mode: ExportMode) -> Vec<u8> {
+        self.doc.export(mode)
+    }
+
     /// Analyze the container info of the doc
     ///
     /// This is used for development and debugging. It can be slow.
@@ -678,11 +690,6 @@ impl LoroDoc {
     /// Get the path from the root to the container
     pub fn get_path_to_container(&self, id: &ContainerID) -> Option<Vec<(ContainerID, Index)>> {
         self.doc.get_path_to_container(id)
-    }
-
-    /// Export the document in the given mode.
-    pub fn export(&self, mode: ExportMode) -> Vec<u8> {
-        self.doc.export(mode)
     }
 }
 

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -10,7 +10,7 @@ use loro::{
 use loro_internal::{handler::TextDelta, id::ID, vv, LoroResult};
 use rand::{Rng, SeedableRng};
 use serde_json::json;
-use tracing::{trace, trace_span};
+use tracing::{info, trace, trace_span};
 
 mod integration_test;
 
@@ -933,7 +933,9 @@ fn new_update_encode_mode() {
     let doc2 = LoroDoc::new();
 
     // Export updates from doc and import to doc2
-    let updates = doc.export(loro::ExportMode::Updates(&Default::default()));
+    let updates = doc.export(loro::ExportMode::Updates {
+        from: &Default::default(),
+    });
     doc2.import(&updates).unwrap();
 
     // Check equality
@@ -951,7 +953,9 @@ fn new_update_encode_mode() {
     doc2.commit();
 
     // Export updates from doc2 and import to doc
-    let updates2 = doc2.export(loro::ExportMode::Updates(&doc.oplog_vv()));
+    let updates2 = doc2.export(loro::ExportMode::Updates {
+        from: &doc.oplog_vv(),
+    });
     doc.import(&updates2).unwrap();
 
     // Check equality after syncing back
@@ -1016,12 +1020,16 @@ fn test_gc_sync() {
     assert_eq!(trim_end, 10);
 
     apply_random_ops(&new_doc, 1234, 5);
-    let updates = new_doc.export(loro::ExportMode::Updates(&doc.oplog_vv()));
+    let updates = new_doc.export(loro::ExportMode::Updates {
+        from: &doc.oplog_vv(),
+    });
     doc.import(&updates).unwrap();
     assert_eq!(doc.get_deep_value(), new_doc.get_deep_value());
 
     apply_random_ops(&doc, 11, 5);
-    let updates = doc.export(loro::ExportMode::Updates(&new_doc.oplog_vv()));
+    let updates = doc.export(loro::ExportMode::Updates {
+        from: &new_doc.oplog_vv(),
+    });
     new_doc.import(&updates).unwrap();
     assert_eq!(doc.get_deep_value(), new_doc.get_deep_value());
 }
@@ -1195,4 +1203,48 @@ fn test_map_checkout_on_trimmed_doc() {
         .checkout(&ID::new(doc.peer_id(), 0).into())
         .unwrap_err();
     assert_eq!(err, LoroError::SwitchToTrimmedVersion);
+}
+
+#[test]
+fn test_loro_export_local_updates() {
+    use std::sync::{Arc, Mutex};
+
+    let doc = LoroDoc::new();
+    let text = doc.get_text("text");
+    let updates = Arc::new(Mutex::new(Vec::new()));
+
+    let updates_clone = updates.clone();
+    let subscription = doc.subscribe_local_update(Box::new(move |bytes: &[u8]| {
+        updates_clone.lock().unwrap().push(bytes.to_vec());
+    }));
+
+    // Make some changes
+    text.insert(0, "Hello").unwrap();
+    doc.commit();
+    text.insert(5, " world").unwrap();
+    doc.commit();
+
+    // Check that updates were recorded
+    {
+        let recorded_updates = updates.lock().unwrap();
+        assert_eq!(recorded_updates.len(), 2);
+
+        // Verify the content of the updates
+        let doc_b = LoroDoc::new();
+        doc_b.import(&recorded_updates[0]).unwrap();
+        assert_eq!(doc_b.get_text("text").to_string(), "Hello");
+
+        doc_b.import(&recorded_updates[1]).unwrap();
+        assert_eq!(doc_b.get_text("text").to_string(), "Hello world");
+    }
+
+    {
+        // Test that the subscription can be dropped
+        drop(subscription);
+        // Make another change
+        text.insert(11, "!").unwrap();
+        doc.commit();
+        // Check that no new update was recorded
+        assert_eq!(updates.lock().unwrap().len(), 2);
+    }
 }


### PR DESCRIPTION
# Add `subscribeLocalUpdates` method to Loro

This PR introduces a new method `subscribeLocalUpdates` to the Loro API, enabling users to listen for local changes made to the document.

This allows users to subscribe to doc's local updates without the manual `exportFrom(lastVV)`, which might also include the recent imported changes and make the system less efficient.

## Features

- Subscribe to local updates in Loro instances
- Receive updates as `Uint8Array`
- Unsubscribe functionality included

## Use Cases

1. Syncing changes between multiple Loro instances
2. Saving updates to a persistent storage
3. Implementing custom change tracking or logging

## Example Usage

```typescript
const loro = new Loro();
const unsubscribe = loro.subscribeLocalUpdates((update) => {
  console.log("Local update received:", update);
  // Handle the update (e.g., send to other instances, save to storage)
});

// Unsubscribe when no longer needed
unsubscribe();
```