### PR TITLE
feat: allow users to query the changed containers in the target id range

### DIFF
--- a/.changeset/hip-squids-train.md
+++ b/.changeset/hip-squids-train.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": minor
+---
+
+Feat: allow users to query the changed containers in the target id range

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "ctor 0.2.6",
  "dev-utils",
  "enum-as-inner 0.6.0",
+ "fxhash",
  "generic-btree",
  "loro-common 1.0.0-beta.5",
  "loro-delta 1.0.0-beta.5",

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1655,6 +1655,7 @@ impl LoroDoc {
     }
 
     pub fn get_changed_containers_in(&self, id: ID, len: usize) -> FxHashSet<ContainerID> {
+        self.commit_then_renew();
         let mut set = FxHashSet::default();
         let oplog = &self.oplog().try_lock().unwrap();
         for op in oplog.iter_ops(id.to_span(len)) {

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1653,6 +1653,17 @@ impl LoroDoc {
 
         Ok(())
     }
+
+    pub fn get_changed_containers_in(&self, id: ID, len: usize) -> FxHashSet<ContainerID> {
+        let mut set = FxHashSet::default();
+        let oplog = &self.oplog().try_lock().unwrap();
+        for op in oplog.iter_ops(id.to_span(len)) {
+            let id = oplog.arena.get_container_id(op.container()).unwrap();
+            set.insert(id);
+        }
+
+        set
+    }
 }
 
 // FIXME: PERF: This method is quite slow because it iterates all the changes

--- a/crates/loro-internal/src/op.rs
+++ b/crates/loro-internal/src/op.rs
@@ -328,6 +328,10 @@ impl<'a> RichOp<'a> {
         self.peer
     }
 
+    pub fn container(&self) -> ContainerIdx {
+        self.op.container
+    }
+
     pub fn timestamp(&self) -> i64 {
         self.timestamp
     }

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1663,7 +1663,9 @@ impl LoroDoc {
         Ok(JsValue::from(obj).into())
     }
 
-    /// Returns a set of container IDs that were modified within the specified ID range.
+    /// Gets container IDs modified in the given ID range.
+    ///
+    /// **NOTE:** This method will implicitly commit.
     ///
     /// This method identifies which containers were affected by changes in a given range of operations.
     /// It can be used together with `doc.travelChangeAncestors()` to analyze the history of changes

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -16,6 +16,7 @@ import {
   encodeFrontiers,
   decodeFrontiers,
 } from "../bundler/index";
+import { ContainerID } from "loro-wasm";
 
 it("basic example", () => {
   const doc = new LoroDoc();
@@ -674,4 +675,17 @@ it("can push container to movable list", () => {
   const list = doc.getMovableList("list");
   const map = list.pushContainer(new LoroMap());
   expect(list.toJSON()).toStrictEqual([{}]);
+})
+
+it("can query the history for changed containers", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId("0");
+  doc.getText("text").insert(0, "H");
+  doc.getMap("map").set("key", "H");
+  const changed = doc.getChangedContainersIn({ peer: "0", counter: 0 }, 2)
+  const changedSet = new Set(changed);
+  expect(changedSet).toEqual(new Set([
+    "cid:root-text:Text" as ContainerID,
+    "cid:root-map:Map" as ContainerID,
+  ]))
 })

--- a/crates/loro/Cargo.toml
+++ b/crates/loro/Cargo.toml
@@ -21,6 +21,7 @@ delta = { path = "../delta", package = "loro-delta", version = "1.0.0-beta.5" }
 generic-btree = { version = "^0.10.5" }
 enum-as-inner = { workspace = true }
 tracing = { workspace = true }
+fxhash.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0.87"

--- a/crates/loro/Cargo.toml
+++ b/crates/loro/Cargo.toml
@@ -21,7 +21,7 @@ delta = { path = "../delta", package = "loro-delta", version = "1.0.0-beta.5" }
 generic-btree = { version = "^0.10.5" }
 enum-as-inner = { workspace = true }
 tracing = { workspace = true }
-fxhash.workspace = true
+fxhash = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0.87"

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -850,7 +850,9 @@ impl LoroDoc {
         self.doc.is_shallow()
     }
 
-    /// Returns a set of container IDs that were modified within the specified ID range.
+    /// Gets container IDs modified in the given ID range.
+    ///
+    /// **NOTE:** This method will implicitly commit.
     ///
     /// This method can be used in conjunction with `doc.travel_change_ancestors()` to traverse
     /// the history and identify all changes that affected specific containers.
@@ -859,10 +861,6 @@ impl LoroDoc {
     ///
     /// * `id` - The starting ID of the change range
     /// * `len` - The length of the change range to check
-    ///
-    /// # Returns
-    ///
-    /// A HashSet containing the IDs of all containers that were modified in the given range.
     pub fn get_changed_containers_in(&self, id: ID, len: usize) -> FxHashSet<ContainerID> {
         self.doc.get_changed_containers_in(id, len)
     }

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 use event::{DiffEvent, Subscriber};
+use fxhash::FxHashSet;
 use loro_common::InternalString;
 pub use loro_internal::cursor::CannotFindRelativePosition;
 use loro_internal::cursor::Cursor;
@@ -847,6 +848,23 @@ impl LoroDoc {
     /// Check if the doc contains the full history.
     pub fn is_shallow(&self) -> bool {
         self.doc.is_shallow()
+    }
+
+    /// Returns a set of container IDs that were modified within the specified ID range.
+    ///
+    /// This method can be used in conjunction with `doc.travel_change_ancestors()` to traverse
+    /// the history and identify all changes that affected specific containers.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The starting ID of the change range
+    /// * `len` - The length of the change range to check
+    ///
+    /// # Returns
+    ///
+    /// A HashSet containing the IDs of all containers that were modified in the given range.
+    pub fn get_changed_containers_in(&self, id: ID, len: usize) -> FxHashSet<ContainerID> {
+        self.doc.get_changed_containers_in(id, len)
     }
 }
 

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -2190,3 +2190,35 @@ fn get_editor() {
     let mov_id = tree.get_last_move_id(&node_0).unwrap();
     assert_eq!(mov_id.peer, 2);
 }
+
+#[test]
+fn get_changed_containers_in() {
+    let doc = LoroDoc::new();
+    doc.set_peer_id(0).unwrap();
+    let text = doc.get_text("text");
+    text.insert(0, "H").unwrap();
+    let map = doc.get_map("map");
+    map.insert("key", "value").unwrap();
+    let changed_set = doc.get_changed_containers_in(ID::new(0, 0), 2);
+    assert_eq!(
+        changed_set,
+        vec![
+            ContainerID::new_root("text", ContainerType::Text),
+            ContainerID::new_root("map", ContainerType::Map),
+        ]
+        .into_iter()
+        .collect()
+    );
+
+    map.insert("key1", "value1").unwrap();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({
+            "text": "H",
+            "map": {
+                "key": "value",
+                "key1": "value1"
+            }
+        })
+    )
+}


### PR DESCRIPTION
# Add API to query changed containers in history

## Summary

Added a new API `getChangedContainersIn()` that allows users to query which containers were modified within a specific range of changes in the document's history. This feature enables better analysis and tracking of document modifications across containers.

## Details

- Added `getChangedContainersIn(id, len)` method to `LoroDoc` that returns a set of container IDs modified in the given range
- Implemented in Rust core with `FxHashSet` for efficient unique container tracking
- Exposed through WASM bindings for JavaScript/TypeScript usage
- Added comprehensive tests in both Rust and TypeScript

# Example

```ts
  const doc = new LoroDoc();
  doc.setPeerId("0");
  doc.getText("text").insert(0, "H");
  doc.getMap("map").set("key", "H");
  const changed = doc.getChangedContainersIn({ peer: "0", counter: 0 }, 2)
  const changedSet = new Set(changed);
  expect(changedSet).toEqual(new Set([
    "cid:root-text:Text" as ContainerID,
    "cid:root-map:Map" as ContainerID,
  ]))
```


## Use Cases
- Analyzing which parts of a document were affected by specific changes
- Building history analysis tools
- Tracking container modifications for debugging or auditing purposes

## Notes
- The method implicitly commits the pending transaction before analysis
- Can be used in conjunction with `travelChangeAncestors()` for detailed history analysis