### PR TITLE
feat: add exportJsonInIdSpan and make peer compression optional

### DIFF
--- a/.changeset/popular-ghosts-travel.md
+++ b/.changeset/popular-ghosts-travel.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": minor
+---
+
+feat: add exportJsonInIdSpan and make peer compression optional

--- a/crates/loro-internal/benches/encode.rs
+++ b/crates/loro-internal/benches/encode.rs
@@ -111,12 +111,12 @@ mod run {
         b.bench_function("B4_encode_json_update", |b| {
             ensure_ran();
             b.iter(|| {
-                let _ = loro.export_json_updates(&Default::default(), &loro.oplog_vv());
+                let _ = loro.export_json_updates(&Default::default(), &loro.oplog_vv(), true);
             })
         });
         b.bench_function("B4_decode_json_update", |b| {
             ensure_ran();
-            let json = loro.export_json_updates(&Default::default(), &loro.oplog_vv());
+            let json = loro.export_json_updates(&Default::default(), &loro.oplog_vv(), true);
             b.iter(|| {
                 let store2 = LoroDoc::default();
                 store2.import_json_updates(json.clone()).unwrap();

--- a/crates/loro-internal/examples/encoding.rs
+++ b/crates/loro-internal/examples/encoding.rs
@@ -79,9 +79,12 @@ fn main() {
         output.len(),
     );
 
-    let json_updates =
-        serde_json::to_string(&loro.export_json_updates(&Default::default(), &loro.oplog_vv()))
-            .unwrap();
+    let json_updates = serde_json::to_string(&loro.export_json_updates(
+        &Default::default(),
+        &loro.oplog_vv(),
+        true,
+    ))
+    .unwrap();
     let output = miniz_oxide::deflate::compress_to_vec(json_updates.as_bytes(), 6);
     println!(
         "json updates size {} after compression {}",

--- a/crates/loro-internal/examples/encoding_refactored.rs
+++ b/crates/loro-internal/examples/encoding_refactored.rs
@@ -23,9 +23,12 @@ fn log_size() {
         txn.commit().unwrap();
         let snapshot = loro.export_snapshot().unwrap();
         let updates = loro.export_from(&Default::default());
-        let json_updates =
-            serde_json::to_string(&loro.export_json_updates(&Default::default(), &loro.oplog_vv()))
-                .unwrap();
+        let json_updates = serde_json::to_string(&loro.export_json_updates(
+            &Default::default(),
+            &loro.oplog_vv(),
+            true,
+        ))
+        .unwrap();
         println!("\n");
         println!("Snapshot size={}", snapshot.len());
         println!("Updates size={}", updates.len());

--- a/crates/loro-internal/src/oplog/change_store/block_encode.rs
+++ b/crates/loro-internal/src/oplog/change_store/block_encode.rs
@@ -702,7 +702,7 @@ mod test {
         println!("Snapshot bytes {:?}", dev_utils::ByteSize(bytes.length()));
         // assert!(bytes.len() < 30);
 
-        let json = doc.export_json_updates(&Default::default(), &doc.oplog_vv());
+        let json = doc.export_json_updates(&Default::default(), &doc.oplog_vv(), true);
         let json_string = serde_json::to_string(&json.changes).unwrap();
         println!(
             "JSON string bytes {:?}",

--- a/crates/loro-internal/tests/test.rs
+++ b/crates/loro-internal/tests/test.rs
@@ -947,7 +947,7 @@ fn counter() {
     counter.increment(1.).unwrap();
     counter.increment(2.).unwrap();
     counter.decrement(1.).unwrap();
-    let json = doc.export_json_updates(&Default::default(), &doc.oplog_vv());
+    let json = doc.export_json_updates(&Default::default(), &doc.oplog_vv(), true);
     let doc2 = LoroDoc::new_auto_commit();
     doc2.import_json_updates(json).unwrap();
 }

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -6,12 +6,12 @@ use loro_internal::encoding::{ImportBlobMetadata, ImportStatus};
 use loro_internal::event::Diff;
 use loro_internal::handler::{Handler, ValueOrHandler};
 use loro_internal::version::VersionRange;
-use loro_internal::{CounterSpan, ListDiffItem, LoroDoc, LoroValue};
+use loro_internal::{Counter, CounterSpan, IdSpan, ListDiffItem, LoroDoc, LoroValue};
 use wasm_bindgen::JsValue;
 
 use crate::{
-    frontiers_to_ids, Container, Cursor, JsContainer, JsImportBlobMetadata, LoroCounter, LoroList,
-    LoroMap, LoroMovableList, LoroText, LoroTree, VersionVector,
+    frontiers_to_ids, Container, Cursor, JsContainer, JsIdSpan, JsImportBlobMetadata, LoroCounter,
+    LoroList, LoroMap, LoroMovableList, LoroText, LoroTree, VersionVector,
 };
 use wasm_bindgen::__rt::IntoJsResult;
 use wasm_bindgen::convert::RefFromWasmAbi;
@@ -77,6 +77,22 @@ pub(crate) fn js_to_container(js: JsContainer) -> Result<Container, JsValue> {
     };
 
     Ok(container)
+}
+
+pub(crate) fn js_to_id_span(js: JsIdSpan) -> Result<IdSpan, JsValue> {
+    let value: JsValue = js.into();
+    let peer = Reflect::get(&value, &JsValue::from_str("peer"))?
+        .as_string()
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+    let counter = Reflect::get(&value, &JsValue::from_str("counter"))?
+        .as_f64()
+        .unwrap() as Counter;
+    let length = Reflect::get(&value, &JsValue::from_str("length"))?
+        .as_f64()
+        .unwrap() as Counter;
+    Ok(IdSpan::new(peer, counter, counter + length))
 }
 
 pub(crate) fn js_to_version_vector(

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1260,7 +1260,7 @@ impl LoroDoc {
         let v = json
             .serialize(&s)
             .map_err(std::convert::Into::<JsValue>::into)?;
-        Ok(v.into())
+        Ok(v)
     }
 
     /// Import updates from the JSON format.

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -4,7 +4,9 @@
 #![allow(clippy::doc_lazy_continuation)]
 // #![warn(missing_docs)]
 
-use convert::{import_status_to_js_value, js_to_version_vector, resolved_diff_to_js};
+use convert::{
+    import_status_to_js_value, js_to_id_span, js_to_version_vector, resolved_diff_to_js,
+};
 use js_sys::{Array, Object, Promise, Reflect, Uint8Array};
 use loro_internal::{
     change::Lamport,
@@ -206,6 +208,8 @@ extern "C" {
     pub type JsLoroTreeValue;
     #[wasm_bindgen(typescript_type = "Record<string, ContainerID>")]
     pub type JsLoroRootShallowValue;
+    #[wasm_bindgen(typescript_type = "{ peer: PeerID, counter: number, length: number }")]
+    pub type JsIdSpan;
 }
 
 mod observer {
@@ -1222,6 +1226,7 @@ impl LoroDoc {
         &self,
         start_vv: JsValue,
         end_vv: JsValue,
+        with_peer_compression: Option<bool>,
     ) -> JsResult<JsJsonSchema> {
         let mut json_start_vv: &InternalVersionVector = &Default::default();
         let temp_start_vv: Option<wasm_bindgen::__rt::Ref<'static, VersionVector>>;
@@ -1235,9 +1240,24 @@ impl LoroDoc {
             temp_end_vv = Some(js_to_version_vector(end_vv)?);
             json_end_vv = &temp_end_vv.as_ref().unwrap().0;
         }
-        let json_schema = self.0.export_json_updates(json_start_vv, json_end_vv);
+        let json_schema = self.0.export_json_updates(
+            json_start_vv,
+            json_end_vv,
+            with_peer_compression.unwrap_or(true),
+        );
         let s = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         let v = json_schema
+            .serialize(&s)
+            .map_err(std::convert::Into::<JsValue>::into)?;
+        Ok(v.into())
+    }
+
+    #[wasm_bindgen(js_name = "exportJsonInIdSpan", skip_typescript)]
+    pub fn exportJsonInIdSpan(&self, idSpan: JsIdSpan) -> JsResult<JsValue> {
+        let id_span = js_to_id_span(idSpan)?;
+        let json = self.0.export_json_in_id_span(id_span);
+        let s = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        let v = json
             .serialize(&s)
             .map_err(std::convert::Into::<JsValue>::into)?;
         Ok(v.into())
@@ -5599,9 +5619,19 @@ interface LoroDoc<T extends Record<string, Container> = Record<string, Container
      *
      * @param start - The start version vector.
      * @param end - The end version vector.
+     * @param withPeerCompression - Whether to compress the peer IDs in the updates. Defaults to true. If you want to process the operations in application code, set this to false.
      * @returns The updates in the given range.
      */
-    exportJsonUpdates(start?: VersionVector, end?: VersionVector): JsonSchema;
+    exportJsonUpdates(start?: VersionVector, end?: VersionVector, withPeerCompression?: boolean): JsonSchema;
+    /**
+     * Export the readable [`Change`]s in the given [`IdSpan`].
+     *
+     * The peers are not compressed in the returned changes.
+     *
+     * @param idSpan - The id span to export.
+     * @returns The changes in the given id span.
+     */
+    exportJsonInIdSpan(idSpan: IdSpan): JsonChange[];
 }
 interface LoroList<T = unknown> {
     new(): LoroList<T>;

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -993,3 +993,33 @@ it("detach and attach on empty doc", () => {
   doc.attach();
   expect(doc.isDetached()).toBe(false);
 })
+
+it("export json in id span", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId("1");
+  doc.getText("text").insert(0, "Hello");
+  doc.commit();
+  {
+    const changes = doc.exportJsonInIdSpan({ peer: "1", counter: 0, length: 1 });
+    expect(changes).toStrictEqual([{
+      id: "0@1",
+      timestamp: expect.any(Number),
+      deps: [],
+      lamport: 0,
+      msg: undefined,
+      ops: [{
+        container: "cid:root-text:Text",
+        counter: 0,
+        content: {
+          type: "insert",
+          pos: 0,
+          text: "H"
+        }
+      }]
+    }]);
+  }
+  {
+    const changes = doc.exportJsonInIdSpan({ peer: "2", counter: 0, length: 1 });
+    expect(changes).toStrictEqual([]);
+  }
+})

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -994,7 +994,7 @@ it("detach and attach on empty doc", () => {
   expect(doc.isDetached()).toBe(false);
 })
 
-it("export json in id span", () => {
+it("export json in id span #602", () => {
   const doc = new LoroDoc();
   doc.setPeerId("1");
   doc.getText("text").insert(0, "Hello");

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -442,7 +442,25 @@ impl LoroDoc {
         start_vv: &VersionVector,
         end_vv: &VersionVector,
     ) -> JsonSchema {
-        self.doc.export_json_updates(start_vv, end_vv)
+        self.doc.export_json_updates(start_vv, end_vv, true)
+    }
+
+    /// Export the current state with json-string format of the document, without peer compression.
+    ///
+    /// Compared to [`export_json_updates`], this method does not compress the peer IDs in the updates.
+    /// So the operations are easier to be processed by application code.
+    #[inline]
+    pub fn export_json_updates_without_peer_compression(
+        &self,
+        start_vv: &VersionVector,
+        end_vv: &VersionVector,
+    ) -> JsonSchema {
+        self.doc.export_json_updates(start_vv, end_vv, false)
+    }
+
+    /// Export the readable [`Change`]s in the given [`IdSpan`]
+    pub fn export_json_in_id_span(&self, id_span: IdSpan) -> Vec<JsonChange> {
+        self.doc.export_json_in_id_span(id_span)
     }
 
     /// Export all the ops not included in the given `VersionVector`

--- a/crates/loro/tests/integration_test/detached_editing_test.rs
+++ b/crates/loro/tests/integration_test/detached_editing_test.rs
@@ -100,10 +100,12 @@ fn allow_editing_on_detached_mode_when_detached_editing_is_enabled() {
     start_version: Frontiers(
         [],
     ),
-    peers: [
-        1,
-        2,
-    ],
+    peers: Some(
+        [
+            1,
+            2,
+        ],
+    ),
     changes: [
         JsonChange {
             id: 0@0,


### PR DESCRIPTION
This change will make the internal operations more accessible to the application code.

- Introduced `export_json_updates_without_peer_compression` method to allow exporting JSON updates without compressing peer IDs, making it easier for application code to process.
- Updated existing `export_json_updates` method to accept a `with_peer_compression` parameter, defaulting to true.
- Refactored related code in various files to accommodate the new functionality, ensuring backward compatibility.