### PR TITLE
Add functions to ffi

### DIFF
--- a/crates/loro-ffi/src/doc.rs
+++ b/crates/loro-ffi/src/doc.rs
@@ -13,7 +13,7 @@ use loro::{
 };
 
 use crate::{
-    event::{DiffEvent, Subscriber},
+    event::{DiffBatch, DiffEvent, Subscriber},
     AbsolutePosition, Configure, ContainerID, ContainerIdLike, Cursor, Frontiers, Index,
     LoroCounter, LoroList, LoroMap, LoroMovableList, LoroText, LoroTree, LoroValue, StyleConfigMap,
     ValueOrContainer, VersionVector,
@@ -615,6 +615,18 @@ impl LoroDoc {
 
     pub fn get_pending_txn_len(&self) -> u32 {
         self.doc.get_pending_txn_len() as u32
+    }
+
+    pub fn revert_to(&self, version: &Frontiers) -> LoroResult<()> {
+        self.doc.revert_to(&version.into())
+    }
+
+    pub fn apply_diff(&self, diff: DiffBatch) -> LoroResult<()> {
+        self.doc.apply_diff(diff.into())
+    }
+
+    pub fn diff(&self, a: &Frontiers, b: &Frontiers) -> LoroResult<DiffBatch> {
+        self.doc.diff(&a.into(), &b.into()).map(|x| x.into())
     }
 }
 

--- a/crates/loro-ffi/src/lib.rs
+++ b/crates/loro-ffi/src/lib.rs
@@ -24,8 +24,8 @@ pub use container::{
 };
 mod event;
 pub use event::{
-    ContainerDiff, Diff, DiffEvent, Index, ListDiffItem, MapDelta, PathItem, Subscriber, TextDelta,
-    TreeDiff, TreeDiffItem, TreeExternalDiff,
+    ContainerDiff, Diff, DiffBatch, DiffEvent, Index, ListDiffItem, MapDelta, PathItem, Subscriber,
+    TextDelta, TreeDiff, TreeDiffItem, TreeExternalDiff,
 };
 mod undo;
 pub use undo::{AbsolutePosition, CursorWithPos, OnPop, OnPush, UndoItemMeta, UndoManager};

--- a/crates/loro-ffi/src/value.rs
+++ b/crates/loro-ffi/src/value.rs
@@ -6,7 +6,7 @@ pub trait LoroValueLike: Sync + Send {
     fn as_loro_value(&self) -> crate::LoroValue;
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum ContainerType {
     Text,
     Map,
@@ -17,7 +17,7 @@ pub enum ContainerType {
     Unknown { kind: u8 },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum ContainerID {
     Root {
         name: String,

--- a/crates/loro/src/event.rs
+++ b/crates/loro/src/event.rs
@@ -249,8 +249,8 @@ impl From<ValueOrHandler> for ValueOrContainer {
 /// A batch of diffs.
 #[derive(Default, Clone)]
 pub struct DiffBatch {
-    cid_to_events: FxHashMap<ContainerID, Diff<'static>>,
-    order: Vec<ContainerID>,
+    pub cid_to_events: FxHashMap<ContainerID, Diff<'static>>,
+    pub order: Vec<ContainerID>,
 }
 
 impl std::fmt::Debug for DiffBatch {


### PR DESCRIPTION
Initial attempt at adding support for https://github.com/loro-dev/loro/pull/610 within the ffi

I got stuck on:

```
^^^^ the trait `From<&event::Diff>` is not implemented for `loro::event::Diff<'_>`, which is required by `&event::Diff: Into<_>`
```

which then cascades into needing a bunch of conversion functions