### PR TITLE
refactor: use hierarchy value for tree value

### DIFF
--- a/crates/fuzz/src/container/tree.rs
+++ b/crates/fuzz/src/container/tree.rs
@@ -486,18 +486,9 @@ impl ApplyDiff for TreeTracker {
 
     fn to_value(&self) -> LoroValue {
         let mut list: Vec<FxHashMap<_, _>> = Vec::new();
-        let mut q = VecDeque::from_iter(
-            self.tree
-                .iter()
-                .sorted_unstable_by_key(|x| &x.position)
-                .enumerate(),
-        );
-
-        while let Some((i, node)) = q.pop_front() {
+        for (i, node) in self.tree.iter().enumerate() {
             list.push(node.to_value(i));
-            q.extend(node.children.iter().enumerate());
         }
-
         list.into()
     }
 }
@@ -535,6 +526,15 @@ impl TreeNode {
         );
         map.insert("fractional_index".to_string(), self.position.clone().into());
         map.insert("index".to_string(), (index as i64).into());
+        map.insert(
+            "children".to_string(),
+            self.children
+                .iter()
+                .enumerate()
+                .map(|(i, n)| n.to_value(i))
+                .collect::<Vec<_>>()
+                .into(),
+        );
         map
     }
 }

--- a/crates/fuzz/tests/compatibility.rs
+++ b/crates/fuzz/tests/compatibility.rs
@@ -30,8 +30,21 @@ fn updates_with_commit_message_can_be_imported_to_016() {
     let doc2 = loro_016::LoroDoc::new();
     doc2.import(&doc1.export_snapshot()).unwrap();
     assert_eq!(
-        doc2.get_deep_value().to_json(),
-        doc1.get_deep_value().to_json()
+        doc2.get_text("text").to_string(),
+        doc1.get_text("text").to_string()
+    );
+
+    assert_eq!(
+        doc2.get_tree("tree")
+            .nodes()
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>(),
+        doc1.get_tree("tree")
+            .nodes()
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
     );
 
     {

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4002,7 +4002,7 @@ mod test {
             .unwrap();
         assert_eq!(meta, 123.into());
         assert_eq!(
-            r#"[{"parent":null,"meta":{"a":123},"id":"0@1","index":0,"fractional_index":"80"}]"#,
+            r#"[{"parent":null,"meta":{"a":123},"id":"0@1","index":0,"children":[],"fractional_index":"80"}]"#,
             tree.get_deep_value().to_json()
         );
         let bytes = loro.export_snapshot();

--- a/crates/loro-internal/src/handler/tree.rs
+++ b/crates/loro-internal/src/handler/tree.rs
@@ -11,7 +11,7 @@ use smallvec::smallvec;
 use crate::{
     container::tree::tree_op::TreeOp,
     delta::{TreeDiffItem, TreeExternalDiff},
-    state::{FractionalIndexGenResult, NodePosition, TreeParentId},
+    state::{FractionalIndexGenResult, NodePosition, TreeNodeWithChildren, TreeParentId},
     txn::{EventHint, Transaction},
     BasicHandler, HandlerTrait, MapHandler,
 };
@@ -818,6 +818,19 @@ impl TreeHandler {
 
     pub fn roots(&self) -> Vec<TreeID> {
         self.children(&TreeParentId::Root).unwrap_or_default()
+    }
+
+    pub fn get_all_hierarchy_nodes_under(&self, parent: TreeParentId) -> Vec<TreeNodeWithChildren> {
+        match &self.inner {
+            MaybeDetached::Detached(_t) => {
+                // TODO: implement
+                unimplemented!()
+            }
+            MaybeDetached::Attached(a) => a.with_state(|state| {
+                let a = state.as_tree_state().unwrap();
+                a.get_all_hierarchy_nodes_under(parent)
+            }),
+        }
     }
 
     #[allow(non_snake_case)]

--- a/crates/loro-internal/src/handler/tree.rs
+++ b/crates/loro-internal/src/handler/tree.rs
@@ -11,7 +11,7 @@ use smallvec::smallvec;
 use crate::{
     container::tree::tree_op::TreeOp,
     delta::{TreeDiffItem, TreeExternalDiff},
-    state::{FractionalIndexGenResult, NodePosition, TreeNodeWithChildren, TreeParentId},
+    state::{FractionalIndexGenResult, NodePosition, TreeNode, TreeNodeWithChildren, TreeParentId},
     txn::{EventHint, Transaction},
     BasicHandler, HandlerTrait, MapHandler,
 };
@@ -816,6 +816,17 @@ impl TreeHandler {
         }
     }
 
+    pub fn get_nodes_under(&self, parent: TreeParentId) -> Vec<TreeNode> {
+        match &self.inner {
+            MaybeDetached::Detached(_t) => {
+                unreachable!()
+            }
+            MaybeDetached::Attached(a) => a.with_state(|state| {
+                let a = state.as_tree_state().unwrap();
+                a.get_all_tree_nodes_under(parent)
+            }),
+        }
+    }
     pub fn roots(&self) -> Vec<TreeID> {
         self.children(&TreeParentId::Root).unwrap_or_default()
     }

--- a/crates/loro-internal/src/history_cache.rs
+++ b/crates/loro-internal/src/history_cache.rs
@@ -264,7 +264,7 @@ impl ContainerHistoryCache {
                                         op: Arc::new(TreeOp::Create {
                                             target: node.id,
                                             parent: node.parent.tree_id(),
-                                            position: node.position.clone(),
+                                            position: node.fractional_index.clone(),
                                         }),
                                         effected: true,
                                     })

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -21,7 +21,7 @@ pub use loro::LoroDoc;
 pub use loro_common;
 pub use oplog::OpLog;
 pub use state::DocState;
-pub use state::{TreeNodeWithChildren, TreeParentId};
+pub use state::{TreeNode, TreeNodeWithChildren, TreeParentId};
 pub use undo::UndoManager;
 pub use utils::subscription::Subscription;
 pub mod awareness;
@@ -70,6 +70,7 @@ pub(crate) use loro_common::InternalString;
 
 pub use container::ContainerType;
 pub use encoding::json_schema::json;
+pub use fractional_index::FractionalIndex;
 pub use loro_common::{loro_value, to_value};
 #[cfg(feature = "wasm")]
 pub use value::wasm;

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -21,7 +21,7 @@ pub use loro::LoroDoc;
 pub use loro_common;
 pub use oplog::OpLog;
 pub use state::DocState;
-pub use state::TreeParentId;
+pub use state::{TreeNodeWithChildren, TreeParentId};
 pub use undo::UndoManager;
 pub use utils::subscription::Subscription;
 pub mod awareness;

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -52,7 +52,7 @@ pub(crate) use list_state::ListState;
 pub(crate) use map_state::MapState;
 pub(crate) use richtext_state::RichtextState;
 pub(crate) use tree_state::{get_meta_value, FractionalIndexGenResult, NodePosition, TreeState};
-pub use tree_state::{TreeNodeWithChildren, TreeParentId};
+pub use tree_state::{TreeNode, TreeNodeWithChildren, TreeParentId};
 
 use self::{container_store::ContainerWrapper, unknown_state::UnknownState};
 

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1,6 +1,5 @@
 use std::{
     borrow::Cow,
-    f32::consts::E,
     io::Write,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -52,8 +51,8 @@ pub(crate) use container_store::GcStore;
 pub(crate) use list_state::ListState;
 pub(crate) use map_state::MapState;
 pub(crate) use richtext_state::RichtextState;
-pub use tree_state::TreeParentId;
 pub(crate) use tree_state::{get_meta_value, FractionalIndexGenResult, NodePosition, TreeState};
+pub use tree_state::{TreeNodeWithChildren, TreeParentId};
 
 use self::{container_store::ContainerWrapper, unknown_state::UnknownState};
 

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -741,7 +741,7 @@ impl TreeState {
             ans.push(TreeNode {
                 id: target,
                 parent,
-                position: position.position.clone(),
+                fractional_index: position.position.clone(),
                 index,
                 last_move_op: self.trees.get(&target).map(|x| x.last_move_op).unwrap(),
             });
@@ -793,7 +793,7 @@ impl TreeState {
                 ans.push(TreeNode {
                     id: *target,
                     parent: root,
-                    position: position.position.clone(),
+                    fractional_index: position.position.clone(),
                     index,
                     last_move_op: self.trees.get(target).map(|x| x.last_move_op).unwrap(),
                 });
@@ -1320,12 +1320,13 @@ pub(crate) fn get_meta_value(nodes: &mut Vec<LoroValue>, state: &mut DocState) {
     }
 }
 
-pub(crate) struct TreeNode {
-    pub(crate) id: TreeID,
-    pub(crate) parent: TreeParentId,
-    pub(crate) position: FractionalIndex,
-    pub(crate) index: usize,
-    pub(crate) last_move_op: IdFull,
+#[derive(Debug, Clone)]
+pub struct TreeNode {
+    pub id: TreeID,
+    pub parent: TreeParentId,
+    pub fractional_index: FractionalIndex,
+    pub index: usize,
+    pub last_move_op: IdFull,
 }
 
 #[derive(Debug, Clone)]
@@ -1512,7 +1513,7 @@ mod snapshot {
         let mut position_register = ValueRegister::new();
         let mut id_to_idx = FxHashMap::default();
         for node in input.iter() {
-            position_set.insert(node.position.clone());
+            position_set.insert(node.fractional_index.clone());
             let idx = node_ids.len();
             node_ids.push(EncodedTreeNodeId {
                 peer_idx: peers.register(&node.id.peer),
@@ -1538,7 +1539,7 @@ mod snapshot {
                 last_set_peer_idx: peers.register(&last_set_id.peer),
                 last_set_counter: last_set_id.counter,
                 last_set_lamport_sub_counter: last_set_id.lamport as i32 - last_set_id.counter,
-                fractional_index_idx: position_register.register(&node.position),
+                fractional_index_idx: position_register.register(&node.fractional_index),
             })
         }
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3433,7 +3433,7 @@ impl LoroTree {
         Ok(ans)
     }
 
-    /// Get the flat array of the forest.
+    /// Get the hierarchy array of the forest.
     ///
     /// Note: the metadata will be not resolved. So if you don't only care about hierarchy
     /// but also the metadata, you should use `toJson()`.
@@ -3445,6 +3445,23 @@ impl LoroTree {
             .handler
             .get_all_hierarchy_nodes_under(TreeParentId::Root);
         self.get_node_with_children(value)
+    }
+
+    /// Get the flat array of the forest. If `with_deleted` is true, the deleted nodes will be included.
+    #[wasm_bindgen(js_name = "getNodes", skip_typescript)]
+    pub fn get_nodes(&self, with_deleted: bool) -> JsResult<Array> {
+        let nodes = Array::new();
+        for v in self.handler.get_nodes_under(TreeParentId::Root) {
+            let node = LoroTreeNode::from_tree(v.id, self.handler.clone(), self.doc.clone());
+            nodes.push(&node.into());
+        }
+        if with_deleted {
+            for v in self.handler.get_nodes_under(TreeParentId::Deleted) {
+                let node = LoroTreeNode::from_tree(v.id, self.handler.clone(), self.doc.clone());
+                nodes.push(&node.into());
+            }
+        }
+        Ok(nodes)
     }
 
     fn get_node_with_children(&self, value: Vec<TreeNodeWithChildren>) -> JsResult<Array> {
@@ -3477,7 +3494,7 @@ impl LoroTree {
         Ok(ans)
     }
 
-    /// Get the flat array with metadata of the forest.
+    /// Get the hierarchy array with metadata of the forest.
     ///
     /// @example
     /// ```ts
@@ -3487,7 +3504,7 @@ impl LoroTree {
     /// const tree = doc.getTree("tree");
     /// const root = tree.createNode();
     /// root.data.set("color", "red");
-    /// // [ { id: '0@F2462C4159C4C8D1', parent: null, meta: { color: 'red' } } ]
+    /// // [ { id: '0@F2462C4159C4C8D1', parent: null, meta: { color: 'red' }, children: [] } ]
     /// console.log(tree.toJSON());
     /// ```
     #[wasm_bindgen(js_name = "toJSON")]
@@ -4536,6 +4553,7 @@ export type TreeNodeValue = {
 
 interface LoroTree{
     toArray(): TreeNodeValue[];
+    getNodes(with_deleted: boolean = false): LoroTreeNode[];
 }
 
 interface LoroMovableList {

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -402,7 +402,7 @@ fn tree() {
     root_meta.insert("color", "red").unwrap();
     assert_eq!(
         tree.get_value_with_meta().to_json(),
-        r#"[{"parent":null,"meta":{"color":"red"},"id":"0@1","index":0,"fractional_index":"80"},{"parent":"0@1","meta":{},"id":"1@1","index":0,"fractional_index":"80"}]"#
+        r#"[{"parent":null,"meta":{"color":"red"},"id":"0@1","index":0,"children":[{"parent":"0@1","meta":{},"id":"1@1","index":0,"children":[],"fractional_index":"80"}],"fractional_index":"80"}]"#
     )
 }
 
@@ -1332,21 +1332,22 @@ fn test_tree_checkout_on_trimmed_doc() -> LoroResult<()> {
                     "meta":{},
                     "id": "0@0",
                     "index": 0,
+                    "children": [{
+                        "parent": "0@0",
+                        "meta":{},
+                        "id": "1@0",
+                        "index": 0,
+                        "children": [],
+                        "fractional_index": "80",
+                    },{
+                        "parent": "0@0",
+                        "meta":{},
+                        "id": "3@0",
+                        "index": 1,
+                        "children": [],
+                        "fractional_index": "8180",
+                    },],
                     "fractional_index": "80",
-                },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "1@0",
-                    "index": 0,
-                    "fractional_index": "80",
-                },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "3@0",
-                    "index": 1,
-                    "fractional_index": "8180",
                 },
             ]
         })
@@ -1361,15 +1362,17 @@ fn test_tree_checkout_on_trimmed_doc() -> LoroResult<()> {
                     "meta":{},
                     "id": "0@0",
                     "index": 0,
+                    "children":[{
+                        "parent": "0@0",
+                        "meta":{},
+                        "id": "1@0",
+                        "index": 0,
+                        "children": [],
+                        "fractional_index": "80",
+                    }],
                     "fractional_index": "80",
                 },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "1@0",
-                    "index": 0,
-                    "fractional_index": "80",
-                },
+
             ]
         })
     );
@@ -1383,6 +1386,7 @@ fn test_tree_checkout_on_trimmed_doc() -> LoroResult<()> {
                     "meta":{},
                     "id": "0@0",
                     "index": 0,
+                    "children": [],
                     "fractional_index": "80",
                 },
                 {
@@ -1390,6 +1394,7 @@ fn test_tree_checkout_on_trimmed_doc() -> LoroResult<()> {
                     "meta":{},
                     "id": "1@0",
                     "index": 1,
+                    "children": [],
                     "fractional_index": "8180",
                 },
             ]
@@ -1405,22 +1410,27 @@ fn test_tree_checkout_on_trimmed_doc() -> LoroResult<()> {
                     "meta":{},
                     "id": "0@0",
                     "index": 0,
+                    "children": [
+                        {
+                            "parent": "0@0",
+                            "meta":{},
+                            "id": "1@0",
+                            "index": 0,
+                            "children": [],
+                            "fractional_index": "80",
+                        },
+                        {
+                            "parent": "0@0",
+                            "meta":{},
+                            "id": "3@0",
+                            "index": 1,
+                            "children": [],
+                            "fractional_index": "8180",
+                        },
+                    ],
                     "fractional_index": "80",
                 },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "1@0",
-                    "index": 0,
-                    "fractional_index": "80",
-                },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "3@0",
-                    "index": 1,
-                    "fractional_index": "8180",
-                },
+
             ]
         })
     );
