### PR TITLE
refactor:  hold doc reference in handler

### DIFF
--- a/crates/fuzz/src/actor.rs
+++ b/crates/fuzz/src/actor.rs
@@ -140,14 +140,14 @@ impl Actor {
         // trace!("BeforeUndo {:#?}", self.loro.get_deep_value_with_id());
         // println!("\n\nstart undo\n");
         for _ in 0..undo_length {
-            self.undo_manager.undo.undo(&self.loro).unwrap();
+            self.undo_manager.undo.undo().unwrap();
             self.loro.commit();
         }
         // trace!("AfterUndo {:#?}", self.loro.get_deep_value_with_id());
 
         // println!("\n\nstart redo\n");
         for _ in 0..undo_length {
-            self.undo_manager.undo.redo(&self.loro).unwrap();
+            self.undo_manager.undo.redo().unwrap();
             self.loro.commit();
         }
         // trace!("AfterRedo {:#?}", self.loro.get_deep_value_with_id());

--- a/crates/loro-ffi/src/undo.rs
+++ b/crates/loro-ffi/src/undo.rs
@@ -13,18 +13,18 @@ impl UndoManager {
     }
 
     /// Undo the last change made by the peer.
-    pub fn undo(&self, doc: &LoroDoc) -> LoroResult<bool> {
-        self.0.write().unwrap().undo(doc)
+    pub fn undo(&self) -> LoroResult<bool> {
+        self.0.write().unwrap().undo()
     }
 
     /// Redo the last change made by the peer.
-    pub fn redo(&self, doc: &LoroDoc) -> LoroResult<bool> {
-        self.0.write().unwrap().redo(doc)
+    pub fn redo(&self) -> LoroResult<bool> {
+        self.0.write().unwrap().redo()
     }
 
     /// Record a new checkpoint.
-    pub fn record_new_checkpoint(&self, doc: &LoroDoc) -> LoroResult<()> {
-        self.0.write().unwrap().record_new_checkpoint(doc)
+    pub fn record_new_checkpoint(&self) -> LoroResult<()> {
+        self.0.write().unwrap().record_new_checkpoint()
     }
 
     /// Whether the undo manager can undo.

--- a/crates/loro-internal/src/delta/map_delta.rs
+++ b/crates/loro-internal/src/delta/map_delta.rs
@@ -66,18 +66,11 @@ pub struct ResolvedMapValue {
 }
 
 impl ResolvedMapValue {
-    pub(crate) fn from_map_value(
-        v: MapValue,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        doc: &Weak<LoroDocInner>,
-    ) -> Self {
+    pub(crate) fn from_map_value(v: MapValue, doc: &Weak<LoroDocInner>) -> Self {
         let doc = &doc.upgrade().unwrap();
         ResolvedMapValue {
             idlp: IdLp::new(v.peer, v.lamp),
-            value: v
-                .value
-                .map(|v| ValueOrHandler::from_value(v, arena, txn, doc)),
+            value: v.value.map(|v| ValueOrHandler::from_value(v, doc)),
         }
     }
 

--- a/crates/loro-internal/src/delta/map_delta.rs
+++ b/crates/loro-internal/src/delta/map_delta.rs
@@ -9,7 +9,7 @@ use serde::{ser::SerializeStruct, Serialize};
 
 use crate::{
     arena::SharedArena, change::Lamport, handler::ValueOrHandler, id::PeerID, span::HasLamport,
-    txn::Transaction, DocState, InternalString, LoroValue,
+    txn::Transaction, DocState, InternalString, LoroDocInner, LoroValue,
 };
 
 #[derive(Default, Debug, Clone, Serialize)]
@@ -70,13 +70,14 @@ impl ResolvedMapValue {
         v: MapValue,
         arena: &SharedArena,
         txn: &Weak<Mutex<Option<Transaction>>>,
-        state: &Weak<Mutex<DocState>>,
+        doc: &Weak<LoroDocInner>,
     ) -> Self {
+        let doc = &doc.upgrade().unwrap();
         ResolvedMapValue {
             idlp: IdLp::new(v.peer, v.lamp),
             value: v
                 .value
-                .map(|v| ValueOrHandler::from_value(v, arena, txn, state)),
+                .map(|v| ValueOrHandler::from_value(v, arena, txn, doc)),
         }
     }
 

--- a/crates/loro-internal/src/delta/map_delta.rs
+++ b/crates/loro-internal/src/delta/map_delta.rs
@@ -9,7 +9,7 @@ use serde::{ser::SerializeStruct, Serialize};
 
 use crate::{
     arena::SharedArena, change::Lamport, handler::ValueOrHandler, id::PeerID, span::HasLamport,
-    txn::Transaction, DocState, InternalString, LoroDocInner, LoroValue,
+    txn::Transaction, InternalString, LoroDocInner, LoroValue,
 };
 
 #[derive(Default, Debug, Clone, Serialize)]

--- a/crates/loro-internal/src/delta/map_delta.rs
+++ b/crates/loro-internal/src/delta/map_delta.rs
@@ -1,6 +1,6 @@
 use std::{
     hash::Hash,
-    sync::{Mutex, Weak},
+    sync::Weak,
 };
 
 use fxhash::FxHashMap;
@@ -8,8 +8,7 @@ use loro_common::IdLp;
 use serde::{ser::SerializeStruct, Serialize};
 
 use crate::{
-    arena::SharedArena, change::Lamport, handler::ValueOrHandler, id::PeerID, span::HasLamport,
-    txn::Transaction, InternalString, LoroDocInner, LoroValue,
+    change::Lamport, handler::ValueOrHandler, id::PeerID, span::HasLamport, InternalString, LoroDocInner, LoroValue,
 };
 
 #[derive(Default, Debug, Clone, Serialize)]

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1,6 +1,5 @@
 use super::{state::DocState, txn::Transaction};
 use crate::{
-    arena::SharedArena,
     container::{
         idx::ContainerIdx,
         list::list_op::{DeleteSpan, DeleteSpanWithId, ListOp},
@@ -31,7 +30,7 @@ use std::{
     collections::BinaryHeap,
     fmt::Debug,
     ops::Deref,
-    sync::{Arc, Mutex, Weak},
+    sync::{Arc, Mutex},
 };
 use tracing::{error, info, instrument};
 

--- a/crates/loro-internal/src/handler/tree.rs
+++ b/crates/loro-internal/src/handler/tree.rs
@@ -257,6 +257,13 @@ impl HandlerTrait for TreeHandler {
             _ => None,
         }
     }
+
+    fn doc(&self) -> Option<crate::LoroDoc> {
+        match &self.inner {
+            MaybeDetached::Detached(_) => None,
+            MaybeDetached::Attached(a) => Some(a.doc()),
+        }
+    }
 }
 
 impl std::fmt::Debug for TreeHandler {

--- a/crates/loro-internal/src/handler/tree.rs
+++ b/crates/loro-internal/src/handler/tree.rs
@@ -309,7 +309,7 @@ impl TreeHandler {
                     old_index: index
                 },
             }]),
-            &inner.state,
+            &inner.doc,
         )
     }
 
@@ -414,7 +414,7 @@ impl TreeHandler {
                         position: position.clone(),
                     },
                 }]),
-                &inner.state,
+                &inner.doc,
             )?;
 
             Ok(self
@@ -492,7 +492,7 @@ impl TreeHandler {
                         old_index: self.get_index_by_tree_id(&target).unwrap(),
                     },
                 }]),
-                &inner.state,
+                &inner.doc,
             )
         })?;
         Ok(true)
@@ -667,7 +667,7 @@ impl TreeHandler {
                     position,
                 },
             }]),
-            &inner.state,
+            &inner.doc,
         )?;
         Ok(tree_id)
     }
@@ -700,7 +700,7 @@ impl TreeHandler {
                     old_index,
                 },
             }]),
-            &inner.state,
+            &inner.doc,
         )
     }
 

--- a/crates/loro-internal/src/jsonpath.rs
+++ b/crates/loro-internal/src/jsonpath.rs
@@ -5,7 +5,8 @@ use tracing::trace;
 use crate::handler::{
     Handler, ListHandler, MapHandler, MovableListHandler, TextHandler, TreeHandler, ValueOrHandler,
 };
-use crate::loro::LoroDoc;
+
+use crate::LoroDoc;
 use std::ops::ControlFlow;
 
 #[derive(Error, Debug)]
