### PR TITLE
refactor: tree contains & isDeleted

### DIFF
--- a/crates/fuzz/src/actor.rs
+++ b/crates/fuzz/src/actor.rs
@@ -560,8 +560,6 @@ impl Node {
 }
 
 pub fn assert_tree_value_eq(a: &[LoroValue], b: &[LoroValue]) {
-    // trace!("a = {:#?}", a);
-    // trace!("b = {:#?}", b);
     let a_tree = Node::from_loro_value(a);
     let b_tree = Node::from_loro_value(b);
     let mut a_q = VecDeque::from_iter([a_tree]);

--- a/crates/fuzz/src/container/tree.rs
+++ b/crates/fuzz/src/container/tree.rs
@@ -151,7 +151,11 @@ impl Actionable for TreeAction {
     fn pre_process(&mut self, actor: &mut ActionExecutor, container: usize) {
         let actor = actor.as_tree_actor().unwrap();
         let tree = actor.containers.get(container).unwrap();
-        let nodes = tree.nodes();
+        let nodes = tree
+            .nodes()
+            .into_iter()
+            .filter(|x| !tree.is_node_deleted(*x).unwrap())
+            .collect::<Vec<_>>();
         let node_num = nodes.len();
         let TreeAction { target, action } = self;
         if node_num == 0

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1177,7 +1177,6 @@ impl Handler {
                         )
                     }
                 }
-
                 for diff in diff.into_tree().unwrap().diff {
                     let mut target = diff.target;
                     match diff.action {
@@ -1190,8 +1189,7 @@ impl Handler {
                                 remap_tree_id(p, container_remap)
                             }
                             remap_tree_id(&mut target, container_remap);
-
-                            if x.contains(target) {
+                            if !x.is_node_unexist(&target) && !x.is_node_deleted(&target)? {
                                 // 1@0 is the parent of 2@1
                                 // ┌────┐    ┌───────────────┐
                                 // │xxxx│◀───│Move 2@1 to 0@0◀┐
@@ -1232,7 +1230,7 @@ impl Handler {
                         }
                         TreeExternalDiff::Delete { .. } => {
                             remap_tree_id(&mut target, container_remap);
-                            if x.contains(target) {
+                            if !x.is_node_deleted(&target).unwrap() {
                                 x.delete(target)?;
                             }
                         }

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -1645,12 +1645,21 @@ impl LoroTree {
         self.handler.get_node_parent(&target)
     }
 
-    /// Return whether target node exists.
+    /// Return whether target node exists. including deleted node.
     pub fn contains(&self, target: TreeID) -> bool {
         self.handler.contains(target)
     }
 
-    /// Return all nodes
+    /// Return whether target node is deleted.
+    ///
+    /// # Errors
+    ///
+    /// - If the target node does not exist, return `LoroTreeError::TreeNodeNotExist`.
+    pub fn is_node_deleted(&self, target: TreeID) -> LoroResult<bool> {
+        self.handler.is_node_deleted(&target)
+    }
+
+    /// Return all nodes, including deleted nodes
     pub fn nodes(&self) -> Vec<TreeID> {
         self.handler.nodes()
     }

--- a/loro-js/src/index.ts
+++ b/loro-js/src/index.ts
@@ -2,7 +2,7 @@ export {
   AwarenessWasm, Change, Container, ContainerID, ContainerType,
   Cursor, Delta, ExportMode, ImportBlobMetadata,
   JsonChange, JsonContainerID, JsonOp, JsonOpID, JsonSchema,
-  JsonValue, ListOp, LoroCounter, LoroList, LoroMap,
+  JsonValue, ListOp, LoroCounter, LoroList, LoroMap, LoroDoc,
   LoroMovableList, LoroText, LoroTree, LoroTreeNode, MapOp, MovableListOp,
   OpId, PeerID, Side, TextOp, TreeID, TreeNodeValue, TreeOp, UndoConfig,
   UndoManager, UnknownOp, Value, VersionVector, decodeImportBlobMeta, setDebug,

--- a/loro-js/tests/tree.test.ts
+++ b/loro-js/tests/tree.test.ts
@@ -52,12 +52,16 @@ describe("loro tree", () => {
     const child = tree.createNode(root.id);
     assertEquals(tree.has(child.id), true);
     tree.delete(child.id);
-    assertEquals(tree.has(child.id), false);
+    assertEquals(tree.has(child.id), true);
+    assertEquals(tree.isNodeDeleted(child.id), true);
   });
 
   it("getNodeByID", () => {
     const root = tree.createNode();
     const child = tree.createNode(root.id);
+    assertEquals(tree.getNodeByID(child.id).id, child.id);
+    tree.delete(child.id);
+    assertEquals(child.isDeleted(), true);
     assertEquals(tree.getNodeByID(child.id).id, child.id);
   });
 


### PR DESCRIPTION
# Breaking Change

## Tree Container:

- `contains()`/`has()`:  Deleted nodes are also included. Returns `false` only if the node does not exist.
- `nodes()`: Deleted nodes are also included.
- `isNodeDeleted()`: Added a function to determine whether a node is deleted.