### PR TITLE
fix: tree should use jitter 0 by default

### DIFF
--- a/.changeset/popular-spoons-wash.md
+++ b/.changeset/popular-spoons-wash.md
@@ -2,4 +2,10 @@
 "loro-crdt": patch
 ---
 
-tree should use jitter 0 by default
+The fractional index in LoroTree is now enabled by default with jitter=0.
+
+To reduce the cost of LoroTree, if the `index` property in LoroTree is unused, users can still
+call `tree.disableFractionalIndex()`. However, in the new version, after disabling the fractional 
+index, `tree.moveTo()`, `tree.moveBefore()`, `tree.moveAfter()`, and `tree.createAt()` will 
+throw an error
+

--- a/.changeset/popular-spoons-wash.md
+++ b/.changeset/popular-spoons-wash.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+tree should use jitter 0 by default

--- a/crates/examples/examples/large_map.rs
+++ b/crates/examples/examples/large_map.rs
@@ -4,7 +4,7 @@ use dev_utils::get_mem_usage;
 use loro::LoroDoc;
 
 fn main() {
-    let mut init = Instant::now();
+    let init;
     {
         let start = Instant::now();
         let doc = LoroDoc::new();

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4176,7 +4176,14 @@ mod test {
         loro.set_peer_id(1).unwrap();
         let tree = loro.get_tree("root");
         let id = loro
-            .with_txn(|txn| tree.create_with_txn(txn, TreeParentId::Root, 0))
+            .with_txn(|txn| {
+                tree.create_with_txn(
+                    txn,
+                    TreeParentId::Root,
+                    0,
+                    crate::state::FiIfNotConfigured::UseJitterZero,
+                )
+            })
             .unwrap();
         loro.with_txn(|txn| {
             let meta = tree.get_meta(id)?;
@@ -4206,11 +4213,21 @@ mod test {
         let tree = loro.get_tree("root");
         let text = loro.get_text("text");
         loro.with_txn(|txn| {
-            let id = tree.create_with_txn(txn, TreeParentId::Root, 0)?;
+            let id = tree.create_with_txn(
+                txn,
+                TreeParentId::Root,
+                0,
+                crate::state::FiIfNotConfigured::UseJitterZero,
+            )?;
             let meta = tree.get_meta(id)?;
             meta.insert_with_txn(txn, "a", 1.into())?;
             text.insert_with_txn(txn, 0, "abc")?;
-            let _id2 = tree.create_with_txn(txn, TreeParentId::Root, 0)?;
+            let _id2 = tree.create_with_txn(
+                txn,
+                TreeParentId::Root,
+                0,
+                crate::state::FiIfNotConfigured::UseJitterZero,
+            )?;
             meta.insert_with_txn(txn, "b", 2.into())?;
             Ok(id)
         })

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -51,6 +51,7 @@ pub(crate) use container_store::GcStore;
 pub(crate) use list_state::ListState;
 pub(crate) use map_state::MapState;
 pub(crate) use richtext_state::RichtextState;
+pub(crate) use tree_state::FiIfNotConfigured;
 pub(crate) use tree_state::{get_meta_value, FractionalIndexGenResult, NodePosition, TreeState};
 pub use tree_state::{TreeNode, TreeNodeWithChildren, TreeParentId};
 

--- a/crates/loro-internal/tests/tree.rs
+++ b/crates/loro-internal/tests/tree.rs
@@ -9,8 +9,8 @@ fn tree_index() {
     let child = tree.create(root.into()).unwrap();
     let child2 = tree.create_at(root.into(), 0).unwrap();
     // sort with OpID
-    assert_eq!(tree.get_index_by_tree_id(&child).unwrap(), 0);
-    assert_eq!(tree.get_index_by_tree_id(&child2).unwrap(), 1);
+    assert_eq!(tree.get_index_by_tree_id(&child).unwrap(), 1);
+    assert_eq!(tree.get_index_by_tree_id(&child2).unwrap(), 0);
 
     let doc = LoroDoc::new_auto_commit();
     doc.set_peer_id(0).unwrap();

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -4011,8 +4011,11 @@ impl LoroTree {
         self.handler.enable_fractional_index(jitter);
     }
 
-    /// Disable the fractional index generation for Tree Position when
-    /// you don't need the Tree's siblings to be sorted. The fractional index will always be set to default.
+    /// Disable the fractional index generation when you don't need the Tree's siblings to be sorted.
+    /// The fractional index will always be set to the same default value 0.
+    ///
+    /// After calling this, you cannot use `tree.moveTo()`, `tree.moveBefore()`, `tree.moveAfter()`,
+    /// and `tree.createAt()`.
     #[wasm_bindgen(js_name = "disableFractionalIndex")]
     pub fn disable_fractional_index(&self) {
         self.handler.disable_fractional_index();

--- a/crates/loro-wasm/tests/__snapshots__/tree.test.ts.snap
+++ b/crates/loro-wasm/tests/__snapshots__/tree.test.ts.snap
@@ -14,7 +14,7 @@ exports[`loro tree > toArray 1`] = `
       },
       {
         "children": [],
-        "fractionalIndex": "80",
+        "fractionalIndex": "8180",
         "id": "2@1",
         "index": 1,
         "meta": {},

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -2032,8 +2032,11 @@ impl LoroTree {
         self.handler.enable_fractional_index(jitter);
     }
 
-    /// Disable the fractional index generation for Tree Position when
-    /// you don't need the Tree's siblings to be sorted. The fractional index will be always default.
+    /// Disable the fractional index generation when you don't need the Tree's siblings to be sorted.
+    /// The fractional index will always be set to the same default value 0.
+    ///
+    /// After calling this, you cannot use `tree.moveTo()`, `tree.moveBefore()`, `tree.moveAfter()`,
+    /// and `tree.createAt()`.
     #[inline]
     pub fn disable_fractional_index(&self) {
         self.handler.disable_fractional_index();

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+use pretty_assertions::assert_eq;
 use std::{
     cmp::Ordering,
     ops::ControlFlow,


### PR DESCRIPTION
Otherwise, there may be inconsistency between the tree event and the actual data because the `index` info in the event may be wrong. If the `index` property is unused, users can still disable the use of fractional index by `tree.disableFractionalIndex()`.