@@ -1473,22 +1483,25 @@ fn test_tree_with_other_ops_checkout_on_trimmed_doc() -> LoroResult<()> {
                     "meta":{},
                     "id": "0@0",
                     "index": 0,
+                    "children": [{
+                        "parent": "0@0",
+                        "meta":{},
+                        "id": "1@0",
+                        "index": 0,
+                        "children": [],
+                        "fractional_index": "80",
+                    },
+                    {
+                        "parent": "0@0",
+                        "meta":{},
+                        "id": "3@0",
+                        "index": 1,
+                        "children": [],
+                        "fractional_index": "8180",
+                    },],
                     "fractional_index": "80",
                 },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "1@0",
-                    "index": 0,
-                    "fractional_index": "80",
-                },
-                {
-                    "parent": "0@0",
-                    "meta":{},
-                    "id": "3@0",
-                    "index": 1,
-                    "fractional_index": "8180",
-                },
+
             ]
             }
         )

--- a/loro-js/tests/tree.test.ts
+++ b/loro-js/tests/tree.test.ts
@@ -98,6 +98,20 @@ describe("loro tree", () => {
     assert(keys.includes("children"));
   });
 
+  it("getNodes", ()=>{
+    const loro2 = new LoroDoc();
+    const tree2 = loro2.getTree("root");
+    const root = tree2.createNode();
+    const child = root.createNode();
+    const nodes = tree2.getNodes({withDeleted: false});
+    assertEquals(nodes.length, 2);
+    assertEquals(nodes.map((n)=>{return n.id}), [root.id, child.id])
+    tree2.delete(child.id);
+    const nodesWithDeleted = tree2.getNodes({withDeleted:true});
+    assertEquals(nodesWithDeleted.map((n)=>{return n.id}), [root.id, child.id]);
+    assertEquals(tree2.getNodes({withDeleted: false}).map((n)=>{return n.id}), [root.id]);
+  });
+
   it("subscribe", async () => {
     const root = tree.createNode();
     const child: LoroTreeNode = tree.createNode(root.id);

--- a/loro-js/tests/tree.test.ts
+++ b/loro-js/tests/tree.test.ts
@@ -87,13 +87,15 @@ describe("loro tree", () => {
     tree2.createNode(root.id);
     tree2.createNode(root.id);
     const arr = tree2.toArray();
-    assertEquals(arr.length, 3);
+    assertEquals(arr.length, 1);
+    assertEquals(arr[0].children.length, 2)
     const keys = Object.keys(arr[0]);
     assert(keys.includes("id"));
     assert(keys.includes("parent"));
     assert(keys.includes("index"));
     assert(keys.includes("fractional_index"));
     assert(keys.includes("meta"));
+    assert(keys.includes("children"));
   });
 
   it("subscribe", async () => {


### PR DESCRIPTION
- add `getNodes({withDeleted: boolean})` for getting all `LoroTreeNode`s, if `withDeleted` is true, deleted nodes will also be included.

## Breaking Changes:

### Tree Container
`get_value()`/`get_deep_value()`: use hierarchy instead of flat data