### PR TITLE
Adjust the ffi for apply_delta to map between ffi TextDelta and internal TextDelta

### DIFF
--- a/crates/loro-ffi/src/container/text.rs
+++ b/crates/loro-ffi/src/container/text.rs
@@ -1,8 +1,9 @@
 use std::{fmt::Display, sync::Arc};
 
-use loro::{cursor::Side, LoroResult, PeerID, TextDelta, UpdateOptions, UpdateTimeoutError};
+use loro::{cursor::Side, LoroResult, PeerID, UpdateOptions, UpdateTimeoutError};
+use loro_internal::handler::TextDelta as InternalTextDelta;
 
-use crate::{ContainerID, LoroValue, LoroValueLike};
+use crate::{ContainerID, LoroValue, LoroValueLike, TextDelta};
 
 use super::Cursor;
 
@@ -107,8 +108,9 @@ impl LoroText {
 
     /// Apply a [delta](https://quilljs.com/docs/delta/) to the text container.
     // TODO:
-    pub fn apply_delta(&self, delta: &[TextDelta]) -> LoroResult<()> {
-        self.text.apply_delta(delta)
+    pub fn apply_delta(&self, delta: Vec<TextDelta>) -> LoroResult<()> {
+        let internal_delta: Vec<InternalTextDelta> = delta.into_iter().map(|d| d.into()).collect();
+        self.text.apply_delta(&internal_delta)
     }
 
     /// Mark a range of text with a key-value pair.

--- a/crates/loro-ffi/src/event.rs
+++ b/crates/loro-ffi/src/event.rs
@@ -83,6 +83,32 @@ pub enum TextDelta {
     },
 }
 
+impl From<TextDelta> for loro_internal::handler::TextDelta {
+    fn from(value: TextDelta) -> Self {
+        match value {
+            TextDelta::Retain { retain, attributes } => loro_internal::handler::TextDelta::Retain {
+                retain: retain as usize,
+                attributes: attributes.as_ref().map(|a| {
+                    a.iter()
+                        .map(|(k, v)| (k.to_string(), v.clone().into()))
+                        .collect()
+                }),
+            },
+            TextDelta::Insert { insert, attributes } => loro_internal::handler::TextDelta::Insert {
+                insert,
+                attributes: attributes.as_ref().map(|a| {
+                    a.iter()
+                        .map(|(k, v)| (k.to_string(), v.clone().into()))
+                        .collect()
+                }),
+            },
+            TextDelta::Delete { delete } => loro_internal::handler::TextDelta::Delete {
+                delete: delete as usize,
+            },
+        }
+    }
+}
+
 pub enum ListDiffItem {
     /// Insert a new element into the list.
     Insert {


### PR DESCRIPTION
This is my first time working with rust so I apologize if this isn't the right direction, but I think we need this to be able to define apply_delta in the swift udl.