### PR TITLE
fix: gc snapshot error

### DIFF
--- a/crates/fuzz/tests/test.rs
+++ b/crates/fuzz/tests/test.rs
@@ -11048,6 +11048,132 @@ fn gc_fuzz_22() {
 }
 
 #[test]
+fn gc_fuzz_24() {
+    test_multi_sites_with_gc(
+        5,
+        vec![FuzzTarget::All],
+        &mut [
+            SyncAll,
+            SyncAll,
+            SyncAll,
+            SyncAll,
+            SyncAll,
+            SyncAll,
+            SyncAll,
+            SyncAll,
+            Handle {
+                site: 11,
+                target: 11,
+                container: 11,
+                action: Generic(GenericAction {
+                    value: I32(185273099),
+                    bool: true,
+                    key: 185273099,
+                    pos: 795741901218843403,
+                    length: 5764338190115343115,
+                    prop: 814957259628957519,
+                }),
+            },
+            Handle {
+                site: 0,
+                target: 49,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: Container(Counter),
+                    bool: true,
+                    key: 3351758791,
+                    pos: 3010594536784644039,
+                    length: 14395694394777257927,
+                    prop: 795741901231212487,
+                }),
+            },
+            Handle {
+                site: 5,
+                target: 165,
+                container: 165,
+                action: Generic(GenericAction {
+                    value: I32(84215045),
+                    bool: true,
+                    key: 5,
+                    pos: 1280,
+                    length: 361700864190383360,
+                    prop: 361701409651229957,
+                }),
+            },
+            Handle {
+                site: 5,
+                target: 5,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: I32(131072),
+                    bool: false,
+                    key: 4294907136,
+                    pos: 361701942142959381,
+                    length: 14395694391509714181,
+                    prop: 14395694394777257927,
+                }),
+            },
+            Handle {
+                site: 0,
+                target: 0,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: Container(Counter),
+                    bool: true,
+                    key: 3351758791,
+                    pos: 14395520671940069319,
+                    length: 14395694394777257927,
+                    prop: 795741901218843591,
+                }),
+            },
+            SyncAllUndo {
+                site: 165,
+                op_len: 100663295,
+            },
+            Handle {
+                site: 5,
+                target: 0,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: I32(0),
+                    bool: false,
+                    key: 84215040,
+                    pos: 361700864190383365,
+                    length: 361700864190383492,
+                    prop: 11936128518282651045,
+                }),
+            },
+            Handle {
+                site: 0,
+                target: 50,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: I32(-60160),
+                    bool: true,
+                    key: 4294967288,
+                    pos: 361700864192480517,
+                    length: 18446744073706405637,
+                    prop: 795741901218843403,
+                }),
+            },
+            Handle {
+                site: 5,
+                target: 5,
+                container: 0,
+                action: Generic(GenericAction {
+                    value: I32(0),
+                    bool: false,
+                    key: 83886139,
+                    pos: 361700864190383365,
+                    length: 361700864198706437,
+                    prop: 11936128518282609925,
+                }),
+            },
+        ],
+    )
+}
+
+#[test]
 fn detached_editing_arb_test() {
     fn prop(u: &mut Unstructured<'_>, site_num: u8) -> arbitrary::Result<()> {
         let xs = u.arbitrary::<Vec<Action>>()?;
@@ -11126,6 +11252,8 @@ fn detached_editing_failed_case_0() {
         ],
     )
 }
+
+#[test]
 fn gc_fuzz_23() {
     test_multi_sites_with_gc(
         5,

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bytes::Bytes;
 use inner_store::InnerStore;
-use loro_common::{LoroResult, LoroValue};
+use loro_common::{ContainerID, LoroResult, LoroValue};
 use std::sync::{atomic::AtomicU64, Arc, Mutex};
 
 pub(crate) use container_wrapper::ContainerWrapper;
@@ -188,6 +188,10 @@ impl ContainerStore {
         &mut self,
     ) -> impl Iterator<Item = (&ContainerIdx, &mut ContainerWrapper)> {
         self.store.iter_all_containers_mut()
+    }
+
+    pub fn iter_all_container_ids(&mut self) -> impl Iterator<Item = ContainerID> + '_ {
+        self.store.iter_all_container_ids()
     }
 
     pub(super) fn get_or_create_mut(&mut self, idx: ContainerIdx) -> &mut State {

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -93,6 +93,14 @@ impl InnerStore {
         self.store.iter_mut()
     }
 
+    pub(crate) fn iter_all_container_ids(&mut self) -> impl Iterator<Item = ContainerID> + '_ {
+        // PERF: we don't need to load all the containers here
+        self.load_all();
+        self.store
+            .keys()
+            .map(|idx| self.arena.get_container_id(*idx).unwrap())
+    }
+
     pub(crate) fn encode(&mut self) -> Bytes {
         self.flush();
         self.kv.export()


### PR DESCRIPTION
it should retain all containers created after the `from` version