### PR TITLE
Record timestamp in seconds by default

### DIFF
--- a/crates/loro-internal/src/change.rs
+++ b/crates/loro-internal/src/change.rs
@@ -159,6 +159,10 @@ impl<O: Mergable + HasLength + HasIndex + Debug> Change<O> {
     pub fn len(&self) -> usize {
         self.ops.span().as_()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
 }
 
 use std::{fmt::Debug, sync::Arc};
@@ -252,16 +256,20 @@ impl Change {
     }
 }
 
+/// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
+/// It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
 #[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
 pub(crate) fn get_sys_timestamp() -> Timestamp {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_millis()
+        .as_secs()
         .as_()
 }
 
+/// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
+/// It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 pub fn get_sys_timestamp() -> Timestamp {
     use wasm_bindgen::prelude::wasm_bindgen;
@@ -273,7 +281,7 @@ pub fn get_sys_timestamp() -> Timestamp {
         pub fn now() -> f64;
     }
 
-    now() as Timestamp
+    now() as Timestamp / 1000
 }
 
 #[cfg(test)]

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -4238,6 +4238,12 @@ export interface Change {
     counter: number,
     lamport: number,
     length: number,
+    /**
+     * The timestamp in seconds.
+     * 
+     * [Unix time](https://en.wikipedia.org/wiki/Unix_time)
+     * It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
+     */
     timestamp: number,
     deps: OpId[],
 }
@@ -4442,6 +4448,12 @@ export type JsonSchema = {
 
 export type JsonChange = {
   id: JsonOpID
+  /**
+   * The timestamp in seconds.
+   * 
+   * [Unix time](https://en.wikipedia.org/wiki/Unix_time)
+   * It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
+   */
   timestamp: number,
   deps: JsonOpID[],
   lamport: number,

--- a/crates/loro/src/change_meta.rs
+++ b/crates/loro/src/change_meta.rs
@@ -1,8 +1,8 @@
-use std::{cmp::Ordering, sync::Arc};
+use std::{cmp::Ordering, sync::Arc, time::Instant};
 
 use loro_internal::{
     change::{Change, Lamport, Timestamp},
-    id::{Counter, ID},
+    id::ID,
     version::Frontiers,
 };
 
@@ -19,11 +19,18 @@ use loro_internal::{
 /// The length of the `Change` is how many operations it contains
 #[derive(Debug, Clone)]
 pub struct ChangeMeta {
+    /// Lamport timestamp of the Change
     pub lamport: Lamport,
+    /// The first Op id of the Change
     pub id: ID,
+    /// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
+    /// It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
     pub timestamp: Timestamp,
+    /// The commit message of the change
     pub message: Option<Arc<str>>,
+    /// The dependencies of the first op of the change
     pub deps: Frontiers,
+    /// The total op num inside this change
     pub len: usize,
 }
 
@@ -61,6 +68,7 @@ impl ChangeMeta {
         }
     }
 
+    /// Get the commit message in &str
     pub fn message(&self) -> &str {
         match self.message.as_ref() {
             Some(m) => m,


### PR DESCRIPTION
It's much more efficient than using milliseconds in Loro's use cases