@@ -708,7 +709,6 @@ impl PathValue for LoroValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::loro::LoroDoc;
 
     #[test]
     fn test_parse_jsonpath() -> Result<(), JsonPathError> {

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -122,7 +122,7 @@ impl LoroDoc {
 }
 
 impl std::ops::Deref for LoroDoc {
-    type Target = Arc<LoroDocInner>;
+    type Target = LoroDocInner;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -110,7 +110,20 @@ pub use version::VersionVector;
 /// `LoroApp::detach()` separates [AppState] from [OpLog]. In this mode,
 /// updates to [OpLog] won't affect [AppState], while updates to [AppState]
 /// will continue to affect [OpLog].
+#[derive(Debug)]
 pub struct LoroDoc {
+    inner: Arc<LoroDocInner>,
+}
+
+impl std::ops::Deref for LoroDoc {
+    type Target = LoroDocInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+pub struct LoroDocInner {
     oplog: Arc<Mutex<OpLog>>,
     state: Arc<Mutex<DocState>>,
     arena: SharedArena,

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -110,13 +110,19 @@ pub use version::VersionVector;
 /// `LoroApp::detach()` separates [AppState] from [OpLog]. In this mode,
 /// updates to [OpLog] won't affect [AppState], while updates to [AppState]
 /// will continue to affect [OpLog].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoroDoc {
     inner: Arc<LoroDocInner>,
 }
 
+impl LoroDoc {
+    pub(crate) fn from_inner(inner: Arc<LoroDocInner>) -> Self {
+        Self { inner }
+    }
+}
+
 impl std::ops::Deref for LoroDoc {
-    type Target = LoroDocInner;
+    type Target = Arc<LoroDocInner>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -80,12 +80,7 @@ impl LoroDoc {
         let config: Configure = oplog.configure.clone();
         let global_txn = Arc::new(Mutex::new(None));
         let inner = Arc::new_cyclic(|w| {
-            let state = DocState::new_arc(
-                arena.clone(),
-                Arc::downgrade(&global_txn),
-                w.clone(),
-                config.clone(),
-            );
+            let state = DocState::new_arc(w.clone(), config.clone());
             LoroDocInner {
                 oplog: Arc::new(Mutex::new(oplog)),
                 state,
@@ -377,11 +372,6 @@ impl LoroDoc {
     pub fn state_timestamp(&self) -> Timestamp {
         let f = &self.state.try_lock().unwrap().frontiers;
         self.oplog.try_lock().unwrap().get_timestamp_of_version(f)
-    }
-
-    #[inline]
-    pub(crate) fn get_global_txn(&self) -> Weak<Mutex<Option<Transaction>>> {
-        Arc::downgrade(&self.txn)
     }
 
     #[inline(always)]

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -79,7 +79,7 @@ impl LoroDoc {
         let config: Configure = oplog.configure.clone();
         let global_txn = Arc::new(Mutex::new(None));
         let inner = Arc::new_cyclic(|w| {
-            let state = DocState::new_arc(w.clone(), config.clone());
+            let state = DocState::new_arc(w.clone(), arena.clone(), config.clone());
             LoroDocInner {
                 oplog: Arc::new(Mutex::new(oplog)),
                 state,

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -624,8 +624,6 @@ impl LoroDoc {
         if let LoroValue::Container(c) = value {
             Some(ValueOrHandler::Handler(Handler::new_attached(
                 c.clone(),
-                self.arena.clone(),
-                self.get_global_txn(),
                 self.inner.clone(),
             )))
         } else {
@@ -642,12 +640,7 @@ impl LoroDoc {
     #[inline]
     pub fn get_handler(&self, id: ContainerID) -> Handler {
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
+        Handler::new_attached(id, self.inner.clone())
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
@@ -656,14 +649,9 @@ impl LoroDoc {
     pub fn get_text<I: IntoContainerId>(&self, id: I) -> TextHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Text);
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
-        .into_text()
-        .unwrap()
+        Handler::new_attached(id, self.inner.clone())
+            .into_text()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
@@ -672,14 +660,9 @@ impl LoroDoc {
     pub fn get_list<I: IntoContainerId>(&self, id: I) -> ListHandler {
         let id = id.into_container_id(&self.arena, ContainerType::List);
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
-        .into_list()
-        .unwrap()
+        Handler::new_attached(id, self.inner.clone())
+            .into_list()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
@@ -688,14 +671,9 @@ impl LoroDoc {
     pub fn get_movable_list<I: IntoContainerId>(&self, id: I) -> MovableListHandler {
         let id = id.into_container_id(&self.arena, ContainerType::MovableList);
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
-        .into_movable_list()
-        .unwrap()
+        Handler::new_attached(id, self.inner.clone())
+            .into_movable_list()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
@@ -704,14 +682,9 @@ impl LoroDoc {
     pub fn get_map<I: IntoContainerId>(&self, id: I) -> MapHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Map);
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
-        .into_map()
-        .unwrap()
+        Handler::new_attached(id, self.inner.clone())
+            .into_map()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
@@ -720,14 +693,9 @@ impl LoroDoc {
     pub fn get_tree<I: IntoContainerId>(&self, id: I) -> TreeHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Tree);
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
-        .into_tree()
-        .unwrap()
+        Handler::new_attached(id, self.inner.clone())
+            .into_tree()
+            .unwrap()
     }
 
     #[cfg(feature = "counter")]
@@ -737,14 +705,9 @@ impl LoroDoc {
     ) -> crate::handler::counter::CounterHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Counter);
         self.assert_container_exists(&id);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.get_global_txn(),
-            self.inner.clone(),
-        )
-        .into_counter()
-        .unwrap()
+        Handler::new_attached(id, self.inner.clone())
+            .into_counter()
+            .unwrap()
     }
 
     fn assert_container_exists(&self, id: &ContainerID) {

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -15,7 +15,7 @@ use std::{
             AtomicBool,
             Ordering::{Acquire, Release},
         },
-        Arc, Mutex, Weak,
+        Arc, Mutex,
     },
 };
 use tracing::{debug_span, info, info_span, instrument, warn};
@@ -45,7 +45,6 @@ use crate::{
     oplog::{loro_dag::FrontiersNotIncluded, OpLog},
     state::DocState,
     subscription::{LocalUpdateCallback, Observer, Subscriber},
-    txn::Transaction,
     undo::DiffBatch,
     utils::subscription::{SubscriberSetWithQueue, Subscription},
     version::{shrink_frontiers, Frontiers, ImVersionVector, VersionRange, VersionVectorDiff},

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -399,21 +399,19 @@ impl DocState {
     ) -> Arc<Mutex<Self>> {
         let peer = Arc::new(AtomicU64::new(DefaultRandom.next_u64()));
         let store = self.store.fork(arena.clone(), peer.clone(), config.clone());
-        Arc::new_cyclic(move |weak| {
-            Mutex::new(Self {
-                peer,
-                frontiers: self.frontiers.clone(),
-                store,
-                arena,
-                config,
-                doc,
-                global_txn,
-                in_txn: false,
-                changed_idx_in_txn: FxHashSet::default(),
-                event_recorder: Default::default(),
-                dead_containers_cache: Default::default(),
-            })
-        })
+        Arc::new(Mutex::new(Self {
+            peer,
+            frontiers: self.frontiers.clone(),
+            store,
+            arena,
+            config,
+            doc,
+            global_txn,
+            in_txn: false,
+            changed_idx_in_txn: FxHashSet::default(),
+            event_recorder: Default::default(),
+            dead_containers_cache: Default::default(),
+        }))
     }
 
     pub fn start_recording(&mut self) {

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -29,7 +29,6 @@ use crate::{
     handler::ValueOrHandler,
     id::PeerID,
     op::{Op, RawOp},
-    txn::Transaction,
     version::Frontiers,
     ContainerDiff, ContainerType, DocDiff, InternalString, LoroDocInner, LoroValue, OpLog,
 };

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -351,9 +351,12 @@ impl State {
 
 impl DocState {
     #[inline]
-    pub fn new_arc(doc: Weak<LoroDocInner>, config: Configure) -> Arc<Mutex<Self>> {
+    pub fn new_arc(
+        doc: Weak<LoroDocInner>,
+        arena: SharedArena,
+        config: Configure,
+    ) -> Arc<Mutex<Self>> {
         let peer = DefaultRandom.next_u64();
-        let arena = doc.upgrade().unwrap().arena.clone();
         // TODO: maybe we should switch to certain version in oplog?
 
         let peer = Arc::new(AtomicU64::new(peer));
@@ -374,9 +377,9 @@ impl DocState {
     pub fn fork_with_new_peer_id(
         &mut self,
         doc: Weak<LoroDocInner>,
+        arena: SharedArena,
         config: Configure,
     ) -> Arc<Mutex<Self>> {
-        let arena = doc.upgrade().unwrap().arena.clone();
         let peer = Arc::new(AtomicU64::new(DefaultRandom.next_u64()));
         let store = self.store.fork(arena.clone(), peer.clone(), config.clone());
         Arc::new(Mutex::new(Self {

--- a/crates/loro-internal/src/state/counter_state.rs
+++ b/crates/loro-internal/src/state/counter_state.rs
@@ -10,7 +10,7 @@ use crate::{
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp, RawOpContent},
     txn::Transaction,
-    DocState,
+    DocState, LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -68,7 +68,7 @@ impl ContainerState for CounterState {
         &mut self,
         _arena: &SharedArena,
         _txn: &Weak<Mutex<Option<Transaction>>>,
-        _state: &Weak<Mutex<DocState>>,
+        _doc: &Weak<LoroDocInner>,
     ) -> Diff {
         Diff::Counter(self.value)
     }

--- a/crates/loro-internal/src/state/counter_state.rs
+++ b/crates/loro-internal/src/state/counter_state.rs
@@ -9,7 +9,8 @@ use crate::{
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp, RawOpContent},
-    txn::Transaction, LoroDocInner,
+    txn::Transaction,
+    LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -63,12 +64,7 @@ impl ContainerState for CounterState {
     }
 
     #[doc = " Convert a state to a diff, such that an empty state will be transformed into the same as this state when it\'s applied."]
-    fn to_diff(
-        &mut self,
-        _arena: &SharedArena,
-        _txn: &Weak<Mutex<Option<Transaction>>>,
-        _doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, _doc: &Weak<LoroDocInner>) -> Diff {
         Diff::Counter(self.value)
     }
 

--- a/crates/loro-internal/src/state/counter_state.rs
+++ b/crates/loro-internal/src/state/counter_state.rs
@@ -1,15 +1,13 @@
-use std::sync::{Mutex, Weak};
+use std::sync::Weak;
 
 use loro_common::{ContainerID, LoroError, LoroResult, LoroValue};
 
 use crate::{
-    arena::SharedArena,
     configure::Configure,
     container::idx::ContainerIdx,
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp, RawOpContent},
-    txn::Transaction,
     LoroDocInner,
 };
 

--- a/crates/loro-internal/src/state/counter_state.rs
+++ b/crates/loro-internal/src/state/counter_state.rs
@@ -9,8 +9,7 @@ use crate::{
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp, RawOpContent},
-    txn::Transaction,
-    DocState, LoroDocInner,
+    txn::Transaction, LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -1,19 +1,17 @@
 use std::{
     io::Write,
     ops::RangeBounds,
-    sync::{Mutex, Weak},
+    sync::Weak,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext, FastStateSnapshot};
 use crate::{
-    arena::SharedArena,
     configure::Configure,
     container::{idx::ContainerIdx, list::list_op::ListOp, ContainerID},
     encoding::{EncodeMode, StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff, ListDiff},
     handler::ValueOrHandler,
     op::{ListSlice, Op, RawOp, RawOpContent},
-    txn::Transaction,
     LoroDocInner, LoroValue,
 };
 
@@ -378,7 +376,7 @@ impl ContainerState for ListState {
         &mut self,
         diff: InternalDiff,
         DiffApplyContext {
-            arena, txn, doc, ..
+            arena,  doc, ..
         }: DiffApplyContext,
     ) -> Diff {
         let InternalDiff::ListRaw(delta) = diff else {

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -13,7 +13,8 @@ use crate::{
     event::{Diff, Index, InternalDiff, ListDiff},
     handler::ValueOrHandler,
     op::{ListSlice, Op, RawOp, RawOpContent},
-    txn::Transaction, LoroDocInner, LoroValue,
+    txn::Transaction,
+    LoroDocInner, LoroValue,
 };
 
 use fxhash::FxHashMap;
@@ -405,7 +406,7 @@ impl ContainerState for ListState {
                     }
                     for arr in ArrayVec::from_many(
                         arr.iter()
-                            .map(|v| ValueOrHandler::from_value(v.clone(), arena, txn, doc)),
+                            .map(|v| ValueOrHandler::from_value(v.clone(), doc)),
                     ) {
                         ans.push_insert(arr, Default::default());
                     }
@@ -492,17 +493,12 @@ impl ContainerState for ListState {
 
     #[doc = " Convert a state to a diff that when apply this diff on a empty state,"]
     #[doc = " the state will be the same as this state."]
-    fn to_diff(
-        &mut self,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, doc: &Weak<LoroDocInner>) -> Diff {
         let doc = &doc.upgrade().unwrap();
         Diff::List(ListDiff::from_many(
             self.to_vec()
                 .into_iter()
-                .map(|v| ValueOrHandler::from_value(v, arena, txn, doc)),
+                .map(|v| ValueOrHandler::from_value(v, doc)),
         ))
     }
 

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -1,8 +1,4 @@
-use std::{
-    io::Write,
-    ops::RangeBounds,
-    sync::Weak,
-};
+use std::{io::Write, ops::RangeBounds, sync::Weak};
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext, FastStateSnapshot};
 use crate::{
@@ -375,9 +371,7 @@ impl ContainerState for ListState {
     fn apply_diff_and_convert(
         &mut self,
         diff: InternalDiff,
-        DiffApplyContext {
-            arena,  doc, ..
-        }: DiffApplyContext,
+        DiffApplyContext { doc, .. }: DiffApplyContext,
     ) -> Diff {
         let InternalDiff::ListRaw(delta) = diff else {
             unreachable!()
@@ -396,7 +390,7 @@ impl ContainerState for ListState {
                     match &value.values {
                         either::Either::Left(range) => {
                             for i in range.to_range() {
-                                let value = arena.get_value(i).unwrap();
+                                let value = doc.arena.get_value(i).unwrap();
                                 arr.push(value);
                             }
                         }
@@ -422,7 +416,8 @@ impl ContainerState for ListState {
         Diff::List(ans)
     }
 
-    fn apply_diff(&mut self, diff: InternalDiff, DiffApplyContext { arena, .. }: DiffApplyContext) {
+    fn apply_diff(&mut self, diff: InternalDiff, DiffApplyContext { doc, .. }: DiffApplyContext) {
+        let doc = &doc.upgrade().unwrap();
         match diff {
             InternalDiff::ListRaw(delta) => {
                 let mut index = 0;
@@ -436,7 +431,7 @@ impl ContainerState for ListState {
                             match &value.values {
                                 either::Either::Left(range) => {
                                     for i in range.to_range() {
-                                        let value = arena.get_value(i).unwrap();
+                                        let value = doc.arena.get_value(i).unwrap();
                                         arr.push(value);
                                     }
                                 }

--- a/crates/loro-internal/src/state/list_state.rs
+++ b/crates/loro-internal/src/state/list_state.rs
@@ -13,8 +13,7 @@ use crate::{
     event::{Diff, Index, InternalDiff, ListDiff},
     handler::ValueOrHandler,
     op::{ListSlice, Op, RawOp, RawOpContent},
-    txn::Transaction,
-    DocState, LoroDocInner, LoroValue,
+    txn::Transaction, LoroDocInner, LoroValue,
 };
 
 use fxhash::FxHashMap;

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -18,8 +18,7 @@ use crate::{
     event::{Diff, Index, InternalDiff},
     handler::ValueOrHandler,
     op::{Op, RawOp, RawOpContent},
-    txn::Transaction,
-    DocState, InternalString, LoroDocInner, LoroValue,
+    txn::Transaction, InternalString, LoroDocInner, LoroValue,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    mem,
-    sync::Weak,
-};
+use std::{collections::BTreeMap, mem, sync::Weak};
 
 use fxhash::FxHashMap;
 use loro_common::{ContainerID, IdLp, LoroResult, PeerID};
@@ -46,12 +42,7 @@ impl ContainerState for MapState {
     fn apply_diff_and_convert(
         &mut self,
         diff: InternalDiff,
-        DiffApplyContext {
-            arena,
-            txn,
-            doc,
-            mode,
-        }: DiffApplyContext,
+        DiffApplyContext { doc, mode }: DiffApplyContext,
     ) -> Diff {
         let InternalDiff::Map(delta) = diff else {
             unreachable!()

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -18,7 +18,8 @@ use crate::{
     event::{Diff, Index, InternalDiff},
     handler::ValueOrHandler,
     op::{Op, RawOp, RawOpContent},
-    txn::Transaction, InternalString, LoroDocInner, LoroValue,
+    txn::Transaction,
+    InternalString, LoroDocInner, LoroValue,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -88,9 +89,7 @@ impl ContainerState for MapState {
                     key,
                     ResolvedMapValue {
                         idlp: IdLp::new(value.peer, value.lamp),
-                        value: value
-                            .value
-                            .map(|v| ValueOrHandler::from_value(v, arena, txn, doc)),
+                        value: value.value.map(|v| ValueOrHandler::from_value(v, doc)),
                     },
                 )
             }
@@ -132,18 +131,13 @@ impl ContainerState for MapState {
 
     #[doc = " Convert a state to a diff that when apply this diff on a empty state,"]
     #[doc = " the state will be the same as this state."]
-    fn to_diff(
-        &mut self,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, doc: &Weak<LoroDocInner>) -> Diff {
         Diff::Map(ResolvedMapDelta {
             updated: self
                 .map
                 .clone()
                 .into_iter()
-                .map(|(k, v)| (k, ResolvedMapValue::from_map_value(v, arena, txn, doc)))
+                .map(|(k, v)| (k, ResolvedMapValue::from_map_value(v, doc)))
                 .collect::<FxHashMap<_, _>>(),
         })
     }

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeMap,
     mem,
-    sync::{Mutex, Weak},
+    sync::Weak,
 };
 
 use fxhash::FxHashMap;
@@ -9,7 +9,6 @@ use loro_common::{ContainerID, IdLp, LoroResult, PeerID};
 use rle::HasLength;
 
 use crate::{
-    arena::SharedArena,
     configure::Configure,
     container::{idx::ContainerIdx, map::MapSet},
     delta::{MapValue, ResolvedMapDelta, ResolvedMapValue},
@@ -18,7 +17,6 @@ use crate::{
     event::{Diff, Index, InternalDiff},
     handler::ValueOrHandler,
     op::{Op, RawOp, RawOpContent},
-    txn::Transaction,
     InternalString, LoroDocInner, LoroValue,
 };
 

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use loro_delta::{array_vec::ArrayVec, DeltaRope, DeltaRopeBuilder};
 use serde_columnar::columnar;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Mutex, Weak};
 use tracing::{instrument, warn};
 
 use fxhash::FxHashMap;
@@ -19,8 +19,7 @@ use crate::{
     handler::ValueOrHandler,
     op::{ListSlice, Op, RawOp},
     state::movable_list_state::inner::PushElemInfo,
-    txn::Transaction,
-    DocState, ListDiff, LoroDocInner,
+    txn::Transaction, ListDiff, LoroDocInner,
 };
 
 use self::{

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -19,7 +19,8 @@ use crate::{
     handler::ValueOrHandler,
     op::{ListSlice, Op, RawOp},
     state::movable_list_state::inner::PushElemInfo,
-    txn::Transaction, ListDiff, LoroDocInner,
+    txn::Transaction,
+    ListDiff, LoroDocInner,
 };
 
 use self::{
@@ -1160,7 +1161,7 @@ impl ContainerState for MovableListState {
                                         .delete(1)
                                         .insert(
                                             ArrayVec::from([ValueOrHandler::from_value(
-                                                value, arena, txn, doc,
+                                                value, doc,
                                             )]),
                                             ListDeltaMeta { from_move: false },
                                         )
@@ -1191,7 +1192,7 @@ impl ContainerState for MovableListState {
                                     .retain(new_index, Default::default())
                                     .insert(
                                         ArrayVec::from([ValueOrHandler::from_value(
-                                            new_value, arena, txn, doc,
+                                            new_value, doc,
                                         )]),
                                         ListDeltaMeta {
                                             from_move: (result.delete.is_some() && !value_updated)
@@ -1238,9 +1239,7 @@ impl ContainerState for MovableListState {
                                 &DeltaRopeBuilder::new()
                                     .retain(index, Default::default())
                                     .insert(
-                                        ArrayVec::from([ValueOrHandler::from_value(
-                                            value, arena, txn, doc,
-                                        )]),
+                                        ArrayVec::from([ValueOrHandler::from_value(value, doc)]),
                                         ListDeltaMeta {
                                             from_move: (result.delete.is_some() && !value_updated)
                                                 || from_delete,
@@ -1350,19 +1349,14 @@ impl ContainerState for MovableListState {
         Ok(ans)
     }
 
-    fn to_diff(
-        &mut self,
-        arena: &SharedArena,
-        txn: &Weak<Mutex<Option<Transaction>>>,
-        doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, doc: &Weak<LoroDocInner>) -> Diff {
         let doc = &doc.upgrade().unwrap();
         Diff::List(
             DeltaRopeBuilder::new()
                 .insert_many(
                     self.to_vec()
                         .into_iter()
-                        .map(|v| ValueOrHandler::from_value(v, arena, txn, doc)),
+                        .map(|v| ValueOrHandler::from_value(v, doc)),
                     Default::default(),
                 )
                 .build(),

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use loro_delta::{array_vec::ArrayVec, DeltaRope, DeltaRopeBuilder};
 use serde_columnar::columnar;
-use std::sync::{Mutex, Weak};
+use std::sync::Weak;
 use tracing::{instrument, warn};
 
 use fxhash::FxHashMap;
@@ -9,7 +9,6 @@ use generic_btree::BTree;
 use loro_common::{CompactIdLp, ContainerID, IdFull, IdLp, LoroResult, LoroValue, PeerID, ID};
 
 use crate::{
-    arena::SharedArena,
     configure::Configure,
     container::{idx::ContainerIdx, list::list_op::ListOp},
     delta::DeltaItem,
@@ -19,7 +18,6 @@ use crate::{
     handler::ValueOrHandler,
     op::{ListSlice, Op, RawOp},
     state::movable_list_state::inner::PushElemInfo,
-    txn::Transaction,
     ListDiff, LoroDocInner,
 };
 

--- a/crates/loro-internal/src/state/movable_list_state.rs
+++ b/crates/loro-internal/src/state/movable_list_state.rs
@@ -1023,12 +1023,7 @@ impl ContainerState for MovableListState {
     fn apply_diff_and_convert(
         &mut self,
         diff: InternalDiff,
-        DiffApplyContext {
-            arena,
-            txn,
-            doc,
-            mode,
-        }: DiffApplyContext,
+        DiffApplyContext { doc, mode }: DiffApplyContext,
     ) -> Diff {
         let InternalDiff::MovableList(mut diff) = diff else {
             unreachable!()

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -27,7 +27,8 @@ use crate::{
     handler::TextDelta,
     op::{Op, RawOp},
     txn::Transaction,
-    utils::{lazy::LazyLoad, string_slice::StringSlice}, LoroDocInner,
+    utils::{lazy::LazyLoad, string_slice::StringSlice},
+    LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -644,12 +645,7 @@ impl ContainerState for RichtextState {
         Ok(Default::default())
     }
 
-    fn to_diff(
-        &mut self,
-        _arena: &SharedArena,
-        _txn: &Weak<Mutex<Option<Transaction>>>,
-        _doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, _doc: &Weak<LoroDocInner>) -> Diff {
         let mut delta = TextDiff::new();
         for span in self.state.get_mut().iter() {
             delta.push_insert(

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -28,7 +28,7 @@ use crate::{
     op::{Op, RawOp},
     txn::Transaction,
     utils::{lazy::LazyLoad, string_slice::StringSlice},
-    DocState,
+    DocState, LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -649,7 +649,7 @@ impl ContainerState for RichtextState {
         &mut self,
         _arena: &SharedArena,
         _txn: &Weak<Mutex<Option<Transaction>>>,
-        _state: &Weak<Mutex<DocState>>,
+        _doc: &Weak<LoroDocInner>,
     ) -> Diff {
         let mut delta = TextDiff::new();
         for span in self.state.get_mut().iter() {

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -27,8 +27,7 @@ use crate::{
     handler::TextDelta,
     op::{Op, RawOp},
     txn::Transaction,
-    utils::{lazy::LazyLoad, string_slice::StringSlice},
-    DocState, LoroDocInner,
+    utils::{lazy::LazyLoad, string_slice::StringSlice}, LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -1,6 +1,6 @@
 use std::{
     ops::Range,
-    sync::{Arc, Mutex, RwLock, Weak},
+    sync::{Arc, RwLock, Weak},
 };
 
 use fxhash::{FxHashMap, FxHashSet};
@@ -9,7 +9,6 @@ use loro_common::{ContainerID, InternalString, LoroError, LoroResult, LoroValue,
 use loro_delta::DeltaRopeBuilder;
 
 use crate::{
-    arena::SharedArena,
     container::{
         idx::ContainerIdx,
         list::list_op,
@@ -26,7 +25,6 @@ use crate::{
     event::{Diff, Index, InternalDiff, TextDiff},
     handler::TextDelta,
     op::{Op, RawOp},
-    txn::Transaction,
     utils::{lazy::LazyLoad, string_slice::StringSlice},
     LoroDocInner,
 };

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -1321,12 +1321,7 @@ impl ContainerState for TreeState {
         Ok(ApplyLocalOpReturn { deleted_containers })
     }
 
-    fn to_diff(
-        &mut self,
-        _arena: &SharedArena,
-        _txn: &Weak<Mutex<Option<Transaction>>>,
-        _doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, _doc: &Weak<LoroDocInner>) -> Diff {
         let mut diffs = vec![];
         let Some(roots) = self.children.get(&TreeParentId::Root) else {
             return Diff::Tree(TreeDiff { diff: vec![] });

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
-use std::sync::{Mutex, Weak};
+use std::sync::Weak;
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
 use crate::configure::Configure;
@@ -23,9 +23,7 @@ use crate::diff_calc::DiffMode;
 use crate::encoding::{EncodeMode, StateSnapshotDecodeContext, StateSnapshotEncoder};
 use crate::event::InternalDiff;
 use crate::op::Op;
-use crate::txn::Transaction;
 use crate::{
-    arena::SharedArena,
     container::tree::tree_op::TreeOp,
     delta::TreeInternalDiff,
     event::{Diff, Index},

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -24,7 +24,6 @@ use crate::encoding::{EncodeMode, StateSnapshotDecodeContext, StateSnapshotEncod
 use crate::event::InternalDiff;
 use crate::op::Op;
 use crate::txn::Transaction;
-use crate::DocState;
 use crate::{
     arena::SharedArena,
     container::tree::tree_op::TreeOp,
@@ -32,6 +31,7 @@ use crate::{
     event::{Diff, Index},
     op::RawOp,
 };
+use crate::{DocState, LoroDocInner};
 
 #[derive(Clone, Debug, EnumAsInner)]
 pub enum TreeFractionalIndexConfigInner {
@@ -1325,7 +1325,7 @@ impl ContainerState for TreeState {
         &mut self,
         _arena: &SharedArena,
         _txn: &Weak<Mutex<Option<Transaction>>>,
-        _state: &Weak<Mutex<DocState>>,
+        _doc: &Weak<LoroDocInner>,
     ) -> Diff {
         let mut diffs = vec![];
         let Some(roots) = self.children.get(&TreeParentId::Root) else {

--- a/crates/loro-internal/src/state/unknown_state.rs
+++ b/crates/loro-internal/src/state/unknown_state.rs
@@ -9,8 +9,7 @@ use crate::{
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp},
-    txn::Transaction,
-    DocState, LoroDocInner,
+    txn::Transaction, LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};

--- a/crates/loro-internal/src/state/unknown_state.rs
+++ b/crates/loro-internal/src/state/unknown_state.rs
@@ -9,7 +9,8 @@ use crate::{
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp},
-    txn::Transaction, LoroDocInner,
+    txn::Transaction,
+    LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -51,12 +52,7 @@ impl ContainerState for UnknownState {
     }
 
     #[doc = r" Convert a state to a diff, such that an empty state will be transformed into the same as this state when it's applied."]
-    fn to_diff(
-        &mut self,
-        _arena: &SharedArena,
-        _txn: &Weak<Mutex<Option<Transaction>>>,
-        _doc: &Weak<LoroDocInner>,
-    ) -> Diff {
+    fn to_diff(&mut self, _doc: &Weak<LoroDocInner>) -> Diff {
         Diff::Unknown
     }
 

--- a/crates/loro-internal/src/state/unknown_state.rs
+++ b/crates/loro-internal/src/state/unknown_state.rs
@@ -1,15 +1,13 @@
-use std::sync::{Mutex, Weak};
+use std::sync::Weak;
 
 use loro_common::{ContainerID, LoroResult, LoroValue};
 
 use crate::{
-    arena::SharedArena,
     configure::Configure,
     container::idx::ContainerIdx,
     encoding::{StateSnapshotDecodeContext, StateSnapshotEncoder},
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp},
-    txn::Transaction,
     LoroDocInner,
 };
 

--- a/crates/loro-internal/src/state/unknown_state.rs
+++ b/crates/loro-internal/src/state/unknown_state.rs
@@ -10,7 +10,7 @@ use crate::{
     event::{Diff, Index, InternalDiff},
     op::{Op, RawOp},
     txn::Transaction,
-    DocState,
+    DocState, LoroDocInner,
 };
 
 use super::{ApplyLocalOpReturn, ContainerState, DiffApplyContext};
@@ -56,7 +56,7 @@ impl ContainerState for UnknownState {
         &mut self,
         _arena: &SharedArena,
         _txn: &Weak<Mutex<Option<Transaction>>>,
-        _state: &Weak<Mutex<DocState>>,
+        _doc: &Weak<LoroDocInner>,
     ) -> Diff {
         Diff::Unknown
     }

--- a/crates/loro-internal/src/subscription.rs
+++ b/crates/loro-internal/src/subscription.rs
@@ -157,7 +157,7 @@ mod test {
     use tracing::trace;
 
     use super::*;
-    use crate::{handler::HandlerTrait, loro::LoroDoc};
+    use crate::{handler::HandlerTrait, LoroDoc};
 
     #[test]
     fn test_recursive_events() {

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -40,10 +40,6 @@ use super::{
 };
 
 impl crate::LoroDoc {
-    pub(crate) fn inner(&self) -> &LoroDocInner {
-        &self.inner
-    }
-
     /// Create a new transaction.
     /// Every ops created inside one transaction will be packed into a single
     /// [Change].

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -560,56 +560,36 @@ impl Transaction {
     /// if it's str it will use Root container, which will not be None
     pub fn get_text<I: IntoContainerId>(&self, id: I) -> TextHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Text);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.global_txn.clone(),
-            self.doc.clone(),
-        )
-        .into_text()
-        .unwrap()
+        Handler::new_attached(id, self.doc.clone())
+            .into_text()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
     /// if it's str it will use Root container, which will not be None
     pub fn get_list<I: IntoContainerId>(&self, id: I) -> ListHandler {
         let id = id.into_container_id(&self.arena, ContainerType::List);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.global_txn.clone(),
-            self.doc.clone(),
-        )
-        .into_list()
-        .unwrap()
+        Handler::new_attached(id, self.doc.clone())
+            .into_list()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
     /// if it's str it will use Root container, which will not be None
     pub fn get_map<I: IntoContainerId>(&self, id: I) -> MapHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Map);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.global_txn.clone(),
-            self.doc.clone(),
-        )
-        .into_map()
-        .unwrap()
+        Handler::new_attached(id, self.doc.clone())
+            .into_map()
+            .unwrap()
     }
 
     /// id can be a str, ContainerID, or ContainerIdRaw.
     /// if it's str it will use Root container, which will not be None
     pub fn get_tree<I: IntoContainerId>(&self, id: I) -> TreeHandler {
         let id = id.into_container_id(&self.arena, ContainerType::Tree);
-        Handler::new_attached(
-            id,
-            self.arena.clone(),
-            self.global_txn.clone(),
-            self.doc.clone(),
-        )
-        .into_tree()
-        .unwrap()
+        Handler::new_attached(id, self.doc.clone())
+            .into_tree()
+            .unwrap()
     }
 
     pub fn next_id(&self) -> ID {
@@ -774,7 +754,7 @@ fn change_to_diff(
                     let values = arena
                         .get_values(range.to_range())
                         .into_iter()
-                        .map(|v| ValueOrHandler::from_value(v, arena, txn, &doc));
+                        .map(|v| ValueOrHandler::from_value(v, &doc));
                     ans.push(TxnContainerDiff {
                         idx: op.container,
                         diff: Diff::List(
@@ -802,7 +782,7 @@ fn change_to_diff(
                 diff: Diff::Map(ResolvedMapDelta::new().with_entry(
                     key,
                     ResolvedMapValue {
-                        value: value.map(|v| ValueOrHandler::from_value(v, arena, txn, &doc)),
+                        value: value.map(|v| ValueOrHandler::from_value(v, &doc)),
                         idlp: IdLp::new(peer, lamport),
                     },
                 )),
@@ -824,7 +804,7 @@ fn change_to_diff(
                     &DeltaRopeBuilder::new()
                         .retain(to as usize, Default::default())
                         .insert(
-                            ArrayVec::from([ValueOrHandler::from_value(value, arena, txn, &doc)]),
+                            ArrayVec::from([ValueOrHandler::from_value(value, &doc)]),
                             ListDeltaMeta { from_move: true },
                         )
                         .build(),
@@ -842,9 +822,7 @@ fn change_to_diff(
                             .retain(index, Default::default())
                             .delete(1)
                             .insert(
-                                ArrayVec::from([ValueOrHandler::from_value(
-                                    value, arena, txn, &doc,
-                                )]),
+                                ArrayVec::from([ValueOrHandler::from_value(value, &doc)]),
                                 Default::default(),
                             )
                             .build(),

--- a/crates/loro-internal/src/undo.rs
+++ b/crates/loro-internal/src/undo.rs
@@ -16,7 +16,7 @@ use crate::{
     delta::TreeExternalDiff,
     event::{Diff, EventTriggerKind},
     version::Frontiers,
-    ContainerDiff, DiffEvent, DocDiff, LoroDoc, Subscription,
+    ContainerDiff, DiffEvent, DocDiff, LoroDoc, LoroDocInner, Subscription,
 };
 
 /// A batch of diffs.
@@ -154,6 +154,7 @@ pub struct UndoManager {
     inner: Arc<Mutex<UndoManagerInner>>,
     _peer_id_change_sub: Subscription,
     _undo_sub: Subscription,
+    doc: LoroDoc,
 }
 
 impl std::fmt::Debug for UndoManager {
@@ -553,6 +554,7 @@ impl UndoManager {
             inner,
             _peer_id_change_sub: sub,
             _undo_sub: undo_sub,
+            doc: doc.clone(),
         }
     }
 
@@ -576,16 +578,9 @@ impl UndoManager {
             .push(prefix.into());
     }
 
-    pub fn record_new_checkpoint(&mut self, doc: &LoroDoc) -> LoroResult<()> {
-        if doc.peer_id() != self.peer() {
-            return Err(LoroError::UndoWithDifferentPeerId {
-                expected: self.peer(),
-                actual: doc.peer_id(),
-            });
-        }
-
-        doc.commit_then_renew();
-        let counter = get_counter_end(doc, self.peer());
+    pub fn record_new_checkpoint(&mut self) -> LoroResult<()> {
+        self.doc.commit_then_renew();
+        let counter = get_counter_end(&self.doc, self.peer());
         self.inner
             .try_lock()
             .unwrap()
@@ -594,9 +589,8 @@ impl UndoManager {
     }
 
     #[instrument(skip_all)]
-    pub fn undo(&mut self, doc: &LoroDoc) -> LoroResult<bool> {
+    pub fn undo(&mut self) -> LoroResult<bool> {
         self.perform(
-            doc,
             |x| &mut x.undo_stack,
             |x| &mut x.redo_stack,
             UndoOrRedo::Undo,
@@ -604,9 +598,8 @@ impl UndoManager {
     }
 
     #[instrument(skip_all)]
-    pub fn redo(&mut self, doc: &LoroDoc) -> LoroResult<bool> {
+    pub fn redo(&mut self) -> LoroResult<bool> {
         self.perform(
-            doc,
             |x| &mut x.redo_stack,
             |x| &mut x.undo_stack,
             UndoOrRedo::Redo,
@@ -615,11 +608,11 @@ impl UndoManager {
 
     fn perform(
         &mut self,
-        doc: &LoroDoc,
         get_stack: impl Fn(&mut UndoManagerInner) -> &mut Stack,
         get_opposite: impl Fn(&mut UndoManagerInner) -> &mut Stack,
         kind: UndoOrRedo,
     ) -> LoroResult<bool> {
+        let doc = &self.doc.clone();
         // When in the undo/redo loop, the new undo/redo stack item should restore the selection
         // to the state it was in before the item that was popped two steps ago from the stack.
         //
@@ -673,8 +666,7 @@ impl UndoManager {
         // Because users may change the selections during the undo/redo loop, it's
         // more stable to keep the selection stored in the last stack item
         // rather than using the current selection directly.
-
-        self.record_new_checkpoint(doc)?;
+        self.record_new_checkpoint()?;
         let end_counter = get_counter_end(doc, self.peer());
         let mut top = {
             let mut inner = self.inner.try_lock().unwrap();

--- a/crates/loro-internal/src/undo.rs
+++ b/crates/loro-internal/src/undo.rs
@@ -6,7 +6,7 @@ use std::{
 use either::Either;
 use fxhash::FxHashMap;
 use loro_common::{
-    ContainerID, Counter, CounterSpan, HasIdSpan, IdSpan, LoroError, LoroResult, LoroValue, PeerID,
+    ContainerID, Counter, CounterSpan, HasIdSpan, IdSpan, LoroResult, LoroValue, PeerID,
 };
 use tracing::{debug_span, info_span, instrument};
 
@@ -16,7 +16,7 @@ use crate::{
     delta::TreeExternalDiff,
     event::{Diff, EventTriggerKind},
     version::Frontiers,
-    ContainerDiff, DiffEvent, DocDiff, LoroDoc, LoroDocInner, Subscription,
+    ContainerDiff, DiffEvent, DocDiff, LoroDoc, Subscription,
 };
 
 /// A batch of diffs.

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -128,7 +128,7 @@ pub(crate) fn js_to_version_vector(
     Ok(vv)
 }
 
-pub(crate) fn resolved_diff_to_js(value: &Diff, doc: &Arc<LoroDoc>) -> JsValue {
+pub(crate) fn resolved_diff_to_js(value: &Diff, doc: &LoroDoc) -> JsValue {
     // create a obj
     let obj = Object::new();
     match value {
@@ -240,7 +240,7 @@ pub(crate) fn js_diff_to_inner_diff(js: JsValue) -> JsResult<Diff> {
     }
 }
 
-fn delta_item_to_js(item: ListDiffItem, doc: &Arc<LoroDoc>) -> (JsValue, Option<JsValue>) {
+fn delta_item_to_js(item: ListDiffItem, doc: &LoroDoc) -> (JsValue, Option<JsValue>) {
     match item {
         loro_internal::loro_delta::DeltaItem::Retain { len, attr: _ } => {
             let obj = Object::new();
@@ -414,19 +414,18 @@ fn map_delta_to_js(value: &ResolvedMapDelta, doc: &Arc<LoroDoc>) -> JsValue {
     obj.into_js_result().unwrap()
 }
 
-pub(crate) fn handler_to_js_value(handler: Handler, doc: Option<Arc<LoroDoc>>) -> JsValue {
+pub(crate) fn handler_to_js_value(handler: Handler) -> JsValue {
     match handler {
         Handler::Text(t) => LoroText {
             handler: t,
-            doc,
             delta_cache: None,
         }
         .into(),
-        Handler::Map(m) => LoroMap { handler: m, doc }.into(),
-        Handler::List(l) => LoroList { handler: l, doc }.into(),
-        Handler::Tree(t) => LoroTree { handler: t, doc }.into(),
-        Handler::MovableList(m) => LoroMovableList { handler: m, doc }.into(),
-        Handler::Counter(c) => LoroCounter { handler: c, doc }.into(),
+        Handler::Map(m) => LoroMap { handler: m }.into(),
+        Handler::List(l) => LoroList { handler: l }.into(),
+        Handler::Tree(t) => LoroTree { handler: t }.into(),
+        Handler::MovableList(m) => LoroMovableList { handler: m }.into(),
+        Handler::Counter(c) => LoroCounter { handler: c }.into(),
         Handler::Unknown(_) => unreachable!(),
     }
 }

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -128,7 +128,7 @@ pub(crate) fn js_to_version_vector(
     Ok(vv)
 }
 
-pub(crate) fn resolved_diff_to_js(value: &Diff, doc: &LoroDoc) -> JsValue {
+pub(crate) fn resolved_diff_to_js(value: &Diff) -> JsValue {
     // create a obj
     let obj = Object::new();
     match value {
@@ -145,7 +145,7 @@ pub(crate) fn resolved_diff_to_js(value: &Diff, doc: &LoroDoc) -> JsValue {
             let arr = Array::new();
             let mut i = 0;
             for v in list.iter() {
-                let (a, b) = delta_item_to_js(v.clone(), doc);
+                let (a, b) = delta_item_to_js(v.clone());
                 arr.set(i as u32, a);
                 i += 1;
                 if let Some(b) = b {
@@ -176,12 +176,8 @@ pub(crate) fn resolved_diff_to_js(value: &Diff, doc: &LoroDoc) -> JsValue {
             js_sys::Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("map"))
                 .unwrap();
 
-            js_sys::Reflect::set(
-                &obj,
-                &JsValue::from_str("updated"),
-                &map_delta_to_js(map, doc),
-            )
-            .unwrap();
+            js_sys::Reflect::set(&obj, &JsValue::from_str("updated"), &map_delta_to_js(map))
+                .unwrap();
         }
 
         Diff::Counter(v) => {
@@ -240,7 +236,7 @@ pub(crate) fn js_diff_to_inner_diff(js: JsValue) -> JsResult<Diff> {
     }
 }
 
-fn delta_item_to_js(item: ListDiffItem, doc: &LoroDoc) -> (JsValue, Option<JsValue>) {
+fn delta_item_to_js(item: ListDiffItem) -> (JsValue, Option<JsValue>) {
     match item {
         loro_internal::loro_delta::DeltaItem::Retain { len, attr: _ } => {
             let obj = Object::new();
@@ -265,7 +261,7 @@ fn delta_item_to_js(item: ListDiffItem, doc: &LoroDoc) -> (JsValue, Option<JsVal
                 for (i, v) in value.into_iter().enumerate() {
                     let value = match v {
                         ValueOrHandler::Value(v) => convert(v),
-                        ValueOrHandler::Handler(h) => handler_to_js_value(h, Some(doc.clone())),
+                        ValueOrHandler::Handler(h) => handler_to_js_value(h),
                     };
                     arr.set(i as u32, value);
                 }
@@ -396,13 +392,13 @@ impl From<ImportBlobMetadata> for JsImportBlobMetadata {
     }
 }
 
-fn map_delta_to_js(value: &ResolvedMapDelta, doc: &Arc<LoroDoc>) -> JsValue {
+fn map_delta_to_js(value: &ResolvedMapDelta) -> JsValue {
     let obj = Object::new();
     for (key, value) in value.updated.iter() {
         let value = if let Some(value) = value.value.clone() {
             match value {
                 ValueOrHandler::Value(v) => convert(v),
-                ValueOrHandler::Handler(h) => handler_to_js_value(h, Some(doc.clone())),
+                ValueOrHandler::Handler(h) => handler_to_js_value(h),
             }
         } else {
             JsValue::null()

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 
 use js_sys::{Array, Map, Object, Reflect, Uint8Array};
 use loro_common::{IdLp, LoroListValue, LoroMapValue, LoroValue};
@@ -9,7 +8,7 @@ use loro_internal::event::{Diff, ListDeltaMeta, ListDiff, TextDiff, TextMeta};
 use loro_internal::handler::{Handler, ValueOrHandler};
 use loro_internal::version::VersionRange;
 use loro_internal::StringSlice;
-use loro_internal::{Counter, CounterSpan, FxHashMap, IdSpan, ListDiffItem, LoroDoc};
+use loro_internal::{Counter, CounterSpan, FxHashMap, IdSpan, ListDiffItem};
 use wasm_bindgen::{JsCast, JsValue};
 
 use crate::{

--- a/crates/loro-wasm/src/counter.rs
+++ b/crates/loro-wasm/src/counter.rs
@@ -1,7 +1,7 @@
 use super::subscription_to_js_function_callback;
 use loro_internal::{
     handler::{counter::CounterHandler, Handler},
-    HandlerTrait, LoroDoc,
+    HandlerTrait,
 };
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;

--- a/crates/loro/src/counter.rs
+++ b/crates/loro/src/counter.rs
@@ -2,7 +2,7 @@ use loro_internal::{
     container::ContainerID, handler::counter::CounterHandler, HandlerTrait, LoroResult,
 };
 
-use crate::{Container, ContainerTrait, SealedTrait};
+use crate::{Container, ContainerTrait, LoroDoc, SealedTrait};
 
 /// A counter that can be incremented or decremented.
 #[derive(Debug, Clone)]
@@ -80,5 +80,9 @@ impl ContainerTrait for LoroCounter {
 
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
+    }
+
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
     }
 }

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -998,6 +998,8 @@ pub trait ContainerTrait: SealedTrait {
         Self: Sized;
     /// Whether the container is deleted.
     fn is_deleted(&self) -> bool;
+    /// Get the doc of the container.
+    fn doc(&self) -> Option<LoroDoc>;
 }
 
 /// LoroList container. It's used to model array.
@@ -1052,6 +1054,10 @@ impl ContainerTrait for LoroList {
 
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
+    }
+
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
     }
 }
 
@@ -1321,6 +1327,10 @@ impl ContainerTrait for LoroMap {
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
     }
+
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
+    }
 }
 
 impl LoroMap {
@@ -1484,6 +1494,10 @@ impl ContainerTrait for LoroText {
 
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
+    }
+
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
     }
 }
 
@@ -1849,6 +1863,9 @@ impl ContainerTrait for LoroTree {
 
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
+    }
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
     }
 }
 
@@ -2258,6 +2275,9 @@ impl ContainerTrait for LoroMovableList {
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
     }
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
+    }
 }
 
 impl LoroMovableList {
@@ -2533,6 +2553,9 @@ impl ContainerTrait for LoroUnknown {
     fn is_deleted(&self) -> bool {
         self.handler.is_deleted()
     }
+    fn doc(&self) -> Option<LoroDoc> {
+        self.handler.doc().map(LoroDoc::_new)
+    }
 }
 
 use enum_as_inner::EnumAsInner;
@@ -2634,6 +2657,18 @@ impl ContainerTrait for Container {
             #[cfg(feature = "counter")]
             Container::Counter(x) => x.is_deleted(),
             Container::Unknown(x) => x.is_deleted(),
+        }
+    }
+    fn doc(&self) -> Option<LoroDoc> {
+        match self {
+            Container::List(x) => x.doc(),
+            Container::Map(x) => x.doc(),
+            Container::Text(x) => x.doc(),
+            Container::Tree(x) => x.doc(),
+            Container::MovableList(x) => x.doc(),
+            #[cfg(feature = "counter")]
+            Container::Counter(x) => x.doc(),
+            Container::Unknown(x) => x.doc(),
         }
     }
 }
@@ -2750,18 +2785,18 @@ impl UndoManager {
     }
 
     /// Undo the last change made by the peer.
-    pub fn undo(&mut self, doc: &LoroDoc) -> LoroResult<bool> {
-        self.0.undo(&doc.doc)
+    pub fn undo(&mut self) -> LoroResult<bool> {
+        self.0.undo()
     }
 
     /// Redo the last change made by the peer.
-    pub fn redo(&mut self, doc: &LoroDoc) -> LoroResult<bool> {
-        self.0.redo(&doc.doc)
+    pub fn redo(&mut self) -> LoroResult<bool> {
+        self.0.redo()
     }
 
     /// Record a new checkpoint.
-    pub fn record_new_checkpoint(&mut self, doc: &LoroDoc) -> LoroResult<()> {
-        self.0.record_new_checkpoint(&doc.doc)
+    pub fn record_new_checkpoint(&mut self) -> LoroResult<()> {
+        self.0.record_new_checkpoint()
     }
 
     /// Whether the undo manager can undo.

--- a/crates/loro/tests/integration_test/detached_editing_test.rs
+++ b/crates/loro/tests/integration_test/detached_editing_test.rs
@@ -250,9 +250,9 @@ fn undo_still_works_after_detached_editing() {
     doc.commit();
     doc.get_text("text").insert(5, " world!").unwrap();
     doc.commit();
-    undo.undo(&doc).unwrap();
+    undo.undo().unwrap();
     assert_eq!(doc.get_text("text").to_string(), "Hello");
-    undo.redo(&doc).unwrap();
+    undo.redo().unwrap();
     assert_eq!(doc.get_text("text").to_string(), "Hello world!");
 
     doc.set_detached_editing(true);
@@ -263,10 +263,10 @@ fn undo_still_works_after_detached_editing() {
     doc.commit();
     assert!(undo.can_undo());
     assert!(!undo.can_redo());
-    undo.undo(&doc).unwrap();
+    undo.undo().unwrap();
     assert_eq!(doc.get_text("text").to_string(), "Hello");
     assert!(!undo.can_undo());
     assert!(undo.can_redo());
-    undo.redo(&doc).unwrap();
+    undo.redo().unwrap();
     assert_eq!(doc.get_text("text").to_string(), "Hello alice!");
 }

--- a/crates/loro/tests/integration_test/undo_test.rs
+++ b/crates/loro/tests/integration_test/undo_test.rs
@@ -27,14 +27,14 @@ fn basic_list_undo_insertion() -> Result<(), LoroError> {
             "list": ["12", "34"]
         })
     );
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
             "list": ["12"]
         })
     );
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
@@ -63,7 +63,7 @@ fn basic_list_undo_deletion() -> Result<(), LoroError> {
             "list": ["12"]
         })
     );
-    undo.undo(&doc)?; // op 3
+    undo.undo()?; // op 3
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
@@ -73,7 +73,7 @@ fn basic_list_undo_deletion() -> Result<(), LoroError> {
 
     // Now, to undo "34" correctly we need to include the latest change
     // If we only undo op 1, op 3 will create "34" again.
-    undo.undo(&doc)?; // op 4
+    undo.undo()?; // op 4
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
@@ -97,23 +97,23 @@ fn basic_map_undo() -> Result<(), LoroError> {
     doc_a.commit();
     doc_a.get_map("map").delete("a")?;
     doc_a.commit();
-    undo.undo(&doc_a)?; // op 3
+    undo.undo()?; // op 3
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {"a": "a", "b": "b"}})
     );
 
-    undo.undo(&doc_a)?; // op 4
+    undo.undo()?; // op 4
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {"a": "a"}})
     );
 
-    undo.undo(&doc_a)?; // op 5
+    undo.undo()?; // op 5
     assert_eq!(doc_a.get_deep_value().to_json_value(), json!({"map": {}}));
 
     // Redo
-    undo.redo(&doc_a)?;
+    undo.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {
@@ -122,7 +122,7 @@ fn basic_map_undo() -> Result<(), LoroError> {
     );
 
     // Redo
-    undo.redo(&doc_a)?;
+    undo.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {
@@ -132,7 +132,7 @@ fn basic_map_undo() -> Result<(), LoroError> {
     );
 
     // Redo
-    undo.redo(&doc_a)?;
+    undo.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {
@@ -157,7 +157,7 @@ fn map_collaborative_undo() -> Result<(), LoroError> {
     doc_b.commit();
 
     doc_a.import(&doc_b.export_from(&Default::default()))?;
-    undo.undo(&doc_a)?;
+    undo.undo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {"b": "b"}})
@@ -177,17 +177,17 @@ fn map_container_undo() -> Result<(), LoroError> {
     doc.commit();
     map.insert("number", 0)?; // op 2
     doc.commit();
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({"map": {"text": "T"}})
     );
-    undo.undo(&doc)?;
-    undo.undo(&doc)?;
+    undo.undo()?;
+    undo.undo()?;
     assert_eq!(doc.get_deep_value().to_json_value(), json!({"map": {}}));
-    undo.redo(&doc)?;
-    undo.redo(&doc)?;
-    undo.redo(&doc)?;
+    undo.redo()?;
+    undo.redo()?;
+    undo.redo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({"map": {"text": "T", "number": 0}})
@@ -228,17 +228,17 @@ fn one_register_collaborative_undo() -> Result<(), LoroError> {
     sync(&doc_a, &doc_b);
     let mut undo = UndoManager::new(&doc_a);
     doc_a.get_map("map").insert("color", "red")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     sync(&doc_a, &doc_b);
     doc_b.get_map("map").insert("color", "green")?;
     sync(&doc_a, &doc_b);
-    undo.record_new_checkpoint(&doc_a)?;
-    undo.undo(&doc_a)?;
+    undo.record_new_checkpoint()?;
+    undo.undo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {"color": "black"}})
     );
-    undo.redo(&doc_a)?;
+    undo.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({"map": {"color": "green"}})
@@ -302,7 +302,7 @@ fn undo_id_span_that_contains_remote_deps_inside() -> Result<(), LoroError> {
         })
     );
     while undo_a.can_undo() {
-        undo_a.undo(&doc_a)?;
+        undo_a.undo()?;
     }
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
@@ -336,7 +336,7 @@ fn undo_id_span_that_contains_remote_deps_inside_many_times() -> Result<(), Loro
 
     // Undo all ops from A
     while undo.can_undo() {
-        undo.undo(&doc_a)?;
+        undo.undo()?;
     }
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
@@ -353,25 +353,25 @@ fn undo_manager() -> Result<(), LoroError> {
     doc.set_peer_id(1)?;
     let mut undo = UndoManager::new(&doc);
     doc.get_text("text").insert(0, "123")?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     doc.get_text("text").insert(3, "456")?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     doc.get_text("text").insert(6, "789")?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     for i in 0..10 {
         info_span!("round", i).in_scope(|| {
             assert_eq!(doc.get_text("text").to_string(), "123456789");
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(doc.get_text("text").to_string(), "123456");
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(doc.get_text("text").to_string(), "123");
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(doc.get_text("text").to_string(), "");
-            undo.redo(&doc)?;
+            undo.redo()?;
             assert_eq!(doc.get_text("text").to_string(), "123");
-            undo.redo(&doc)?;
+            undo.redo()?;
             assert_eq!(doc.get_text("text").to_string(), "123456");
-            undo.redo(&doc)?;
+            undo.redo()?;
             assert_eq!(doc.get_text("text").to_string(), "123456789");
             Ok::<(), loro::LoroError>(())
         })?;
@@ -386,11 +386,11 @@ fn undo_manager_with_sub_container() -> Result<(), LoroError> {
     doc.set_peer_id(1)?;
     let mut undo = UndoManager::new(&doc);
     let map = doc.get_list("list").insert_container(0, LoroMap::new())?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     let text = map.insert_container("text", LoroText::new())?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     text.insert(0, "123")?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     for i in 0..10 {
         info_span!("round", ?i).in_scope(|| {
             assert_eq!(
@@ -401,7 +401,7 @@ fn undo_manager_with_sub_container() -> Result<(), LoroError> {
                     }]
                 })
             );
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(
                 doc.get_deep_value().to_json_value(),
                 json!({
@@ -410,28 +410,28 @@ fn undo_manager_with_sub_container() -> Result<(), LoroError> {
                     }]
                 })
             );
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(
                 doc.get_deep_value().to_json_value(),
                 json!({
                     "list": [{}]
                 })
             );
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(
                 doc.get_deep_value().to_json_value(),
                 json!({
                     "list": []
                 })
             );
-            undo.redo(&doc)?;
+            undo.redo()?;
             assert_eq!(
                 doc.get_deep_value().to_json_value(),
                 json!({
                     "list": [{}]
                 })
             );
-            undo.redo(&doc)?;
+            undo.redo()?;
             assert_eq!(
                 doc.get_deep_value().to_json_value(),
                 json!({
@@ -440,7 +440,7 @@ fn undo_manager_with_sub_container() -> Result<(), LoroError> {
                     }]
                 })
             );
-            undo.redo(&doc)?;
+            undo.redo()?;
             assert_eq!(
                 doc.get_deep_value().to_json_value(),
                 json!({
@@ -465,29 +465,29 @@ fn test_undo_container_deletion() -> LoroResult<()> {
 
     let map = doc.get_map("map");
     let text = map.insert_container("text", LoroText::new())?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     text.insert(0, "T")?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({"map": {"text": "T"}})
     );
     map.delete("text")?;
     assert_eq!(doc.get_deep_value().to_json_value(), json!({"map": {}}));
-    undo.record_new_checkpoint(&doc)?;
-    undo.undo(&doc)?;
+    undo.record_new_checkpoint()?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({"map": {"text": "T"}})
     );
-    undo.redo(&doc)?;
+    undo.redo()?;
     assert_eq!(doc.get_deep_value().to_json_value(), json!({"map": {}}));
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({"map": {"text": "T"}})
     );
-    undo.redo(&doc)?;
+    undo.redo()?;
     assert_eq!(doc.get_deep_value().to_json_value(), json!({"map": {}}));
     doc.commit();
     Ok(())
@@ -526,9 +526,9 @@ fn undo_richtext_editing() -> LoroResult<()> {
     let mut undo = UndoManager::new(&doc);
     let text = doc.get_text("text");
     text.insert(0, "Hello")?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     text.mark(0..5, "bold", true)?;
-    undo.record_new_checkpoint(&doc)?;
+    undo.record_new_checkpoint()?;
     assert_eq!(
         text.get_richtext_value().to_json_value(),
         json!([
@@ -537,17 +537,17 @@ fn undo_richtext_editing() -> LoroResult<()> {
     );
     for i in 0..10 {
         debug_span!("round", i).in_scope(|| {
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(
                 text.get_richtext_value().to_json_value(),
                 json!([
                     {"insert": "Hello", }
                 ])
             );
-            undo.undo(&doc)?;
+            undo.undo()?;
             assert_eq!(text.get_richtext_value().to_json_value(), json!([]));
             debug_span!("redo 1").in_scope(|| {
-                undo.redo(&doc).unwrap();
+                undo.redo().unwrap();
             });
             assert_eq!(
                 text.get_richtext_value().to_json_value(),
@@ -556,7 +556,7 @@ fn undo_richtext_editing() -> LoroResult<()> {
                 ])
             );
             debug_span!("redo 2").in_scope(|| {
-                undo.redo(&doc).unwrap();
+                undo.redo().unwrap();
             });
             assert_eq!(
                 text.get_richtext_value().to_json_value(),
@@ -579,12 +579,12 @@ fn undo_richtext_editing_collab() -> LoroResult<()> {
     let doc_b = LoroDoc::new();
     doc_b.set_peer_id(2)?;
     doc_a.get_text("text").insert(0, "A fox jumped")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     sync(&doc_a, &doc_b);
     doc_b.get_text("text").mark(2..12, "italic", true)?;
     sync(&doc_a, &doc_b);
     doc_a.get_text("text").mark(0..5, "bold", true)?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     sync(&doc_a, &doc_b);
     assert_eq!(
         doc_a.get_text("text").get_richtext_value().to_json_value(),
@@ -595,7 +595,7 @@ fn undo_richtext_editing_collab() -> LoroResult<()> {
         ])
     );
     for _ in 0..10 {
-        undo.undo(&doc_a)?;
+        undo.undo()?;
         assert_eq!(
             doc_a.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -604,7 +604,7 @@ fn undo_richtext_editing_collab() -> LoroResult<()> {
             ])
         );
         // FIXME: right now redo/undo like this is wasteful
-        undo.redo(&doc_a)?;
+        undo.redo()?;
         assert_eq!(
             doc_a.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -636,12 +636,12 @@ fn undo_richtext_conflict_set_style() -> LoroResult<()> {
     doc_b.set_peer_id(2)?;
 
     doc_a.get_text("text").insert(0, "A fox jumped")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     sync(&doc_a, &doc_b);
     doc_b.get_text("text").mark(2..12, "color", "red")?;
     sync(&doc_a, &doc_b);
     doc_a.get_text("text").mark(0..5, "color", "green")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     sync(&doc_a, &doc_b);
     assert_eq!(
         doc_a.get_text("text").get_richtext_value().to_json_value(),
@@ -651,7 +651,7 @@ fn undo_richtext_conflict_set_style() -> LoroResult<()> {
         ])
     );
     for _ in 0..10 {
-        undo.undo(&doc_a)?;
+        undo.undo()?;
         assert_eq!(
             doc_a.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -659,12 +659,12 @@ fn undo_richtext_conflict_set_style() -> LoroResult<()> {
                 {"insert": "fox jumped", "attributes": {"color": "red"}}
             ])
         );
-        undo.undo(&doc_a)?;
+        undo.undo()?;
         assert_eq!(
             doc_a.get_text("text").get_richtext_value().to_json_value(),
             json!([])
         );
-        undo.redo(&doc_a)?;
+        undo.redo()?;
         assert_eq!(
             doc_a.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -672,7 +672,7 @@ fn undo_richtext_conflict_set_style() -> LoroResult<()> {
                 {"insert": "fox jumped", "attributes": {"color": "red"}}
             ])
         );
-        undo.redo(&doc_a)?;
+        undo.redo()?;
         assert_eq!(
             doc_a.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -693,30 +693,30 @@ fn undo_text_collab_delete() -> LoroResult<()> {
     let doc_b = LoroDoc::new();
     doc_b.set_peer_id(2)?;
     doc_a.get_text("text").insert(0, "A ")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     doc_a.get_text("text").insert(2, "fox ")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     doc_a.get_text("text").insert(6, "jumped")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     sync(&doc_a, &doc_b);
 
     doc_b.get_text("text").delete(2, 4)?;
     sync(&doc_a, &doc_b);
     doc_a.get_text("text").insert(0, "123!")?;
-    undo.record_new_checkpoint(&doc_a)?;
+    undo.record_new_checkpoint()?;
     for _ in 0..3 {
         assert_eq!(doc_a.get_text("text").to_string(), "123!A jumped");
-        undo.undo(&doc_a)?;
+        undo.undo()?;
         assert_eq!(doc_a.get_text("text").to_string(), "A jumped");
-        undo.undo(&doc_a)?;
+        undo.undo()?;
         assert_eq!(doc_a.get_text("text").to_string(), "A ");
-        undo.undo(&doc_a)?;
+        undo.undo()?;
         assert_eq!(doc_a.get_text("text").to_string(), "");
-        undo.redo(&doc_a)?;
+        undo.redo()?;
         assert_eq!(doc_a.get_text("text").to_string(), "A ");
-        undo.redo(&doc_a)?;
+        undo.redo()?;
         assert_eq!(doc_a.get_text("text").to_string(), "A jumped");
-        undo.redo(&doc_a)?;
+        undo.redo()?;
         assert_eq!(doc_a.get_text("text").to_string(), "123!A jumped");
     }
     Ok(())
@@ -772,7 +772,7 @@ fn collab_undo() -> anyhow::Result<()> {
                     {"insert": " fox jumped."}
                 ])
             );
-            undo_a.undo(&doc_a)?;
+            undo_a.undo()?;
             assert!(undo_a.can_redo());
             assert_eq!(
                 doc_a.get_text("text").get_richtext_value().to_json_value(),
@@ -782,14 +782,14 @@ fn collab_undo() -> anyhow::Result<()> {
                     {"insert": " fox jumped."}
                 ])
             );
-            undo_a.undo(&doc_a)?;
+            undo_a.undo()?;
             assert_eq!(
                 doc_a.get_text("text").get_richtext_value().to_json_value(),
                 json!([
                     {"insert": "Hello A fox jumped."},
                 ])
             );
-            undo_a.undo(&doc_a)?;
+            undo_a.undo()?;
             assert_eq!(
                 doc_a.get_text("text").get_richtext_value().to_json_value(),
                 json!([
@@ -798,7 +798,7 @@ fn collab_undo() -> anyhow::Result<()> {
             );
 
             assert!(!undo_a.can_undo());
-            undo_a.redo(&doc_a)?;
+            undo_a.redo()?;
             assert_eq!(
                 doc_a.get_text("text").get_richtext_value().to_json_value(),
                 json!([
@@ -806,7 +806,7 @@ fn collab_undo() -> anyhow::Result<()> {
                 ])
             );
 
-            undo_a.redo(&doc_a)?;
+            undo_a.redo()?;
             assert_eq!(
                 doc_a.get_text("text").get_richtext_value().to_json_value(),
                 json!([
@@ -815,7 +815,7 @@ fn collab_undo() -> anyhow::Result<()> {
                     {"insert": " fox jumped."}
                 ])
             );
-            undo_a.redo(&doc_a)?;
+            undo_a.redo()?;
             Ok::<(), LoroError>(())
         })?;
     }
@@ -831,7 +831,7 @@ fn collab_undo() -> anyhow::Result<()> {
                 {"insert": " fox jumped."}
             ])
         );
-        undo_b.undo(&doc_b)?;
+        undo_b.undo()?;
         assert!(undo_b.can_redo());
         assert_eq!(
             doc_b.get_text("text").get_richtext_value().to_json_value(),
@@ -842,7 +842,7 @@ fn collab_undo() -> anyhow::Result<()> {
             ])
         );
 
-        undo_b.undo(&doc_b)?;
+        undo_b.undo()?;
         assert_eq!(
             doc_b.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -851,7 +851,7 @@ fn collab_undo() -> anyhow::Result<()> {
                 {"insert": " "},
             ])
         );
-        undo_b.undo(&doc_b)?;
+        undo_b.undo()?;
         assert_eq!(
             doc_b.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -860,7 +860,7 @@ fn collab_undo() -> anyhow::Result<()> {
         );
         assert!(!undo_b.can_undo());
         assert!(undo_b.can_redo());
-        undo_b.redo(&doc_b)?;
+        undo_b.redo()?;
         assert_eq!(
             doc_b.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -869,7 +869,7 @@ fn collab_undo() -> anyhow::Result<()> {
                 {"insert": " "},
             ])
         );
-        undo_b.redo(&doc_b)?;
+        undo_b.redo()?;
         assert_eq!(
             doc_b.get_text("text").get_richtext_value().to_json_value(),
             json!([
@@ -878,7 +878,7 @@ fn collab_undo() -> anyhow::Result<()> {
                 {"insert": " fox"}
             ])
         );
-        undo_b.redo(&doc_b)?;
+        undo_b.redo()?;
     }
 
     Ok(())
@@ -949,25 +949,25 @@ fn undo_sub_sub_container() -> anyhow::Result<()> {
         ])
     );
 
-    undo_a.undo(&doc_a)?; // 4 -> 3
+    undo_a.undo()?; // 4 -> 3
     assert_eq!(
         text_a.get_richtext_value().to_json_value(),
         json!([
             {"insert": "Fox World!"},
         ])
     );
-    undo_a.undo(&doc_a)?; // 3 -> 2
-                          // It should be "FHoexllo World!" here ideally
-                          // But it's too expensive to calculate and make the code too complicated
-                          // So we skip the test
-    undo_a.undo(&doc_a)?; // 2 -> 1.5
+    undo_a.undo()?; // 3 -> 2
+                    // It should be "FHoexllo World!" here ideally
+                    // But it's too expensive to calculate and make the code too complicated
+                    // So we skip the test
+    undo_a.undo()?; // 2 -> 1.5
     assert_eq!(
         text_a.get_richtext_value().to_json_value(),
         json!([
             {"insert": "Fox"},
         ])
     );
-    undo_a.undo(&doc_a)?; // 1.5 -> 1
+    undo_a.undo()?; // 1.5 -> 1
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
@@ -975,7 +975,7 @@ fn undo_sub_sub_container() -> anyhow::Result<()> {
         })
     );
 
-    undo_a.undo(&doc_a)?; // 1 -> 0
+    undo_a.undo()?; // 1 -> 0
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
@@ -983,23 +983,23 @@ fn undo_sub_sub_container() -> anyhow::Result<()> {
         })
     );
 
-    undo_a.redo(&doc_a)?; // 0 -> 1
+    undo_a.redo()?; // 0 -> 1
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
             "map": {"list": []}
         })
     );
-    undo_a.redo(&doc_a)?; // 1 -> 1.5
+    undo_a.redo()?; // 1 -> 1.5
     assert_eq!(
         text_a.get_richtext_value().to_json_value(),
         json!([
             {"insert": "Fox"},
         ])
     );
-    undo_a.redo(&doc_a)?; // 1.5 -> 2
+    undo_a.redo()?; // 1.5 -> 2
 
-    undo_a.redo(&doc_a)?; // 2 -> 3
+    undo_a.redo()?; // 2 -> 3
 
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
@@ -1019,7 +1019,7 @@ fn undo_sub_sub_container() -> anyhow::Result<()> {
         .unwrap()
         .into_text()
         .unwrap();
-    undo_a.redo(&doc_a)?; // 3 -> 4
+    undo_a.redo()?; // 3 -> 4
     assert_eq!(
         text_a.get_richtext_value().to_json_value(),
         json!([
@@ -1089,7 +1089,7 @@ fn test_remote_merge_transform() -> LoroResult<()> {
         ])
     );
 
-    undo_a.undo(&doc_a)?;
+    undo_a.undo()?;
     assert_eq!(
         text_a.get_richtext_value().to_json_value(),
         json!([
@@ -1097,7 +1097,7 @@ fn test_remote_merge_transform() -> LoroResult<()> {
         ])
     );
 
-    undo_a.undo(&doc_a)?;
+    undo_a.undo()?;
     assert_eq!(text_a.get_richtext_value().to_json_value(), json!([]));
 
     Ok(())
@@ -1123,7 +1123,7 @@ fn undo_tree_move() -> LoroResult<()> {
     doc_b.import(&doc_a.export_from(&Default::default()))?;
     let latest_value = tree_a.get_value();
     // a
-    undo.undo(&doc_a)?;
+    undo.undo()?;
     let a_value = tree_a.get_value().as_list().unwrap().clone();
     assert_eq!(a_value.len(), 2);
     assert!(a_value[0]
@@ -1139,14 +1139,14 @@ fn undo_tree_move() -> LoroResult<()> {
         .unwrap()
         .is_null());
 
-    undo.redo(&doc_a)?;
+    undo.redo()?;
     assert_eq!(tree_a.get_value(), latest_value);
     // b
-    undo2.undo(&doc_b)?;
+    undo2.undo()?;
     let b_value = tree_b.get_value().as_list().unwrap().clone();
     assert_eq!(b_value.len(), 0);
-    undo.undo(&doc_a)?;
-    undo.undo(&doc_a)?;
+    undo.undo()?;
+    undo.undo()?;
     let a_value = tree_a.get_value().as_list().unwrap().clone();
     assert_eq!(a_value.len(), 1);
     assert_eq!(
@@ -1181,7 +1181,7 @@ fn undo_tree_concurrent_delete() -> LoroResult<()> {
     tree_b.delete(child)?;
     doc_a.import(&doc_b.export_from(&Default::default()))?;
     doc_b.import(&doc_a.export_from(&Default::default()))?;
-    undo_b.undo(&doc_b)?;
+    undo_b.undo()?;
     assert!(tree_b.get_value().as_list().unwrap().is_empty());
     Ok(())
 }
@@ -1203,7 +1203,7 @@ fn undo_tree_concurrent_delete2() -> LoroResult<()> {
     tree_b.delete(child)?;
     doc_a.import(&doc_b.export_from(&Default::default()))?;
     doc_b.import(&doc_a.export_from(&Default::default()))?;
-    undo_b.undo(&doc_b)?;
+    undo_b.undo()?;
     assert_eq!(tree_b.get_value().as_list().unwrap().len(), 1);
     assert_eq!(
         tree_b.get_value().as_list().unwrap()[0]
@@ -1289,7 +1289,7 @@ fn undo_redo_when_collab() -> anyhow::Result<()> {
     text_a.insert(0, "Alice")?;
     sync(&doc_a, &doc_b);
     text_b.delete(0, 5)?;
-    undo_a.undo(&doc_a)?;
+    undo_a.undo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
@@ -1297,7 +1297,7 @@ fn undo_redo_when_collab() -> anyhow::Result<()> {
         })
     );
     doc_a.import(&doc_b.export_from(&Default::default()))?;
-    undo_a.undo(&doc_a)?;
+    undo_a.undo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
@@ -1306,7 +1306,7 @@ fn undo_redo_when_collab() -> anyhow::Result<()> {
     );
     text_b.insert(0, "Bob ")?;
     doc_a.import(&doc_b.export_from(&Default::default()))?;
-    undo_a.undo(&doc_a)?;
+    undo_a.undo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
@@ -1315,21 +1315,21 @@ fn undo_redo_when_collab() -> anyhow::Result<()> {
     );
 
     assert!(undo_a.can_redo());
-    undo_a.redo(&doc_a)?;
+    undo_a.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
             "text": "Bob Hi "
         })
     );
-    undo_a.redo(&doc_a)?;
+    undo_a.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
             "text": "Bob Hi World"
         })
     );
-    undo_a.redo(&doc_a)?;
+    undo_a.redo()?;
     assert_eq!(
         doc_a.get_deep_value().to_json_value(),
         json!({
@@ -1366,7 +1366,7 @@ fn undo_list_move() -> anyhow::Result<()> {
                 "list": ["2", "1", "0"]
             })
         );
-        undo.undo(&doc)?;
+        undo.undo()?;
         assert!(undo.can_redo());
         assert_eq!(
             doc.get_deep_value().to_json_value(),
@@ -1374,14 +1374,14 @@ fn undo_list_move() -> anyhow::Result<()> {
                 "list": ["1", "2", "0"]
             })
         );
-        undo.undo(&doc)?;
+        undo.undo()?;
         assert_eq!(
             doc.get_deep_value().to_json_value(),
             json!({
                 "list": ["0", "1", "2"]
             })
         );
-        undo.undo(&doc)?;
+        undo.undo()?;
         assert_eq!(
             doc.get_deep_value().to_json_value(),
             json!({
@@ -1389,28 +1389,28 @@ fn undo_list_move() -> anyhow::Result<()> {
             })
         );
 
-        undo.undo(&doc)?;
-        undo.undo(&doc)?;
+        undo.undo()?;
+        undo.undo()?;
         assert!(!undo.can_undo());
-        undo.redo(&doc)?;
+        undo.redo()?;
         assert!(undo.can_undo());
-        undo.redo(&doc)?;
+        undo.redo()?;
 
-        undo.redo(&doc)?;
+        undo.redo()?;
         assert_eq!(
             doc.get_deep_value().to_json_value(),
             json!({
                 "list": ["0", "1", "2"]
             })
         );
-        undo.redo(&doc)?;
+        undo.redo()?;
         assert_eq!(
             doc.get_deep_value().to_json_value(),
             json!({
                 "list": ["1", "2", "0"]
             })
         );
-        undo.redo(&doc)?;
+        undo.redo()?;
         assert_eq!(
             doc.get_deep_value().to_json_value(),
             json!({
@@ -1442,7 +1442,7 @@ fn undo_collab_list_move() -> LoroResult<()> {
     doc_b.get_movable_list("list").mov(0, 1)?;
     sync(&doc, &doc_b);
     assert_eq!(list.get_value().to_json_value(), json!(["1", "0", "2"]));
-    undo.undo(&doc)?;
+    undo.undo()?;
     // FIXME: cannot infer move correctly for now
     assert_eq!(list.get_value().to_json_value(), json!(["0", "1", "2"]));
     Ok(())
@@ -1469,14 +1469,14 @@ fn exclude_certain_local_ops_from_undo() -> anyhow::Result<()> {
             "text": "x1y2z3abc"
         })
     );
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
             "text": "x1y2z3"
         })
     );
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
@@ -1484,14 +1484,14 @@ fn exclude_certain_local_ops_from_undo() -> anyhow::Result<()> {
         })
     );
     assert!(!undo.can_undo());
-    undo.redo(&doc)?;
+    undo.redo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
             "text": "x1y2z3"
         })
     );
-    undo.redo(&doc)?;
+    undo.redo()?;
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({
@@ -1522,7 +1522,7 @@ fn should_not_trigger_update_when_undo_ops_depend_on_deleted_container() -> anyh
     doc_a.get_map("map").delete("text")?;
     sync(&doc_a, &doc_b);
     let f = doc_b.oplog_frontiers();
-    undo.undo(&doc_b)?;
+    undo.undo()?;
     // should not update doc_b, because the undo operation depends on a deleted container
     assert_eq!(f, doc_b.oplog_frontiers());
     Ok(())
@@ -1561,18 +1561,18 @@ fn undo_manager_events() -> anyhow::Result<()> {
     doc.commit();
     assert_eq!(push_count.load(atomic::Ordering::SeqCst), 2);
 
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(&*popped_value.try_lock().unwrap(), &LoroValue::I64(5));
     assert_eq!(pop_count.load(atomic::Ordering::SeqCst), 1);
     assert_eq!(push_count.load(atomic::Ordering::SeqCst), 3);
-    undo.undo(&doc)?;
+    undo.undo()?;
     assert_eq!(&*popped_value.try_lock().unwrap(), &LoroValue::I64(0));
     assert_eq!(pop_count.load(atomic::Ordering::SeqCst), 2);
     assert_eq!(push_count.load(atomic::Ordering::SeqCst), 4);
-    undo.redo(&doc)?;
+    undo.redo()?;
     assert_eq!(pop_count.load(atomic::Ordering::SeqCst), 3);
     assert_eq!(push_count.load(atomic::Ordering::SeqCst), 5);
-    undo.redo(&doc)?;
+    undo.redo()?;
     assert_eq!(pop_count.load(atomic::Ordering::SeqCst), 4);
     assert_eq!(push_count.load(atomic::Ordering::SeqCst), 6);
     Ok(())
@@ -1620,7 +1620,7 @@ fn undo_transform_cursor_position() -> anyhow::Result<()> {
         assert_eq!(text.to_string(), "Hi Hii world!");
     }
     assert_eq!(popped_cursors.try_lock().unwrap().len(), 0);
-    undo.undo(&doc)?;
+    undo.undo()?;
 
     // Undo will create new "Hello". They have different IDs than the original ones.
     // But the original cursors are bound on the original deleted text.


### PR DESCRIPTION
Each `Container` needs to hold a reference to `LoroDoc` to prevent scenarios like https://github.com/loro-dev/loro-py/pull/7 where `LoroDoc` might be dropped while the `Container`'s methods are being called.