### PR TITLE
feat: find id spans between

### DIFF
--- a/.changeset/tame-spies-attack.md
+++ b/.changeset/tame-spies-attack.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": minor
+---
+
+feat: find id spans between #607

--- a/crates/loro-ffi/src/version.rs
+++ b/crates/loro-ffi/src/version.rs
@@ -133,8 +133,8 @@ pub struct VersionVectorDiff {
 impl From<loro::VersionVectorDiff> for VersionVectorDiff {
     fn from(value: loro::VersionVectorDiff) -> Self {
         Self {
-            left: value.left.into_iter().collect(),
-            right: value.right.into_iter().collect(),
+            left: value.retreat.into_iter().collect(),
+            right: value.forward.into_iter().collect(),
         }
     }
 }

--- a/crates/loro-internal/src/dag.rs
+++ b/crates/loro-internal/src/dag.rs
@@ -111,12 +111,12 @@ impl<T: Dag + ?Sized> DagUtils for T {
                 let to_span = self.get(to).unwrap();
                 if from_span.id_start() == to_span.id_start() {
                     if from.counter < to.counter {
-                        ans.right.insert(
+                        ans.forward.insert(
                             from.peer,
                             CounterSpan::new(from.counter + 1, to.counter + 1),
                         );
                     } else {
-                        ans.left.insert(
+                        ans.retreat.insert(
                             from.peer,
                             CounterSpan::new(to.counter + 1, from.counter + 1),
                         );
@@ -127,7 +127,7 @@ impl<T: Dag + ?Sized> DagUtils for T {
                 if from_span.deps().len() == 1
                     && to_span.contains_id(from_span.deps().as_single().unwrap())
                 {
-                    ans.left.insert(
+                    ans.retreat.insert(
                         from.peer,
                         CounterSpan::new(to.counter + 1, from.counter + 1),
                     );
@@ -137,7 +137,7 @@ impl<T: Dag + ?Sized> DagUtils for T {
                 if to_span.deps().len() == 1
                     && from_span.contains_id(to_span.deps().as_single().unwrap())
                 {
-                    ans.right.insert(
+                    ans.forward.insert(
                         from.peer,
                         CounterSpan::new(from.counter + 1, to.counter + 1),
                     );

--- a/crates/loro-internal/src/dag.rs
+++ b/crates/loro-internal/src/dag.rs
@@ -99,7 +99,6 @@ impl<T: Dag + ?Sized> DagUtils for T {
 
     fn find_path(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
         let mut ans = VersionVectorDiff::default();
-        trace!("find_path from={:?} to={:?}", from, to);
         if from == to {
             return ans;
         }

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -84,8 +84,8 @@ pub use encoding::json_schema::json;
 pub use fractional_index::FractionalIndex;
 pub use loro_common::{loro_value, to_value};
 pub use loro_common::{
-    Counter, CounterSpan, IdLp, IdSpan, Lamport, LoroEncodeError, LoroError, LoroResult,
-    LoroTreeError, PeerID, TreeID, ID,
+    Counter, CounterSpan, IdLp, IdSpan, IdSpanVector, Lamport, LoroEncodeError, LoroError,
+    LoroResult, LoroTreeError, PeerID, TreeID, ID,
 };
 pub use loro_common::{LoroBinaryValue, LoroListValue, LoroMapValue, LoroStringValue};
 #[cfg(feature = "wasm")]

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1637,7 +1637,7 @@ impl LoroDoc {
     }
 
     #[inline]
-    pub fn find_spans_between(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
+    pub fn find_id_spans_between(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
         self.oplog().try_lock().unwrap().dag.find_path(from, to)
     }
 }

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -30,7 +30,7 @@ use crate::{
         IntoContainerId,
     },
     cursor::{AbsolutePosition, CannotFindRelativePosition, Cursor, PosQueryResult},
-    dag::Dag,
+    dag::{Dag, DagUtils},
     diff_calc::DiffCalculator,
     encoding::{
         self, decode_snapshot, export_fast_snapshot, export_fast_updates,
@@ -49,7 +49,7 @@ use crate::{
     txn::Transaction,
     undo::DiffBatch,
     utils::subscription::{SubscriberSetWithQueue, Subscription},
-    version::{shrink_frontiers, Frontiers, ImVersionVector, VersionRange},
+    version::{shrink_frontiers, Frontiers, ImVersionVector, VersionRange, VersionVectorDiff},
     ChangeMeta, DocDiff, HandlerTrait, InternalString, ListHandler, LoroError, MapHandler,
     VersionVector,
 };
@@ -1634,6 +1634,11 @@ impl LoroDoc {
         } else {
             0
         }
+    }
+
+    #[inline]
+    pub fn find_spans_between(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
+        self.oplog().try_lock().unwrap().dag.find_path(from, to)
     }
 }
 

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -409,7 +409,7 @@ impl OpLog {
 
         let common_ancestors_vv = self.dag.frontiers_to_vv(&common_ancestors).unwrap();
         // go from lca to merged_vv
-        let diff = common_ancestors_vv.diff(&merged_vv).right;
+        let diff = common_ancestors_vv.diff(&merged_vv).forward;
         let mut iter = self.dag.iter_causal(common_ancestors, diff);
         let mut node = iter.next();
         let mut cur_cnt = 0;

--- a/crates/loro-internal/src/version.rs
+++ b/crates/loro-internal/src/version.rs
@@ -300,9 +300,9 @@ impl Deref for VersionVector {
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct VersionVectorDiff {
-    /// need to add these spans to move from right to left
+    /// these spans are included in the left, but not in the right
     pub left: IdSpanVector,
-    /// need to add these spans to move from left to right
+    /// these spans are included in the right, but not in the left
     pub right: IdSpanVector,
 }
 

--- a/crates/loro-wasm/deno_tests/basic.test.ts
+++ b/crates/loro-wasm/deno_tests/basic.test.ts
@@ -1,43 +1,60 @@
-import init, { initSync, LoroDoc, LoroMap } from "../web/loro_wasm.js";
+import init, { initSync, LoroDoc, LoroMap, LoroText } from "../web/index.js";
 import { expect } from "npm:expect";
 
 await init();
 
 Deno.test("basic", () => {
-    const doc = new LoroDoc();
-    doc.getText("text").insert(0, "Hello, world!");
-    expect(doc.getText("text").toString()).toBe("Hello, world!");
+  const doc = new LoroDoc();
+  doc.getText("text").insert(0, "Hello, world!");
+  expect(doc.getText("text").toString()).toBe("Hello, world!");
 });
 
 Deno.test("fork when detached", () => {
-    const doc = new LoroDoc();
-    doc.setPeerId("0");
-    doc.getText("text").insert(0, "Hello, world!");
-    doc.checkout([{ peer: "0", counter: 5 }]);
-    const newDoc = doc.fork();
-    newDoc.setPeerId("1");
-    newDoc.getText("text").insert(6, " Alice!");
-    // ┌───────────────┐     ┌───────────────┐
-    // │    Hello,     │◀─┬──│     world!    │
-    // └───────────────┘  │  └───────────────┘
-    //                    │
-    //                    │  ┌───────────────┐
-    //                    └──│     Alice!    │
-    //                       └───────────────┘
-    doc.import(newDoc.export({ mode: "update" }));
-    doc.checkoutToLatest();
-    console.log(doc.getText("text").toString()); // "Hello, world! Alice!"
+  const doc: LoroDoc = new LoroDoc();
+  doc.setPeerId("0");
+  doc.getText("text").insert(0, "Hello, world!");
+  doc.checkout([{ peer: "0", counter: 5 }]);
+  const newDoc = doc.fork();
+  newDoc.setPeerId("1");
+  newDoc.getText("text").insert(6, " Alice!");
+  // ┌───────────────┐     ┌───────────────┐
+  // │    Hello,     │◀─┬──│     world!    │
+  // └───────────────┘  │  └───────────────┘
+  //                    │
+  //                    │  ┌───────────────┐
+  //                    └──│     Alice!    │
+  //                       └───────────────┘
+  doc.import(newDoc.export({ mode: "update" }));
+  doc.checkoutToLatest();
+  console.log(doc.getText("text").toString()); // "Hello, world! Alice!"
 });
 
 Deno.test("isDeleted", () => {
-    const doc = new LoroDoc();
-    const list = doc.getList("list");
-    expect(list.isDeleted()).toBe(false);
-    const tree = doc.getTree("root");
-    const node = tree.createNode(undefined, undefined);
-    const containerBefore = node.data.setContainer("container", new LoroMap());
-    containerBefore.set("A", "B");
-    tree.delete(node.id);
-    const containerAfter = doc.getContainerById(containerBefore.id) as LoroMap;
-    expect(containerAfter.isDeleted()).toBe(true);
+  const doc = new LoroDoc();
+  const list = doc.getList("list");
+  expect(list.isDeleted()).toBe(false);
+  const tree = doc.getTree("root");
+  const node = tree.createNode(undefined, undefined);
+  const containerBefore = node.data.setContainer("container", new LoroMap());
+  containerBefore.set("A", "B");
+  tree.delete(node.id);
+  const containerAfter = doc.getContainerById(containerBefore.id) as LoroMap;
+  expect(containerAfter.isDeleted()).toBe(true);
+});
+
+Deno.test("toJsonWithReplacer", () => {
+  const doc = new LoroDoc();
+  const text = doc.getText("text");
+  text.insert(0, "Hello");
+  text.mark({ start: 0, end: 2 }, "bold", true);
+
+  // Use delta to represent text
+  // @ts-ignore： deno is not very clever
+  const json = doc.toJsonWithReplacer((key, value) => {
+    if (value instanceof LoroText) {
+      return value.toDelta();
+    }
+
+    return value;
+  });
 });

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -679,8 +679,8 @@ impl LoroDoc {
     ///
     /// - left: the id_span that you need to forward from `from` to `to`
     /// - right: the id_span that you need to forward from `to` to `from`
-    #[wasm_bindgen(js_name = "findSpansBetween")]
-    pub fn find_spans_between(
+    #[wasm_bindgen(js_name = "findIdSpansBetween")]
+    pub fn find_id_spans_between(
         &self,
         from: Vec<JsID>,
         to: Vec<JsID>,
@@ -712,7 +712,7 @@ impl LoroDoc {
 
         let from = ids_to_frontiers(from)?;
         let to = ids_to_frontiers(to)?;
-        let diff = self.0.find_spans_between(&from, &to);
+        let diff = self.0.find_id_spans_between(&from, &to);
         let obj = Object::new();
 
         js_sys::Reflect::set(&obj, &"left".into(), &id_span_vector_to_js(diff.left)).unwrap();

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1889,6 +1889,18 @@ fn diff_event_to_js_value(event: DiffEvent, doc: &Arc<LoroDocInner>) -> JsValue 
     }
 
     Reflect::set(&obj, &"events".into(), &events.into()).unwrap();
+    Reflect::set(
+        &obj,
+        &"from".into(),
+        &frontiers_to_ids(&event.event_meta.from).into(),
+    )
+    .unwrap();
+    Reflect::set(
+        &obj,
+        &"to".into(),
+        &frontiers_to_ids(&event.event_meta.to).into(),
+    )
+    .unwrap();
     obj.into()
 }
 
@@ -5512,6 +5524,8 @@ export interface LoroEventBatch {
      */
     currentTarget?: ContainerID;
     events: LoroEvent[];
+    from: Frontiers;
+    to: Frontiers;
 }
 
 /**

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -715,8 +715,8 @@ impl LoroDoc {
         let diff = self.0.find_id_spans_between(&from, &to);
         let obj = Object::new();
 
-        js_sys::Reflect::set(&obj, &"left".into(), &id_span_vector_to_js(diff.left)).unwrap();
-        js_sys::Reflect::set(&obj, &"right".into(), &id_span_vector_to_js(diff.right)).unwrap();
+        js_sys::Reflect::set(&obj, &"retreat".into(), &id_span_vector_to_js(diff.retreat)).unwrap();
+        js_sys::Reflect::set(&obj, &"forward".into(), &id_span_vector_to_js(diff.forward)).unwrap();
         let v: JsValue = obj.into();
         Ok(v.into())
     }
@@ -5156,8 +5156,18 @@ export type IdSpan = {
 }
 
 export type VersionVectorDiff = {
-    left: IdSpan[],
-    right: IdSpan[],
+    /**
+     * The spans that the `from` side needs to retreat to reach the `to` side
+     *
+     * These spans are included in the `from`, but not in the `to`
+     */
+    retreat: IdSpan[],
+    /**
+     * The spans that the `from` side needs to forward to reach the `to` side
+     *
+     * These spans are included in the `to`, but not in the `from`
+     */
+    forward: IdSpan[],
 }
 
 export type UndoConfig = {

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1039,7 +1039,7 @@ it("find spans between versions", () => {
   const f2 = doc.oplogFrontiers();
 
   // Test finding spans between frontiers (f1 -> f2)
-  let diff = doc.findSpansBetween(f1, f2);
+  let diff = doc.findIdSpansBetween(f1, f2);
   expect(diff.left).toHaveLength(0); // No changes needed to go from f2 to f1
   expect(diff.right).toHaveLength(1); // One change needed to go from f1 to f2
   expect(diff.right[0]).toEqual({
@@ -1050,7 +1050,7 @@ it("find spans between versions", () => {
 
   // Test empty frontiers
   const emptyFrontiers: OpId[] = [];
-  diff = doc.findSpansBetween(emptyFrontiers, f2);
+  diff = doc.findIdSpansBetween(emptyFrontiers, f2);
   expect(diff.left).toHaveLength(0); // No changes needed to go from f2 to empty
   expect(diff.right).toHaveLength(1); // One change needed to go from empty to f2
   expect(diff.right[0]).toEqual({
@@ -1068,7 +1068,7 @@ it("find spans between versions", () => {
   const f3 = doc.oplogFrontiers();
 
   // Test finding spans between f2 and f3
-  diff = doc.findSpansBetween(f2, f3);
+  diff = doc.findIdSpansBetween(f2, f3);
   expect(diff.left).toHaveLength(0); // No changes needed to go from f3 to f2
   expect(diff.right).toHaveLength(1); // One change needed to go from f2 to f3
   expect(diff.right[0]).toEqual({
@@ -1078,7 +1078,7 @@ it("find spans between versions", () => {
   });
 
   // Test spans in both directions between f1 and f3
-  diff = doc.findSpansBetween(f1, f3);
+  diff = doc.findIdSpansBetween(f1, f3);
   expect(diff.left).toHaveLength(0); // No changes needed to go from f3 to f1
   expect(diff.right).toHaveLength(2); // Two changes needed to go from f1 to f3
   const rightSpans = new Map(diff.right.map(span => [span.peer, span]));
@@ -1094,7 +1094,7 @@ it("find spans between versions", () => {
   });
 
   // Test spans in reverse direction (f3 -> f1)
-  diff = doc.findSpansBetween(f3, f1);
+  diff = doc.findIdSpansBetween(f3, f1);
   expect(diff.right).toHaveLength(0); // No changes needed to go from f3 to f1
   expect(diff.left).toHaveLength(2); // Two changes needed to go from f1 to f3
   const leftSpans = new Map(diff.left.map(span => [span.peer, span]));

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1120,7 +1120,7 @@ it("can travel changes from event", async () => {
   const snapshot = docA.export({ mode: "snapshot" });
   let done = false;
   docB.subscribe(e => {
-    const spans = docB.findSpansBetween(e.from, e.to);
+    const spans = docB.findIdSpansBetween(e.from, e.to);
     expect(spans.left).toHaveLength(0);
     expect(spans.right).toHaveLength(1);
     expect(spans.right[0]).toEqual({

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1110,7 +1110,7 @@ it("find spans between versions", () => {
   });
 });
 
-it("can travel changes from event", () => {
+it("can travel changes from event", async () => {
   const docA = new LoroDoc();
   docA.setPeerId("1");
   const docB = new LoroDoc();
@@ -1118,6 +1118,7 @@ it("can travel changes from event", () => {
   docA.getText("text").update("Hello");
   docA.commit();
   const snapshot = docA.export({ mode: "snapshot" });
+  let done = false;
   docB.subscribe(e => {
     const spans = docB.findSpansBetween(e.from, e.to);
     expect(spans.left).toHaveLength(0);
@@ -1144,5 +1145,9 @@ it("can travel changes from event", () => {
         }
       }]
     }]);
+    done = true;
   });
+  docB.import(snapshot);
+  await Promise.resolve();
+  expect(done).toBe(true);
 })

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1040,9 +1040,9 @@ it("find spans between versions", () => {
 
   // Test finding spans between frontiers (f1 -> f2)
   let diff = doc.findIdSpansBetween(f1, f2);
-  expect(diff.left).toHaveLength(0); // No changes needed to go from f2 to f1
-  expect(diff.right).toHaveLength(1); // One change needed to go from f1 to f2
-  expect(diff.right[0]).toEqual({
+  expect(diff.retreat).toHaveLength(0); // No changes needed to go from f2 to f1
+  expect(diff.forward).toHaveLength(1); // One change needed to go from f1 to f2
+  expect(diff.forward[0]).toEqual({
     peer: "1",
     counter: 5,
     length: 6,
@@ -1051,9 +1051,9 @@ it("find spans between versions", () => {
   // Test empty frontiers
   const emptyFrontiers: OpId[] = [];
   diff = doc.findIdSpansBetween(emptyFrontiers, f2);
-  expect(diff.left).toHaveLength(0); // No changes needed to go from f2 to empty
-  expect(diff.right).toHaveLength(1); // One change needed to go from empty to f2
-  expect(diff.right[0]).toEqual({
+  expect(diff.retreat).toHaveLength(0); // No changes needed to go from f2 to empty
+  expect(diff.forward).toHaveLength(1); // One change needed to go from empty to f2
+  expect(diff.forward[0]).toEqual({
     peer: "1",
     counter: 0,
     length: 11,
@@ -1069,9 +1069,9 @@ it("find spans between versions", () => {
 
   // Test finding spans between f2 and f3
   diff = doc.findIdSpansBetween(f2, f3);
-  expect(diff.left).toHaveLength(0); // No changes needed to go from f3 to f2
-  expect(diff.right).toHaveLength(1); // One change needed to go from f2 to f3
-  expect(diff.right[0]).toEqual({
+  expect(diff.retreat).toHaveLength(0); // No changes needed to go from f3 to f2
+  expect(diff.forward).toHaveLength(1); // One change needed to go from f2 to f3
+  expect(diff.forward[0]).toEqual({
     peer: "2",
     counter: 0,
     length: 2,
@@ -1079,15 +1079,15 @@ it("find spans between versions", () => {
 
   // Test spans in both directions between f1 and f3
   diff = doc.findIdSpansBetween(f1, f3);
-  expect(diff.left).toHaveLength(0); // No changes needed to go from f3 to f1
-  expect(diff.right).toHaveLength(2); // Two changes needed to go from f1 to f3
-  const rightSpans = new Map(diff.right.map(span => [span.peer, span]));
-  expect(rightSpans.get("1")).toEqual({
+  expect(diff.retreat).toHaveLength(0); // No changes needed to go from f3 to f1
+  expect(diff.forward).toHaveLength(2); // Two changes needed to go from f1 to f3
+  const forwardSpans = new Map(diff.forward.map(span => [span.peer, span]));
+  expect(forwardSpans.get("1")).toEqual({
     peer: "1",
     counter: 5,
     length: 6,
   });
-  expect(rightSpans.get("2")).toEqual({
+  expect(forwardSpans.get("2")).toEqual({
     peer: "2",
     counter: 0,
     length: 2,
@@ -1095,15 +1095,15 @@ it("find spans between versions", () => {
 
   // Test spans in reverse direction (f3 -> f1)
   diff = doc.findIdSpansBetween(f3, f1);
-  expect(diff.right).toHaveLength(0); // No changes needed to go from f3 to f1
-  expect(diff.left).toHaveLength(2); // Two changes needed to go from f1 to f3
-  const leftSpans = new Map(diff.left.map(span => [span.peer, span]));
-  expect(leftSpans.get("1")).toEqual({
+  expect(diff.forward).toHaveLength(0); // No changes needed to go from f3 to f1
+  expect(diff.retreat).toHaveLength(2); // Two changes needed to go from f1 to f3
+  const retreatSpans = new Map(diff.retreat.map(span => [span.peer, span]));
+  expect(retreatSpans.get("1")).toEqual({
     peer: "1",
     counter: 5,
     length: 6,
   });
-  expect(leftSpans.get("2")).toEqual({
+  expect(retreatSpans.get("2")).toEqual({
     peer: "2",
     counter: 0,
     length: 2,
@@ -1121,14 +1121,14 @@ it("can travel changes from event", async () => {
   let done = false;
   docB.subscribe(e => {
     const spans = docB.findIdSpansBetween(e.from, e.to);
-    expect(spans.left).toHaveLength(0);
-    expect(spans.right).toHaveLength(1);
-    expect(spans.right[0]).toEqual({
+    expect(spans.retreat).toHaveLength(0);
+    expect(spans.forward).toHaveLength(1);
+    expect(spans.forward[0]).toEqual({
       peer: "1",
       counter: 0,
       length: 5,
     });
-    const changes = docB.exportJsonInIdSpan(spans.right[0]);
+    const changes = docB.exportJsonInIdSpan(spans.forward[0]);
     expect(changes).toStrictEqual([{
       id: "0@1",
       timestamp: expect.any(Number),

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -937,6 +937,12 @@ impl LoroDoc {
     pub fn get_changed_containers_in(&self, id: ID, len: usize) -> FxHashSet<ContainerID> {
         self.doc.get_changed_containers_in(id, len)
     }
+
+    /// Find the operation id spans that between the `from` version and the `to` version.
+    #[inline]
+    pub fn find_spans_between(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
+        self.doc.find_spans_between(from, to)
+    }
 }
 
 /// It's used to prevent the user from implementing the trait directly.

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -940,8 +940,8 @@ impl LoroDoc {
 
     /// Find the operation id spans that between the `from` version and the `to` version.
     #[inline]
-    pub fn find_spans_between(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
-        self.doc.find_spans_between(from, to)
+    pub fn find_id_spans_between(&self, from: &Frontiers, to: &Frontiers) -> VersionVectorDiff {
+        self.doc.find_id_spans_between(from, to)
     }
 }
 

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -2671,7 +2671,7 @@ fn test_find_spans_between() -> LoroResult<()> {
     let f2 = doc.state_frontiers();
 
     // Test finding spans between frontiers (f1 -> f2)
-    let diff = doc.find_spans_between(&f1, &f2);
+    let diff = doc.find_id_spans_between(&f1, &f2);
     assert!(diff.left.is_empty()); // No changes needed to go from f2 to f1
     assert_eq!(diff.right.len(), 1); // One change needed to go from f1 to f2
     let span = diff.right.get(&1).unwrap();
@@ -2680,7 +2680,7 @@ fn test_find_spans_between() -> LoroResult<()> {
 
     // Test empty frontiers
     let empty_frontiers = Frontiers::default();
-    let diff = doc.find_spans_between(&empty_frontiers, &f2);
+    let diff = doc.find_id_spans_between(&empty_frontiers, &f2);
     assert!(diff.left.is_empty()); // No changes needed to go from f2 to empty
     assert_eq!(diff.right.len(), 1); // One change needed to go from empty to f2
     let span = diff.right.get(&1).unwrap();
@@ -2696,7 +2696,7 @@ fn test_find_spans_between() -> LoroResult<()> {
     let f3 = doc.state_frontiers();
 
     // Test finding spans between f2 and f3
-    let diff = doc.find_spans_between(&f2, &f3);
+    let diff = doc.find_id_spans_between(&f2, &f3);
     assert!(diff.left.is_empty()); // No changes needed to go from f3 to f2
     assert_eq!(diff.right.len(), 1); // One change needed to go from f2 to f3
     let span = diff.right.get(&2).unwrap();
@@ -2704,7 +2704,7 @@ fn test_find_spans_between() -> LoroResult<()> {
     assert_eq!(span.end, 2);
 
     // Test spans in both directions between f1 and f3
-    let diff = doc.find_spans_between(&f1, &f3);
+    let diff = doc.find_id_spans_between(&f1, &f3);
     assert!(diff.left.is_empty()); // No changes needed to go from f3 to f1
     assert_eq!(diff.right.len(), 2); // Two changes needed to go from f1 to f3
     for (peer, span) in diff.right.iter() {
@@ -2721,7 +2721,7 @@ fn test_find_spans_between() -> LoroResult<()> {
         }
     }
 
-    let diff = doc.find_spans_between(&f3, &f1);
+    let diff = doc.find_id_spans_between(&f3, &f1);
     assert!(diff.right.is_empty()); // No changes needed to go from f3 to f1
     assert_eq!(diff.left.len(), 2); // Two changes needed to go from f1 to f3
     for (peer, span) in diff.left.iter() {

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -2672,18 +2672,18 @@ fn test_find_spans_between() -> LoroResult<()> {
 
     // Test finding spans between frontiers (f1 -> f2)
     let diff = doc.find_id_spans_between(&f1, &f2);
-    assert!(diff.left.is_empty()); // No changes needed to go from f2 to f1
-    assert_eq!(diff.right.len(), 1); // One change needed to go from f1 to f2
-    let span = diff.right.get(&1).unwrap();
+    assert!(diff.retreat.is_empty()); // No changes needed to go from f2 to f1
+    assert_eq!(diff.forward.len(), 1); // One change needed to go from f1 to f2
+    let span = diff.forward.get(&1).unwrap();
     assert_eq!(span.start, 5); // First change ends at counter 3
     assert_eq!(span.end, 11); // Second change ends at counter 6
 
     // Test empty frontiers
     let empty_frontiers = Frontiers::default();
     let diff = doc.find_id_spans_between(&empty_frontiers, &f2);
-    assert!(diff.left.is_empty()); // No changes needed to go from f2 to empty
-    assert_eq!(diff.right.len(), 1); // One change needed to go from empty to f2
-    let span = diff.right.get(&1).unwrap();
+    assert!(diff.retreat.is_empty()); // No changes needed to go from f2 to empty
+    assert_eq!(diff.forward.len(), 1); // One change needed to go from empty to f2
+    let span = diff.forward.get(&1).unwrap();
     assert_eq!(span.start, 0); // From beginning
     assert_eq!(span.end, 11); // To latest change
 
@@ -2697,17 +2697,17 @@ fn test_find_spans_between() -> LoroResult<()> {
 
     // Test finding spans between f2 and f3
     let diff = doc.find_id_spans_between(&f2, &f3);
-    assert!(diff.left.is_empty()); // No changes needed to go from f3 to f2
-    assert_eq!(diff.right.len(), 1); // One change needed to go from f2 to f3
-    let span = diff.right.get(&2).unwrap();
+    assert!(diff.retreat.is_empty()); // No changes needed to go from f3 to f2
+    assert_eq!(diff.forward.len(), 1); // One change needed to go from f2 to f3
+    let span = diff.forward.get(&2).unwrap();
     assert_eq!(span.start, 0);
     assert_eq!(span.end, 2);
 
     // Test spans in both directions between f1 and f3
     let diff = doc.find_id_spans_between(&f1, &f3);
-    assert!(diff.left.is_empty()); // No changes needed to go from f3 to f1
-    assert_eq!(diff.right.len(), 2); // Two changes needed to go from f1 to f3
-    for (peer, span) in diff.right.iter() {
+    assert!(diff.retreat.is_empty()); // No changes needed to go from f3 to f1
+    assert_eq!(diff.forward.len(), 2); // Two changes needed to go from f1 to f3
+    for (peer, span) in diff.forward.iter() {
         match peer {
             1 => {
                 assert_eq!(span.start, 5);
@@ -2722,9 +2722,9 @@ fn test_find_spans_between() -> LoroResult<()> {
     }
 
     let diff = doc.find_id_spans_between(&f3, &f1);
-    assert!(diff.right.is_empty()); // No changes needed to go from f3 to f1
-    assert_eq!(diff.left.len(), 2); // Two changes needed to go from f1 to f3
-    for (peer, span) in diff.left.iter() {
+    assert!(diff.forward.is_empty()); // No changes needed to go from f3 to f1
+    assert_eq!(diff.retreat.len(), 2); // Two changes needed to go from f1 to f3
+    for (peer, span) in diff.retreat.iter() {
         match peer {
             1 => {
                 assert_eq!(span.start, 5);

--- a/scripts/deno.lock
+++ b/scripts/deno.lock
@@ -7,7 +7,8 @@
     "jsr:@std/toml@^1.0.1": "1.0.1",
     "npm:expect@29.7.0": "29.7.0",
     "npm:loro-crdt@1.0.7": "1.0.7",
-    "npm:loro-crdt@1.2.1": "1.2.1"
+    "npm:loro-crdt@1.2.1": "1.2.1",
+    "npm:loro-crdt@1.2.7": "1.2.7"
   },
   "jsr": {
     "@std/collections@1.0.5": {
@@ -259,6 +260,9 @@
     },
     "loro-crdt@1.2.1": {
       "integrity": "sha512-KP06MrpH2Yh2Tl7VHSCS78/ko575nVS5tEp/0NsIf4Q8XfJ0on+Zj6SVHnKpOq0iwKB7xt/mU2yVroe5jPr4SQ=="
+    },
+    "loro-crdt@1.2.7": {
+      "integrity": "sha512-eqVxUtLr7YBv5QaSW4obs01HIMzzJGfBC6MVnKHzMAEdaRitTP6Dj+BRvLFPqLEJthRtjohKez8wZgwzAUDiTg=="
     },
     "loro-wasm@1.0.7": {
       "integrity": "sha512-WFIpGGzc6I7zRMDoRGxa3AHhno7gVnOgwqcrTfmpKWOtktZQ7BvhIV4kYgsdyuIBcMSrQEJTfOY/80xQSjUKTw=="

--- a/scripts/run-js-doc-tests.ts
+++ b/scripts/run-js-doc-tests.ts
@@ -1,4 +1,4 @@
-const LORO_VERSION = "1.2.1";
+const LORO_VERSION = "1.2.7";
 
 export interface CodeBlock {
     filename: string;


### PR DESCRIPTION
Now you can now inspect all the changes that happened in an event:

```ts
const docA = new LoroDoc();
docA.setPeerId("1");
const docB = new LoroDoc();

docA.getText("text").update("Hello");
docA.commit();
const snapshot = docA.export({ mode: "snapshot" });
let done = false;
docB.subscribe(e => {
  const spans = docB.findIdSpansBetween(e.from, e.to);
  expect(spans.retreat).toHaveLength(0);
  expect(spans.forward).toHaveLength(1);
  expect(spans.forward[0]).toEqual({
    peer: "1",
    counter: 0,
    length: 5,
  });
  const changes = docB.exportJsonInIdSpan(spans.forward[0]);
  expect(changes).toStrictEqual([{
    id: "0@1",
    timestamp: expect.any(Number),
    deps: [],
    lamport: 0,
    msg: undefined,
    ops: [{
      container: "cid:root-text:Text",
      counter: 0,
      content: {
        type: "insert",
        pos: 0,
        text: "Hello"
      }
    }]
  }]);
  done = true;
});
docB.import(snapshot);
await Promise.resolve();
expect(done).toBe(true);
```