### PR TITLE
fix(wasm): ownership of vv

### DIFF
--- a/.changeset/violet-fishes-smile.md
+++ b/.changeset/violet-fishes-smile.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Fix VersionVector ownership issue in WASM binding

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1235,7 +1235,7 @@ impl LoroDoc {
             temp_end_vv = Some(js_to_version_vector(end_vv)?);
             json_end_vv = &temp_end_vv.as_ref().unwrap().0;
         }
-        let json_schema = self.0.export_json_updates(&json_start_vv, &json_end_vv);
+        let json_schema = self.0.export_json_updates(json_start_vv, json_end_vv);
         let s = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         let v = json_schema
             .serialize(&s)

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -966,3 +966,21 @@ it("list shallow value vs toJSON", () => {
     ["sub"]
   ]);
 });
+
+
+it("can use version vector multiple times", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId("1");
+  doc.getText("text").update("Hello");
+  doc.commit();
+  const v = doc.version();
+  v.toJSON();
+  doc.exportJsonUpdates(v, v);
+  v.toJSON()
+  doc.exportJsonUpdates(v, v);
+  v.toJSON();
+  doc.export({ mode: "update", from: v });
+  v.toJSON();
+  doc.vvToFrontiers(v);
+  v.toJSON();
+})


### PR DESCRIPTION
If the method takes ownership of the VersionVector in WASM binding, the VersionVector will be freed. So it can no longer be used in JS.