### PR TITLE
refactor: Loro import function should return LoroEncodeError

### DIFF
--- a/crates/examples/benches/bench_text.rs
+++ b/crates/examples/benches/bench_text.rs
@@ -43,7 +43,7 @@ fn bench_text(c: &mut Criterion) {
                 doc
             },
             |doc| {
-                doc.export(loro::ExportMode::Snapshot);
+                doc.export(loro::ExportMode::Snapshot).unwrap();
             },
             criterion::BatchSize::SmallInput,
         )
@@ -53,7 +53,7 @@ fn bench_text(c: &mut Criterion) {
         b.iter_batched(
             || apply_text_actions(&actions, 1),
             |doc| {
-                doc.export(loro::ExportMode::Snapshot);
+                doc.export(loro::ExportMode::Snapshot).unwrap();
             },
             criterion::BatchSize::SmallInput,
         )
@@ -68,7 +68,7 @@ fn bench_text(c: &mut Criterion) {
                 }
                 if doc_snapshot.get().is_none() {
                     let doc = doc.get().unwrap();
-                    let snapshot = doc.export(loro::ExportMode::Snapshot);
+                    let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
                     println!("B4 fast_snapshot size: {:?}", ByteSize(snapshot.len()));
                     doc_snapshot.set(snapshot).unwrap();
                 }
@@ -87,7 +87,7 @@ fn bench_text(c: &mut Criterion) {
             || {
                 if doc_x100_snapshot.get().is_none() {
                     let doc = apply_text_actions(&actions, 100);
-                    let snapshot = doc.export(loro::ExportMode::Snapshot);
+                    let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
                     println!("B4x100 fast_snapshot size: {:?}", ByteSize(snapshot.len()));
                     doc_x100_snapshot.set(snapshot).unwrap();
                 }
@@ -107,7 +107,7 @@ fn bench_text(c: &mut Criterion) {
             || {
                 if doc_x100_snapshot.get().is_none() {
                     let doc = apply_text_actions(&actions, 100);
-                    let snapshot = doc.export(loro::ExportMode::Snapshot);
+                    let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
                     println!("B4x100 fast_snapshot size: {:?}", ByteSize(snapshot.len()));
                     doc_x100_snapshot.set(snapshot).unwrap();
                 }

--- a/crates/examples/examples/init_sheet.rs
+++ b/crates/examples/examples/init_sheet.rs
@@ -8,7 +8,7 @@ pub fn main() {
     println!("init_duration {}", init_duration);
 
     let start = Instant::now();
-    let snapshot = doc.export(loro::ExportMode::Snapshot);
+    let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
     let duration = start.elapsed().as_secs_f64() * 1000.;
     println!("export duration {} size={}", duration, snapshot.len());
 }

--- a/crates/examples/examples/large_movable_list.rs
+++ b/crates/examples/examples/large_movable_list.rs
@@ -65,7 +65,7 @@ pub fn main() {
     println!("Time cost {:?}", start.elapsed());
 
     let start = Instant::now();
-    let updates = doc.export(loro::ExportMode::all_updates());
+    let updates = doc.export(loro::ExportMode::all_updates()).unwrap();
     println!("Export updates time cost {:?}", start.elapsed());
     let start = Instant::now();
     let doc2 = LoroDoc::new();

--- a/crates/examples/examples/list.rs
+++ b/crates/examples/examples/list.rs
@@ -61,10 +61,18 @@ pub fn main() {
                 random_insert(&mut list_a, 100, i);
                 random_insert(&mut list_b, 100, i);
                 doc_a
-                    .import(&doc_b.export(loro::ExportMode::updates(&doc_a.oplog_vv())))
+                    .import(
+                        &doc_b
+                            .export(loro::ExportMode::updates(&doc_a.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
                 doc_b
-                    .import(&doc_a.export(loro::ExportMode::updates(&doc_b.oplog_vv())))
+                    .import(
+                        &doc_a
+                            .export(loro::ExportMode::updates(&doc_b.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
             }
 
@@ -111,10 +119,18 @@ pub fn main() {
                 random_insert(&mut list_a, 100, i);
                 random_insert(&mut list_b, 100, i);
                 doc_a
-                    .import(&doc_b.export(loro::ExportMode::updates(&doc_a.oplog_vv())))
+                    .import(
+                        &doc_b
+                            .export(loro::ExportMode::updates(&doc_a.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
                 doc_b
-                    .import(&doc_a.export(loro::ExportMode::updates(&doc_b.oplog_vv())))
+                    .import(
+                        &doc_a
+                            .export(loro::ExportMode::updates(&doc_b.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
             }
 
@@ -128,19 +144,35 @@ pub fn main() {
             random_insert(&mut list_a, 1000, 0);
             random_insert(&mut list_b, 1000, 0);
             doc_a
-                .import(&doc_b.export(loro::ExportMode::updates(&doc_a.oplog_vv())))
+                .import(
+                    &doc_b
+                        .export(loro::ExportMode::updates(&doc_a.oplog_vv()))
+                        .unwrap(),
+                )
                 .unwrap();
             doc_b
-                .import(&doc_a.export(loro::ExportMode::updates(&doc_b.oplog_vv())))
+                .import(
+                    &doc_a
+                        .export(loro::ExportMode::updates(&doc_b.oplog_vv()))
+                        .unwrap(),
+                )
                 .unwrap();
             for i in 0..1000 {
                 random_set(&mut list_a, 100, i);
                 random_set(&mut list_b, 100, i);
                 doc_a
-                    .import(&doc_b.export(loro::ExportMode::updates(&doc_a.oplog_vv())))
+                    .import(
+                        &doc_b
+                            .export(loro::ExportMode::updates(&doc_a.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
                 doc_b
-                    .import(&doc_a.export(loro::ExportMode::updates(&doc_b.oplog_vv())))
+                    .import(
+                        &doc_a
+                            .export(loro::ExportMode::updates(&doc_b.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
             }
 
@@ -154,19 +186,35 @@ pub fn main() {
             random_insert(&mut list_a, 1000, 0);
             random_insert(&mut list_b, 1000, 0);
             doc_a
-                .import(&doc_b.export(loro::ExportMode::updates(&doc_a.oplog_vv())))
+                .import(
+                    &doc_b
+                        .export(loro::ExportMode::updates(&doc_a.oplog_vv()))
+                        .unwrap(),
+                )
                 .unwrap();
             doc_b
-                .import(&doc_a.export(loro::ExportMode::updates(&doc_b.oplog_vv())))
+                .import(
+                    &doc_a
+                        .export(loro::ExportMode::updates(&doc_b.oplog_vv()))
+                        .unwrap(),
+                )
                 .unwrap();
             for i in 0..1000 {
                 random_move(&mut list_a, 100, i);
                 random_move(&mut list_b, 100, i);
                 doc_a
-                    .import(&doc_b.export(loro::ExportMode::updates(&doc_a.oplog_vv())))
+                    .import(
+                        &doc_b
+                            .export(loro::ExportMode::updates(&doc_a.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
                 doc_b
-                    .import(&doc_a.export(loro::ExportMode::updates(&doc_b.oplog_vv())))
+                    .import(
+                        &doc_a
+                            .export(loro::ExportMode::updates(&doc_b.oplog_vv()))
+                            .unwrap(),
+                    )
                     .unwrap();
             }
 
@@ -186,11 +234,11 @@ fn run(name: &'static str, apply_task: impl FnOnce() -> LoroDoc) -> BenchResult 
     let apply_duration = start.elapsed().as_secs_f64() * 1000.;
 
     let start = Instant::now();
-    let snapshot = doc.export(loro::ExportMode::Snapshot);
+    let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
     let encode_snapshot_duration = start.elapsed().as_secs_f64() * 1000.;
 
     let start = Instant::now();
-    let updates = doc.export(loro::ExportMode::all_updates());
+    let updates = doc.export(loro::ExportMode::all_updates()).unwrap();
     let encode_update_duration = start.elapsed().as_secs_f64() * 1000.;
 
     let start = Instant::now();

--- a/crates/examples/examples/outliner.rs
+++ b/crates/examples/examples/outliner.rs
@@ -42,10 +42,10 @@ pub fn main() {
 
     println!(
         "Updates size: {}",
-        ByteSize(doc.export(loro::ExportMode::Snapshot).len())
+        ByteSize(doc.export(loro::ExportMode::Snapshot).unwrap().len())
     );
     let snapshot = doc.export(loro::ExportMode::Snapshot);
-    println!("Snapshot size: {}", ByteSize(snapshot.len()));
+    println!("Snapshot size: {}", ByteSize(snapshot.unwrap().len()));
     doc.with_oplog(|oplog| {
         println!(
             "Change store kv size: {}",
@@ -72,8 +72,12 @@ pub fn main() {
             }
         }
 
-        doc.import(&new_doc.export(loro::ExportMode::updates(&doc.oplog_vv())))
-            .unwrap();
+        doc.import(
+            &new_doc
+                .export(loro::ExportMode::updates(&doc.oplog_vv()))
+                .unwrap(),
+        )
+        .unwrap();
     }
 
     println!("Time taken to move {} nodes: {:?}", n * k, start.elapsed());
@@ -100,10 +104,10 @@ pub fn main() {
 
     println!(
         "Updates size: {}",
-        ByteSize(doc.export(loro::ExportMode::all_updates()).len())
+        ByteSize(doc.export(loro::ExportMode::all_updates()).unwrap().len())
     );
     let snapshot = doc.export(loro::ExportMode::Snapshot);
-    println!("Snapshot size: {}", ByteSize(snapshot.len()));
+    println!("Snapshot size: {}", ByteSize(snapshot.unwrap().len()));
     doc.compact_change_store();
     doc.with_oplog(|oplog| {
         println!(

--- a/crates/examples/examples/time_tracker.rs
+++ b/crates/examples/examples/time_tracker.rs
@@ -50,12 +50,12 @@ pub fn main() {
     println!("total_time: {}", total_time);
     println!("mem: {}", get_mem_usage());
     let snapshot = doc.export(loro::ExportMode::Snapshot);
-    println!("Snapshot Size {}", ByteSize(snapshot.len()));
+    println!("Snapshot Size {}", ByteSize(snapshot.unwrap().len()));
     println!("mem: {}", get_mem_usage());
     let trimmed_snapshot = doc.export(loro::ExportMode::trimmed_snapshot(&doc.oplog_frontiers()));
     println!(
         "GC Shallow Snapshot Size {}",
-        ByteSize(trimmed_snapshot.len())
+        ByteSize(trimmed_snapshot.unwrap().len())
     );
     println!("mem: {}", get_mem_usage());
 

--- a/crates/examples/src/utils.rs
+++ b/crates/examples/src/utils.rs
@@ -38,7 +38,7 @@ pub fn bench_fast_snapshot(doc: &LoroDoc) {
     {
         println!("======== New snapshot mode =========");
         let start = Instant::now();
-        let snapshot = doc.export(loro::ExportMode::Snapshot);
+        let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
         let elapsed = start.elapsed();
         println!("Fast Snapshot size: {}", ByteSize(snapshot.len()));
         println!("Export fast snapshot time: {:?}", elapsed);
@@ -85,7 +85,9 @@ pub fn bench_fast_snapshot(doc: &LoroDoc) {
     {
         println!("======== New snapshot mode with GC =========");
         let start = Instant::now();
-        let snapshot = doc.export(loro::ExportMode::trimmed_snapshot(&doc.oplog_frontiers()));
+        let snapshot = doc
+            .export(loro::ExportMode::trimmed_snapshot(&doc.oplog_frontiers()))
+            .unwrap();
         let elapsed = start.elapsed();
         println!("Fast Snapshot size: {}", ByteSize(snapshot.len()));
         println!("Export fast snapshot time: {:?}", elapsed);

--- a/crates/fuzz/src/actor.rs
+++ b/crates/fuzz/src/actor.rs
@@ -232,7 +232,7 @@ impl Actor {
                 let new_doc = LoroDoc::new();
                 info_span!("FuzzCheckoutCreatingNewSnapshotDoc",).in_scope(|| {
                     new_doc
-                        .import(&self.loro.export(loro::ExportMode::Snapshot))
+                        .import(&self.loro.export(loro::ExportMode::Snapshot).unwrap())
                         .unwrap();
                     assert_eq!(new_doc.get_deep_value(), self.loro.get_deep_value());
                 });

--- a/crates/fuzz/src/crdt_fuzzer.rs
+++ b/crates/fuzz/src/crdt_fuzzer.rs
@@ -224,12 +224,12 @@ impl CRDTFuzzer {
                     2 => {
                         info_span!("FastSnapshot", from = i, to = j).in_scope(|| {
                             b_doc
-                                .import(&a_doc.export(loro::ExportMode::Snapshot))
+                                .import(&a_doc.export(loro::ExportMode::Snapshot).unwrap())
                                 .unwrap();
                         });
                         info_span!("FastSnapshot", from = j, to = i).in_scope(|| {
                             a_doc
-                                .import(&b_doc.export(loro::ExportMode::Snapshot))
+                                .import(&b_doc.export(loro::ExportMode::Snapshot).unwrap())
                                 .unwrap();
                         });
                     }
@@ -383,7 +383,7 @@ pub fn test_multi_sites_with_gc(
                     let bytes = fuzzer.actors[1]
                         .loro
                         .export(loro::ExportMode::trimmed_snapshot(&f));
-                    fuzzer.actors[0].loro.import(&bytes).unwrap();
+                    fuzzer.actors[0].loro.import(&bytes.unwrap()).unwrap();
                 }
             })
         }
@@ -428,12 +428,12 @@ pub fn test_multi_sites_with_gc(
                     2 => {
                         info_span!("FastSnapshot", from = i, to = j).in_scope(|| {
                             b_doc
-                                .import(&a_doc.export(loro::ExportMode::Snapshot))
+                                .import(&a_doc.export(loro::ExportMode::Snapshot).unwrap())
                                 .unwrap();
                         });
                         info_span!("FastSnapshot", from = j, to = i).in_scope(|| {
                             a_doc
-                                .import(&b_doc.export(loro::ExportMode::Snapshot))
+                                .import(&b_doc.export(loro::ExportMode::Snapshot).unwrap())
                                 .unwrap();
                         });
                     }

--- a/crates/fuzz/tests/compatibility.rs
+++ b/crates/fuzz/tests/compatibility.rs
@@ -54,7 +54,7 @@ fn updates_with_commit_message_can_be_imported_to_016() {
     }
 
     let doc3 = loro::LoroDoc::new();
-    doc3.import(&doc1.export(loro::ExportMode::Snapshot))
+    doc3.import(&doc1.export(loro::ExportMode::Snapshot).unwrap())
         .unwrap();
     let change_from_2 = doc3.get_change(ID::new(doc2.peer_id(), 0)).unwrap();
     assert_eq!(change_from_2.len, 3);

--- a/crates/loro-common/src/error.rs
+++ b/crates/loro-common/src/error.rs
@@ -114,16 +114,24 @@ pub enum LoroTreeError {
 pub enum LoroEncodeError {
     #[error("The frontiers are not found in this doc: {0}")]
     FrontiersNotFound(String),
+    #[error("Trimmed snapshot incompatible with old snapshot format. Use new snapshot format or avoid trimmed snapshots for storage.")]
+    TrimmedSnapshotIncompatibleWithOldFormat,
 }
 
 #[cfg(feature = "wasm")]
 pub mod wasm {
     use wasm_bindgen::JsValue;
 
-    use crate::LoroError;
+    use crate::{LoroEncodeError, LoroError};
 
     impl From<LoroError> for JsValue {
         fn from(value: LoroError) -> Self {
+            JsValue::from_str(&value.to_string())
+        }
+    }
+
+    impl From<LoroEncodeError> for JsValue {
+        fn from(value: LoroEncodeError) -> Self {
             JsValue::from_str(&value.to_string())
         }
     }

--- a/crates/loro-ffi/src/doc.rs
+++ b/crates/loro-ffi/src/doc.rs
@@ -7,8 +7,8 @@ use std::{
 
 use loro::{
     cursor::CannotFindRelativePosition, DocAnalysis, FrontiersNotIncluded, IdSpan, JsonPathError,
-    JsonSchema, Lamport, LoroDoc as InnerLoroDoc, LoroError, LoroResult, PeerID, SubID, Timestamp,
-    ID,
+    JsonSchema, Lamport, LoroDoc as InnerLoroDoc, LoroEncodeError, LoroError, LoroResult, PeerID,
+    SubID, Timestamp, ID,
 };
 
 use crate::{
@@ -485,9 +485,11 @@ impl LoroDoc {
     // }
 
     pub fn export_updates_in_range(&self, spans: &[IdSpan]) -> Vec<u8> {
-        self.doc.export(loro::ExportMode::UpdatesInRange {
-            spans: Cow::Borrowed(spans),
-        })
+        self.doc
+            .export(loro::ExportMode::UpdatesInRange {
+                spans: Cow::Borrowed(spans),
+            })
+            .unwrap()
     }
 
     pub fn export_trimmed_snapshot(&self, frontiers: &Frontiers) -> Vec<u8> {
@@ -495,9 +497,13 @@ impl LoroDoc {
             .export(loro::ExportMode::TrimmedSnapshot(Cow::Owned(
                 frontiers.into(),
             )))
+            .unwrap()
     }
 
-    pub fn export_state_only(&self, frontiers: Option<Arc<Frontiers>>) -> Vec<u8> {
+    pub fn export_state_only(
+        &self,
+        frontiers: Option<Arc<Frontiers>>,
+    ) -> Result<Vec<u8>, LoroEncodeError> {
         self.doc
             .export(loro::ExportMode::StateOnly(frontiers.map(|x| {
                 let a = Arc::try_unwrap(x).unwrap();

--- a/crates/loro-internal/benches/encode.rs
+++ b/crates/loro-internal/benches/encode.rs
@@ -101,7 +101,7 @@ mod run {
         });
         b.bench_function("B4_decode_snapshot", |b| {
             ensure_ran();
-            let buf = loro.export_snapshot();
+            let buf = loro.export_snapshot().unwrap();
             b.iter(|| {
                 let store2 = LoroDoc::default();
                 store2.import(&buf).unwrap();

--- a/crates/loro-internal/benches/text_r.rs
+++ b/crates/loro-internal/benches/text_r.rs
@@ -38,7 +38,7 @@ mod run {
                 txn.commit().unwrap();
             }
 
-            let update = store.export_snapshot();
+            let update = store.export_snapshot().unwrap();
             drop(store);
             b.iter_batched(
                 || {
@@ -93,7 +93,7 @@ mod run {
             txn.commit().unwrap();
 
             b.iter(|| {
-                loro.export_snapshot();
+                loro.export_snapshot().unwrap();
             });
         });
 
@@ -137,7 +137,7 @@ mod run {
             }
             txn.commit().unwrap();
 
-            let data = loro.export_snapshot();
+            let data = loro.export_snapshot().unwrap();
             b.iter(|| {
                 let l = LoroDoc::new();
                 l.import(&data).unwrap();
@@ -344,7 +344,7 @@ mod run {
                     .unwrap();
                 loro.import(&loro_b.export_from(&loro.oplog_vv())).unwrap();
             }
-            let data = loro.export_snapshot();
+            let data = loro.export_snapshot().unwrap();
             b.iter(|| {
                 let loro = LoroDoc::default();
                 loro.import(&data).unwrap();

--- a/crates/loro-internal/benches/tree.rs
+++ b/crates/loro-internal/benches/tree.rs
@@ -123,7 +123,7 @@ mod tree {
             for _ in 0..size {
                 ids.push(tree_a.create(TreeParentId::Root).unwrap())
             }
-            doc_b.import(&doc_a.export_snapshot()).unwrap();
+            doc_b.import(&doc_a.export_snapshot().unwrap()).unwrap();
             let mut rng: StdRng = rand::SeedableRng::seed_from_u64(0);
             let n = 1000;
             b.iter(|| {

--- a/crates/loro-internal/examples/automerge_x100.rs
+++ b/crates/loro-internal/examples/automerge_x100.rs
@@ -21,7 +21,7 @@ fn main() {
     loro.diagnose_size();
     drop(actions);
     let start = Instant::now();
-    let snapshot = loro.export_snapshot();
+    let snapshot = loro.export_snapshot().unwrap();
     println!("Snapshot encoding time {}", start.elapsed().as_millis());
     let compressed = zstd::encode_all(&mut snapshot.as_slice(), 0).unwrap();
     println!(

--- a/crates/loro-internal/examples/encoding.rs
+++ b/crates/loro-internal/examples/encoding.rs
@@ -40,7 +40,7 @@ fn main() {
     }
 
     let start = Instant::now();
-    let snapshot = loro.export_snapshot();
+    let snapshot = loro.export_snapshot().unwrap();
     println!("Snapshot time {}ms", start.elapsed().as_millis());
     let output = miniz_oxide::deflate::compress_to_vec(&snapshot, 6);
     println!(

--- a/crates/loro-internal/examples/encoding_refactored.rs
+++ b/crates/loro-internal/examples/encoding_refactored.rs
@@ -21,7 +21,7 @@ fn log_size() {
             text.insert_with_txn(&mut txn, *pos, ins);
         }
         txn.commit().unwrap();
-        let snapshot = loro.export_snapshot();
+        let snapshot = loro.export_snapshot().unwrap();
         let updates = loro.export_from(&Default::default());
         let json_updates =
             serde_json::to_string(&loro.export_json_updates(&Default::default(), &loro.oplog_vv()))
@@ -47,7 +47,7 @@ fn log_size() {
             text.insert_with_txn(&mut txn, *pos, ins);
             txn.commit().unwrap();
         }
-        let snapshot = loro.export_snapshot();
+        let snapshot = loro.export_snapshot().unwrap();
         let updates = loro.export_from(&Default::default());
         println!("\n");
         println!("Snapshot size={}", snapshot.len());
@@ -72,7 +72,7 @@ fn bench_decode() {
                 text.insert(*pos, ins);
             }
         }
-        let snapshot = loro.export_snapshot();
+        let snapshot = loro.export_snapshot().unwrap();
         // for _ in 0..100 {
         //     black_box(loro.export_snapshot());
         // }

--- a/crates/loro-internal/examples/many_actors.rs
+++ b/crates/loro-internal/examples/many_actors.rs
@@ -23,7 +23,7 @@ fn import_with_many_actors() {
 
     {
         let start = Instant::now();
-        let bytes = store.export_snapshot();
+        let bytes = store.export_snapshot().unwrap();
         LoroDoc::default().import(&bytes).unwrap();
         println!("{} ms", start.elapsed().as_millis());
     }

--- a/crates/loro-internal/examples/state_size.rs
+++ b/crates/loro-internal/examples/state_size.rs
@@ -14,7 +14,7 @@ enum Kind {
 
 fn empty_state() -> Vec<u8> {
     let doc = LoroDoc::new_auto_commit();
-    doc.export(ExportMode::StateOnly(None))
+    doc.export(ExportMode::StateOnly(None)).unwrap()
 }
 
 fn create_elem_sequentially(n: usize, kind: Kind) -> LoroResult<Vec<u8>> {
@@ -48,7 +48,7 @@ fn create_elem_sequentially(n: usize, kind: Kind) -> LoroResult<Vec<u8>> {
             }
         }
     }
-    let bytes = doc.export(ExportMode::StateOnly(None));
+    let bytes = doc.export(ExportMode::StateOnly(None)).unwrap();
     Ok(bytes)
 }
 
@@ -92,7 +92,7 @@ fn create_elem_randomly(n: usize, kind: Kind) -> LoroResult<Vec<u8>> {
         }
         doc.set_peer_id(rng.gen::<u64>()).unwrap();
     }
-    let bytes = doc.export(ExportMode::StateOnly(None));
+    let bytes = doc.export(ExportMode::StateOnly(None)).unwrap();
     Ok(bytes)
 }
 
@@ -102,7 +102,8 @@ fn main() -> LoroResult<()> {
         Kind::List,
         Kind::MovableList,
         Kind::Text,
-        // Kind::Tree,
+        #[allow(unused)]
+        Kind::Tree,
         #[cfg(feature = "counter")]
         Kind::Counter,
     ] {

--- a/crates/loro-internal/examples/tree.rs
+++ b/crates/loro-internal/examples/tree.rs
@@ -48,7 +48,10 @@ fn mov() {
         tree.move_to(ids[i], TreeParentId::Node(ids[j]), children_num)
             .unwrap_or_default();
     }
-    println!("encode snapshot size {:?}", loro.export_snapshot().len());
+    println!(
+        "encode snapshot size {:?}",
+        loro.export_snapshot().unwrap().len()
+    );
     println!(
         "encode updates size {:?}",
         loro.export_from(&Default::default()).len()
@@ -63,7 +66,10 @@ fn create() {
     for _ in 0..size {
         tree.create_at(TreeParentId::Root, 0).unwrap();
     }
-    println!("encode snapshot size {:?}\n", loro.export_snapshot().len());
+    println!(
+        "encode snapshot size {:?}\n",
+        loro.export_snapshot().unwrap().len()
+    );
     println!(
         "encode updates size {:?}",
         loro.export_from(&Default::default()).len()

--- a/crates/loro-internal/src/encoding/outdated_fast_snapshot.rs
+++ b/crates/loro-internal/src/encoding/outdated_fast_snapshot.rs
@@ -63,7 +63,7 @@ pub(super) fn _decode_snapshot_bytes(bytes: Bytes) -> LoroResult<Snapshot> {
     Ok(Snapshot {
         oplog_bytes,
         state_bytes,
-        trimmed_bytes: trimmed_bytes,
+        trimmed_bytes,
     })
 }
 

--- a/crates/loro-internal/src/fork.rs
+++ b/crates/loro-internal/src/fork.rs
@@ -35,9 +35,11 @@ use crate::{version::Frontiers, LoroDoc};
 impl LoroDoc {
     /// Creates a new LoroDoc at a specified version (Frontiers)
     pub fn fork_at(&self, frontiers: &Frontiers) -> LoroDoc {
-        let bytes = self.export(crate::loro::ExportMode::SnapshotAt {
-            version: Cow::Borrowed(frontiers),
-        });
+        let bytes = self
+            .export(crate::loro::ExportMode::SnapshotAt {
+                version: Cow::Borrowed(frontiers),
+            })
+            .unwrap();
         let doc = LoroDoc::new();
         doc.import(&bytes).unwrap();
         doc

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4020,7 +4020,7 @@ mod test {
         txn.commit().unwrap();
 
         let loro2 = LoroDoc::new();
-        loro2.import(&loro.export_snapshot()).unwrap();
+        loro2.import(&loro.export_snapshot().unwrap()).unwrap();
         let handler2 = loro2.get_text("richtext");
         assert_eq!(
             handler2.get_richtext_value().to_json_value(),
@@ -4055,7 +4055,7 @@ mod test {
             r#"[{"parent":null,"meta":{"a":123},"id":"0@1","index":0,"children":[],"fractional_index":"80"}]"#,
             tree.get_deep_value().to_json()
         );
-        let bytes = loro.export_snapshot();
+        let bytes = loro.export_snapshot().unwrap();
         let loro2 = LoroDoc::new();
         loro2.import(&bytes).unwrap();
     }

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -84,8 +84,8 @@ pub use encoding::json_schema::json;
 pub use fractional_index::FractionalIndex;
 pub use loro_common::{loro_value, to_value};
 pub use loro_common::{
-    Counter, CounterSpan, IdLp, IdSpan, Lamport, LoroError, LoroResult, LoroTreeError, PeerID,
-    TreeID, ID,
+    Counter, CounterSpan, IdLp, IdSpan, Lamport, LoroEncodeError, LoroError, LoroResult,
+    LoroTreeError, PeerID, TreeID, ID,
 };
 #[cfg(feature = "wasm")]
 pub use value::wasm;

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1479,12 +1479,12 @@ impl LoroDoc {
             ExportMode::UpdatesInRange { spans } => {
                 export_fast_updates_in_range(&self.oplog.try_lock().unwrap(), spans.as_ref())
             }
-            ExportMode::TrimmedSnapshot(f) => export_trimmed_snapshot(self, &f),
+            ExportMode::TrimmedSnapshot(f) => export_trimmed_snapshot(self, &f)?,
             ExportMode::StateOnly(f) => match f {
-                Some(f) => export_state_only_snapshot(self, &f),
-                None => export_state_only_snapshot(self, &self.oplog_frontiers()),
+                Some(f) => export_state_only_snapshot(self, &f)?,
+                None => export_state_only_snapshot(self, &self.oplog_frontiers())?,
             },
-            ExportMode::SnapshotAt { version } => export_fast_snapshot_at(self, &version),
+            ExportMode::SnapshotAt { version } => export_fast_snapshot_at(self, &version)?,
         };
 
         self.renew_txn_if_auto_commit();

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -2,7 +2,8 @@ use either::Either;
 use fxhash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
 use loro_common::{
-    ContainerID, ContainerType, HasIdSpan, HasLamportSpan, IdSpan, LoroResult, LoroValue, ID,
+    ContainerID, ContainerType, HasIdSpan, HasLamportSpan, IdSpan, LoroEncodeError, LoroResult,
+    LoroValue, ID,
 };
 use rle::HasLength;
 use std::{
@@ -557,11 +558,14 @@ impl LoroDoc {
     }
 
     #[instrument(skip_all)]
-    pub fn export_snapshot(&self) -> Vec<u8> {
+    pub fn export_snapshot(&self) -> Result<Vec<u8>, LoroEncodeError> {
+        if self.is_trimmed() {
+            return Err(LoroEncodeError::TrimmedSnapshotIncompatibleWithOldFormat);
+        }
         self.commit_then_stop();
         let ans = export_snapshot(self);
         self.renew_txn_if_auto_commit();
-        ans
+        Ok(ans)
     }
 
     /// Import the json schema updates.
@@ -1205,8 +1209,9 @@ impl LoroDoc {
                 // 5. Compare the states of the new document and the current document.
 
                 // Step 1: Export the initial state from the GC snapshot.
-                let initial_snapshot =
-                    self.export(ExportMode::state_only(Some(&self.trimmed_frontiers())));
+                let initial_snapshot = self
+                    .export(ExportMode::state_only(Some(&self.trimmed_frontiers())))
+                    .unwrap();
 
                 // Step 2: Create a new document and import the initial snapshot.
                 let doc = LoroDoc::new();
@@ -1215,7 +1220,7 @@ impl LoroDoc {
                 assert_eq!(self.get_deep_value(), doc.get_deep_value());
 
                 // Step 3: Export updates from the trimmed version vector to the current version.
-                let updates = self.export(ExportMode::all_updates());
+                let updates = self.export(ExportMode::all_updates()).unwrap();
 
                 // Step 4: Import these updates into the new document.
                 doc.import(&updates).unwrap();
@@ -1236,7 +1241,7 @@ impl LoroDoc {
                     .dag
                     .frontiers_to_vv(&f)
                     .unwrap();
-                let bytes = self.export(ExportMode::updates_till(&vv));
+                let bytes = self.export(ExportMode::updates_till(&vv)).unwrap();
                 let doc = Self::new();
                 doc.import(&bytes).unwrap();
                 let mut calculated_state = doc.app_state().try_lock().unwrap();
@@ -1466,7 +1471,7 @@ impl LoroDoc {
     }
 
     #[instrument(skip(self))]
-    pub fn export(&self, mode: ExportMode) -> Vec<u8> {
+    pub fn export(&self, mode: ExportMode) -> Result<Vec<u8>, LoroEncodeError> {
         self.commit_then_stop();
         let ans = match mode {
             ExportMode::Snapshot => export_fast_snapshot(self),
@@ -1483,7 +1488,7 @@ impl LoroDoc {
         };
 
         self.renew_txn_if_auto_commit();
-        ans
+        Ok(ans)
     }
 
     pub fn trimmed_vv(&self) -> ImVersionVector {
@@ -1677,7 +1682,7 @@ mod test {
         }
         txn.commit().unwrap();
         let b = LoroDoc::new();
-        b.import(&loro.export_snapshot()).unwrap();
+        b.import(&loro.export_snapshot().unwrap()).unwrap();
         loro.checkout(&Frontiers::default()).unwrap();
         {
             let json = &loro.get_deep_value();
@@ -1711,7 +1716,7 @@ mod test {
         let a = LoroDoc::new_auto_commit();
         let update_a = a.export_snapshot();
         let b = LoroDoc::new_auto_commit();
-        b.import_batch(&[update_a]).unwrap();
+        b.import_batch(&[update_a.unwrap()]).unwrap();
         b.get_text("text").insert(0, "hello").unwrap();
         b.commit_then_renew();
         let oplog = b.oplog().try_lock().unwrap();

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -28,7 +28,7 @@ use crate::state::GcStore;
 use crate::version::{Frontiers, ImVersionVector, VersionVector};
 use crate::LoroError;
 use change_store::BlockOpRef;
-use loro_common::{HasCounter, IdLp, IdSpan};
+use loro_common::{IdLp, IdSpan};
 use rle::{HasLength, RleVec, Sliceable};
 use smallvec::SmallVec;
 

--- a/crates/loro-internal/src/oplog/change_store/block_encode.rs
+++ b/crates/loro-internal/src/oplog/change_store/block_encode.rs
@@ -694,11 +694,11 @@ mod test {
         let bytes = doc.export_from(&Default::default());
         println!("Old Update bytes {:?}", dev_utils::ByteSize(bytes.length()));
 
-        let bytes = doc.export(crate::loro::ExportMode::all_updates());
+        let bytes = doc.export(crate::loro::ExportMode::all_updates()).unwrap();
         println!("Update bytes {:?}", dev_utils::ByteSize(bytes.length()));
         // assert!(bytes.len() < 30);
 
-        let bytes = doc.export(crate::loro::ExportMode::Snapshot);
+        let bytes = doc.export(crate::loro::ExportMode::Snapshot).unwrap();
         println!("Snapshot bytes {:?}", dev_utils::ByteSize(bytes.length()));
         // assert!(bytes.len() < 30);
 

--- a/crates/loro-internal/src/oplog/loro_dag.rs
+++ b/crates/loro-internal/src/oplog/loro_dag.rs
@@ -576,6 +576,20 @@ impl AppDag {
         }
     }
 
+    pub(crate) fn can_export_trimmed_snapshot_on(&self, deps: &Frontiers) -> bool {
+        for id in deps.iter() {
+            if !self.vv.includes_id(*id) {
+                return false;
+            }
+        }
+
+        if self.is_on_trimmed_history(deps) {
+            return false;
+        }
+
+        true
+    }
+
     pub(crate) fn is_on_trimmed_history(&self, deps: &Frontiers) -> bool {
         trace!("Is on trimmed history? deps={:?}", deps);
         trace!("self.trimmed_vv {:?}", &self.trimmed_vv);

--- a/crates/loro-internal/src/oplog/pending_changes.rs
+++ b/crates/loro-internal/src/oplog/pending_changes.rs
@@ -211,7 +211,7 @@ mod test {
         let text_a = a.get_text("text");
         a.with_txn(|txn| text_a.insert_with_txn(txn, 0, "a"))
             .unwrap();
-        let update1 = a.export_snapshot();
+        let update1 = a.export_snapshot().unwrap();
         let version1 = a.oplog_vv();
         a.with_txn(|txn| text_a.insert_with_txn(txn, 1, "b"))
             .unwrap();
@@ -282,14 +282,14 @@ mod test {
         let text_b = b.get_text("text");
         a.with_txn(|txn| text_a.insert_with_txn(txn, 0, "1"))
             .unwrap();
-        b.import(&a.export_snapshot()).unwrap();
+        b.import(&a.export_snapshot().unwrap()).unwrap();
         b.with_txn(|txn| text_b.insert_with_txn(txn, 0, "1"))
             .unwrap();
         let b_change = b.export_from(&a.oplog_vv());
         a.with_txn(|txn| text_a.insert_with_txn(txn, 0, "1"))
             .unwrap();
         c.import(&b_change).unwrap();
-        c.import(&a.export_snapshot()).unwrap();
+        c.import(&a.export_snapshot().unwrap()).unwrap();
         a.import(&b_change).unwrap();
         assert_eq!(c.get_deep_value(), a.get_deep_value());
     }

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -1982,7 +1982,7 @@ mod test {
         }
         {
             let doc_b = LoroDoc::new_auto_commit();
-            doc_b.import(&doc.export_snapshot()).unwrap();
+            doc_b.import(&doc.export_snapshot().unwrap()).unwrap();
             assert_eq!(
                 doc_b.get_deep_value().to_json_value(),
                 json!({

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -1617,7 +1617,6 @@ mod snapshot {
             position_register.register(&p);
         }
 
-        let alive_node_len = input.len();
         for node in input {
             let n = state.trees.get(&node.id).unwrap();
             let last_set_id = n.last_move_op;

--- a/crates/loro-internal/tests/autocommit.rs
+++ b/crates/loro-internal/tests/autocommit.rs
@@ -19,7 +19,7 @@ fn auto_commit() {
     let text_b = doc_b.get_text("text");
     text_b.insert(0, "100").unwrap();
     doc_b.import(&bytes).unwrap();
-    doc_a.import(&doc_b.export_snapshot()).unwrap();
+    doc_a.import(&doc_b.export_snapshot().unwrap()).unwrap();
     assert_eq!(text_a.get_value(), text_b.get_value());
     doc_a.check_state_diff_calc_consistency_slow();
 }
@@ -67,6 +67,6 @@ fn auto_commit_with_checkout() {
     // should include all changes
     let new = LoroDoc::default();
     let a = new.get_map("a");
-    new.import(&doc.export_snapshot()).unwrap();
+    new.import(&doc.export_snapshot().unwrap()).unwrap();
     assert_eq!(a.get_value().to_json_value(), expected,);
 }

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -375,7 +375,7 @@ fn import_after_init_handlers() {
     b.get_list("list_a").insert(0, "list_a").unwrap();
     b.get_text("text").insert(0, "text").unwrap();
     b.get_map("map").insert("m", "map").unwrap();
-    a.import(&b.export_snapshot()).unwrap();
+    a.import(&b.export_snapshot().unwrap()).unwrap();
     a.commit_then_renew();
 }
 
@@ -383,7 +383,7 @@ fn import_after_init_handlers() {
 fn test_from_snapshot() {
     let a = LoroDoc::new_auto_commit();
     a.get_text("text").insert(0, "0").unwrap();
-    let snapshot = a.export_snapshot();
+    let snapshot = a.export_snapshot().unwrap();
     let c = LoroDoc::from_snapshot(&snapshot).unwrap();
     assert_eq!(a.get_deep_value(), c.get_deep_value());
     assert_eq!(a.oplog_frontiers(), c.oplog_frontiers());
@@ -699,7 +699,7 @@ fn map_concurrent_checkout() {
         })
         .unwrap();
     let vb_1 = doc_b.oplog_frontiers();
-    doc_a.import(&doc_b.export_snapshot()).unwrap();
+    doc_a.import(&doc_b.export_snapshot().unwrap()).unwrap();
     doc_a
         .with_txn(|txn| {
             meta_a.insert_with_txn(txn, "key", 2.into()).unwrap();
@@ -770,8 +770,8 @@ fn issue_batch_import_snapshot() {
     doc.get_map("map").insert("s", "hello world!").unwrap();
     doc2.get_map("map").insert("s", "hello?").unwrap();
 
-    let data1 = doc.export_snapshot();
-    let data2 = doc2.export_snapshot();
+    let data1 = doc.export_snapshot().unwrap();
+    let data2 = doc2.export_snapshot().unwrap();
     let doc3 = LoroDoc::new();
     doc3.import_batch(&[data1, data2]).unwrap();
 }
@@ -809,7 +809,7 @@ fn state_may_deadlock_when_import() {
 
         let doc2 = LoroDoc::new_auto_commit();
         doc2.get_map("map").insert("foo", 123).unwrap();
-        doc.import(&doc.export_snapshot()).unwrap();
+        doc.import(&doc.export_snapshot().unwrap()).unwrap();
     })
 }
 
@@ -878,7 +878,7 @@ fn empty_event() {
     doc.subscribe_root(Arc::new(move |_e| {
         fire_clone.store(true, std::sync::atomic::Ordering::Relaxed);
     }));
-    doc.import(&doc.export_snapshot()).unwrap();
+    doc.import(&doc.export_snapshot().unwrap()).unwrap();
     assert!(!fire.load(std::sync::atomic::Ordering::Relaxed));
 }
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -983,7 +983,7 @@ impl LoroDoc {
     /// @deprecated Use `export` instead
     #[wasm_bindgen(js_name = "exportSnapshot")]
     pub fn export_snapshot(&self) -> JsResult<Vec<u8>> {
-        Ok(self.0.export_snapshot())
+        Ok(self.0.export_snapshot()?)
     }
 
     /// Export updates from the specific version to the current version
@@ -1048,7 +1048,7 @@ impl LoroDoc {
     /// ```
     pub fn export(&self, mode: JsExportMode) -> JsResult<Vec<u8>> {
         let export_mode = js_to_export_mode(mode)?;
-        Ok(self.0.export(export_mode))
+        Ok(self.0.export(export_mode)?)
     }
 
     /// Export updates from the specific version to the current version with JSON format.

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -61,7 +61,7 @@ pub use loro_internal::{loro_value, to_value};
 pub use loro_internal::{
     Counter, CounterSpan, FractionalIndex, IdLp, IdSpan, Lamport, PeerID, TreeID, TreeParentId, ID,
 };
-pub use loro_internal::{LoroError, LoroResult, LoroTreeError, LoroValue, ToJson};
+pub use loro_internal::{LoroEncodeError, LoroError, LoroResult, LoroTreeError, LoroValue, ToJson};
 pub use loro_kv_store as kv_store;
 
 #[cfg(feature = "jsonpath")]
@@ -435,7 +435,7 @@ impl LoroDoc {
     )]
     #[inline]
     pub fn export_snapshot(&self) -> Vec<u8> {
-        self.doc.export_snapshot()
+        self.doc.export_snapshot().unwrap()
     }
 
     /// Convert `Frontiers` into `VersionVector`
@@ -723,7 +723,7 @@ impl LoroDoc {
     }
 
     /// Export the document in the given mode.
-    pub fn export(&self, mode: ExportMode) -> Vec<u8> {
+    pub fn export(&self, mode: ExportMode) -> Result<Vec<u8>, LoroEncodeError> {
         self.doc.export(mode)
     }
 

--- a/crates/loro/tests/commit_message_test.rs
+++ b/crates/loro/tests/commit_message_test.rs
@@ -11,7 +11,7 @@ fn test_commit_message() {
 
     // The commit message can be synced to other peers as well
     let doc2 = LoroDoc::new();
-    doc2.import(&doc.export(loro::ExportMode::Snapshot))
+    doc2.import(&doc.export(loro::ExportMode::Snapshot).unwrap())
         .unwrap();
     let change = doc.get_change(ID::new(doc.peer_id(), 1)).unwrap();
     assert_eq!(change.message(), "edits");
@@ -51,7 +51,7 @@ fn test_syncing_commit_message() {
 
     // Export changes from doc1 and import to doc2
     let changes = doc1.export(loro::ExportMode::all_updates());
-    doc2.import(&changes).unwrap();
+    doc2.import(&changes.unwrap()).unwrap();
 
     // Verify the commit message was synced
     let change = doc2.get_change(ID::new(1, 1)).unwrap();
@@ -79,7 +79,7 @@ fn test_commit_message_sync_via_snapshot() {
 
     // Create a new doc from the snapshot
     let doc2 = LoroDoc::new();
-    doc2.import(&snapshot).unwrap();
+    doc2.import(&snapshot.unwrap()).unwrap();
 
     // Verify the commit messages were preserved in the snapshot
     let change1 = doc2.get_change(ID::new(1, 1)).unwrap();
@@ -107,7 +107,7 @@ fn test_commit_message_sync_via_fast_snapshot() {
     doc1.commit_with(CommitOptions::new().commit_msg("second edit"));
 
     let snapshot = doc1.export(loro::ExportMode::Snapshot);
-    doc2.import(&snapshot).unwrap();
+    doc2.import(&snapshot.unwrap()).unwrap();
 
     // Verify the commit messages were preserved in the snapshot
     let change1 = doc2.get_change(ID::new(1, 1)).unwrap();
@@ -121,7 +121,7 @@ fn test_commit_message_sync_via_fast_snapshot() {
     assert_eq!(text2.to_string(), "hello world");
     text2.delete(0, 10).unwrap();
     doc2.set_next_commit_message("From text2");
-    doc1.import(&doc2.export(loro::ExportMode::Snapshot))
+    doc1.import(&doc2.export(loro::ExportMode::Snapshot).unwrap())
         .unwrap();
     let c = doc1.get_change(ID::new(doc2.peer_id(), 0)).unwrap();
     assert_eq!(c.message(), "From text2");

--- a/crates/loro/tests/integration_test/snapshot_at_test.rs
+++ b/crates/loro/tests/integration_test/snapshot_at_test.rs
@@ -23,7 +23,7 @@ fn test_snapshot_at_with_multiple_actions() -> anyhow::Result<()> {
         version: Cow::Borrowed(&frontiers_after_first_commit),
     });
     let new_doc_first = LoroDoc::new();
-    new_doc_first.import(&snapshot_at_first)?;
+    new_doc_first.import(&snapshot_at_first.unwrap())?;
 
     // Verify the state of the new document matches the expected state
     assert_eq!(new_doc_first.get_deep_value(), value_after_first_commit);
@@ -33,7 +33,7 @@ fn test_snapshot_at_with_multiple_actions() -> anyhow::Result<()> {
         version: Cow::Borrowed(&frontiers_after_second_commit),
     });
     let new_doc_second = LoroDoc::new();
-    new_doc_second.import(&snapshot_at_second)?;
+    new_doc_second.import(&snapshot_at_second.unwrap())?;
 
     // Verify the state of the new document matches the expected state
     assert_eq!(new_doc_second.get_deep_value(), value_after_second_commit);
@@ -60,7 +60,7 @@ fn test_fork_at_target_frontiers() -> anyhow::Result<()> {
     assert_eq!(new_doc.get_deep_value(), value_after_first_commit);
 
     // Import all updates to the new document
-    new_doc.import(&doc.export(ExportMode::all_updates()))?;
+    new_doc.import(&doc.export(ExportMode::all_updates()).unwrap())?;
     assert_eq!(new_doc.get_deep_value(), doc.get_deep_value());
 
     Ok(())

--- a/crates/loro/tests/integration_test/trimmed_test.rs
+++ b/crates/loro/tests/integration_test/trimmed_test.rs
@@ -18,7 +18,7 @@ fn test_gc() -> anyhow::Result<()> {
     let trimmed_bytes = doc.export(loro::ExportMode::trimmed_snapshot(&frontiers));
 
     let new_doc = LoroDoc::new();
-    new_doc.import(&trimmed_bytes)?;
+    new_doc.import(&trimmed_bytes.unwrap())?;
     assert_eq!(doc.get_deep_value(), new_doc.get_deep_value());
     Ok(())
 }
@@ -37,7 +37,7 @@ fn test_trimmed_1() -> anyhow::Result<()> {
     let trimmed_bytes = doc.export(loro::ExportMode::trimmed_snapshot(&frontiers));
 
     let new_doc = LoroDoc::new();
-    new_doc.import(&trimmed_bytes)?;
+    new_doc.import(&trimmed_bytes.unwrap())?;
     assert_eq!(doc.get_deep_value(), new_doc.get_deep_value());
     Ok(())
 }
@@ -55,7 +55,7 @@ fn test_checkout_to_text_that_were_created_before_gc() -> anyhow::Result<()> {
     doc.get_text("text").delete(0, 3)?;
     let bytes = doc.export(loro::ExportMode::trimmed_snapshot(&frontiers));
     let new_doc = LoroDoc::new();
-    new_doc.import(&bytes)?;
+    new_doc.import(&bytes.unwrap())?;
     new_doc.checkout(&frontiers)?;
     assert_eq!(new_doc.get_text("text").to_string(), *"2310");
     Ok(())
@@ -74,7 +74,7 @@ fn test_checkout_to_list_that_were_created_before_gc() -> anyhow::Result<()> {
     doc.get_list("list").delete(0, 3)?;
     let bytes = doc.export(loro::ExportMode::trimmed_snapshot(&frontiers));
     let new_doc = LoroDoc::new();
-    new_doc.import(&bytes)?;
+    new_doc.import(&bytes.unwrap())?;
     new_doc.checkout(&frontiers)?;
     assert_eq!(
         new_doc.get_list("list").to_vec(),
@@ -96,7 +96,7 @@ fn test_checkout_to_movable_list_that_were_created_before_gc() -> anyhow::Result
     doc.get_movable_list("list").delete(0, 3)?;
     let bytes = doc.export(loro::ExportMode::trimmed_snapshot(&frontiers));
     let new_doc = LoroDoc::new();
-    new_doc.import(&bytes)?;
+    new_doc.import(&bytes.unwrap())?;
     new_doc.checkout(&frontiers)?;
     assert_eq!(
         new_doc.get_movable_list("list").to_vec(),
@@ -113,7 +113,7 @@ fn trimmed_on_the_given_version_when_feasible() -> anyhow::Result<()> {
     doc.commit();
     let bytes = doc.export(loro::ExportMode::trimmed_snapshot_from_id(ID::new(1, 31)));
     let new_doc = LoroDoc::new();
-    new_doc.import(&bytes)?;
+    new_doc.import(&bytes.unwrap())?;
     assert_eq!(new_doc.trimmed_vv().get(&1).copied().unwrap(), 31);
     Ok(())
 }
@@ -136,12 +136,12 @@ fn export_snapshot_on_a_trimmed_doc() -> anyhow::Result<()> {
 
     // Import into a new document
     let trimmed_doc = LoroDoc::new();
-    trimmed_doc.import(&bytes)?;
+    trimmed_doc.import(&bytes.unwrap())?;
     assert_eq!(trimmed_doc.trimmed_vv().get(&1).copied().unwrap(), 31);
     let new_snapshot = trimmed_doc.export(loro::ExportMode::Snapshot);
 
     let new_doc = LoroDoc::new();
-    new_doc.import(&new_snapshot)?;
+    new_doc.import(&new_snapshot.unwrap())?;
     assert_eq!(new_doc.trimmed_vv().get(&1).copied().unwrap(), 31);
     assert_eq!(new_doc.get_deep_value(), doc.get_deep_value());
     new_doc.checkout(&frontiers)?;
@@ -164,7 +164,7 @@ fn test_richtext_gc() -> anyhow::Result<()> {
     text.insert(3, "456")?; // 5, 6, 7
     let bytes = doc.export(loro::ExportMode::trimmed_snapshot_from_id(ID::new(1, 3)));
     let new_doc = LoroDoc::new();
-    new_doc.import(&bytes)?;
+    new_doc.import(&bytes.unwrap())?;
     new_doc.checkout(&Frontiers::from(ID::new(1, 4)))?;
     assert_eq!(new_doc.get_text("text").to_string(), "321");
     new_doc.checkout_to_latest();
@@ -185,13 +185,16 @@ fn import_updates_depend_on_trimmed_history_should_raise_error() -> anyhow::Resu
     doc.commit();
     let trimmed_snapshot = doc.export(loro::ExportMode::trimmed_snapshot(&doc.oplog_frontiers()));
     doc.get_text("hello").insert(0, "world").unwrap();
-    doc2.import(&doc.export(loro::ExportMode::Updates {
-        from: Cow::Borrowed(&doc2.oplog_vv()),
-    }))
+    doc2.import(
+        &doc.export(loro::ExportMode::Updates {
+            from: Cow::Borrowed(&doc2.oplog_vv()),
+        })
+        .unwrap(),
+    )
     .unwrap();
 
     let new_doc = LoroDoc::new();
-    new_doc.import(&trimmed_snapshot).unwrap();
+    new_doc.import(&trimmed_snapshot.unwrap()).unwrap();
 
     let ran = Arc::new(AtomicBool::new(false));
     let ran_clone = ran.clone();
@@ -205,7 +208,11 @@ fn import_updates_depend_on_trimmed_history_should_raise_error() -> anyhow::Resu
             }
         }
     }));
-    let result = new_doc.import(&doc2.export(loro::ExportMode::updates_owned(new_doc.oplog_vv())));
+    let result = new_doc.import(
+        &doc2
+            .export(loro::ExportMode::updates_owned(new_doc.oplog_vv()))
+            .unwrap(),
+    );
     assert!(result.is_err());
     // But updates from doc should be fine ("hello": "world")
     assert_eq!(new_doc.get_text("hello").to_string(), *"world");
@@ -220,7 +227,7 @@ fn the_vv_on_trimmed_doc() -> anyhow::Result<()> {
     doc.commit();
     let snapshot = doc.export(loro::ExportMode::trimmed_snapshot(&doc.oplog_frontiers()));
     let new_doc = LoroDoc::new();
-    new_doc.import(&snapshot).unwrap();
+    new_doc.import(&snapshot.unwrap()).unwrap();
     assert!(!new_doc.trimmed_vv().is_empty());
     assert_eq!(new_doc.oplog_vv(), new_doc.state_vv());
     assert_eq!(new_doc.oplog_vv(), doc.state_vv());
@@ -231,7 +238,7 @@ fn the_vv_on_trimmed_doc() -> anyhow::Result<()> {
     gen_action(&doc, 0, 10);
     doc.commit();
     let bytes = doc.export(ExportMode::all_updates());
-    new_doc.import(&bytes).unwrap();
+    new_doc.import(&bytes.unwrap()).unwrap();
     assert_eq!(new_doc.oplog_vv(), new_doc.state_vv());
     assert_eq!(new_doc.oplog_vv(), doc.state_vv());
     assert_eq!(new_doc.oplog_frontiers(), doc.oplog_frontiers());
@@ -267,7 +274,7 @@ fn test_cursor_that_cannot_be_found_when_exporting_trimmed_snapshot() -> anyhow:
     doc.commit();
     let snapshot = doc.export(loro::ExportMode::trimmed_snapshot(&doc.oplog_frontiers()));
     let new_doc = LoroDoc::new();
-    new_doc.import(&snapshot)?;
+    new_doc.import(&snapshot.unwrap())?;
     let result = new_doc.get_cursor_pos(&c);
     match result {
         Ok(v) => {
@@ -297,7 +304,7 @@ fn test_cursor_that_can_be_found_when_exporting_trimmed_snapshot() -> anyhow::Re
     doc.commit();
     let snapshot = doc.export(loro::ExportMode::trimmed_snapshot_from_id(ID::new(1, 10)));
     let new_doc = LoroDoc::new();
-    new_doc.import(&snapshot)?;
+    new_doc.import(&snapshot.unwrap())?;
     let result = new_doc.get_cursor_pos(&c);
     match result {
         Ok(v) => {

--- a/crates/loro/tests/issue.rs
+++ b/crates/loro/tests/issue.rs
@@ -12,5 +12,5 @@ fn issue_0() {
     doc.import_batch(&[bytes.into()]).unwrap();
     #[allow(deprecated)]
     doc.export_snapshot();
-    doc.export(loro::ExportMode::Snapshot);
+    doc.export(loro::ExportMode::Snapshot).unwrap();
 }


### PR DESCRIPTION
- Change return type
- Add support for handling potential errors:
  - Invalid or non-existent frontiers
  - Exporting old snapshot format from trimmed snapshot doc
- Improve compatibility with trimmed docs