### PR TITLE
Fix-better-event-order

### DIFF
--- a/.changeset/tricky-bees-peel.md
+++ b/.changeset/tricky-bees-peel.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Better event ordering

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1302,7 +1302,16 @@ impl DocState {
 
         // Sort by path length, so caller can apply the diff from the root to the leaf.
         // Otherwise, the caller may use a wrong path to apply the diff.
-        diff.sort_by_key(|x| x.path.len());
+
+        diff.sort_by_key(|x| {
+            (
+                x.path.len(),
+                match &x.id {
+                    ContainerID::Root { .. } => 0,
+                    ContainerID::Normal { counter, .. } => *counter + 1,
+                },
+            )
+        });
         DocDiff {
             from,
             to,

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -2349,3 +2349,20 @@ fn test_detach_and_attach() {
     doc.attach();
     assert!(!doc.is_detached());
 }
+
+#[test]
+fn test_event_order() {
+    let doc = LoroDoc::new();
+    let _sub = doc.subscribe_root(Arc::new(|e| {
+        let e0 = &e.events[0].diff;
+        assert!(e0.is_map());
+        let e1 = &e.events[1].diff;
+        assert!(e1.is_list());
+        let e2 = &e.events[2].diff;
+        assert!(e2.is_tree());
+    }));
+    doc.get_map("map").insert("key", "value").unwrap();
+    doc.get_list("list").insert(0, "item").unwrap();
+    doc.get_tree("tree").create(None).unwrap();
+    doc.commit();
+}


### PR DESCRIPTION
The event will now be ordered by (depth, container counter). Therefore, two container creation events within the same layer will be sorted based on the containers’ counter values. This approach can prevent the issue where child tree node events are received before the parent tree node events