### PR TITLE
fix: improve shallow snapshot and JSON export handling

### DIFF
--- a/.changeset/tasty-dodos-repeat.md
+++ b/.changeset/tasty-dodos-repeat.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+fix: improve shallow snapshot and JSON export handling #639

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -3056,3 +3056,16 @@ fn test_loro_tree_move() {
         .unwrap();
     tree.mov(child, root).unwrap();
 }
+
+#[test]
+fn test_export_json_updates_in_shallow_snapshot() {
+    let doc = LoroDoc::new();
+    doc.set_peer_id(1).unwrap();
+    doc.get_text("text").insert(0, "123").unwrap();
+    let snapshot = doc
+        .export(ExportMode::shallow_snapshot_since(ID::new(1, 2)))
+        .unwrap();
+    let new_doc = LoroDoc::new();
+    new_doc.import(&snapshot).unwrap();
+    new_doc.export_json_updates(&Default::default(), &new_doc.oplog_vv());
+}


### PR DESCRIPTION
This pull request includes several changes to the `crates/loro-internal` and `crates/loro/tests` directories to improve the handling of version vectors, error checking, and testing. The most important changes are summarized below:

### Handling of Version Vectors:

* [`crates/loro-internal/src/loro.rs`](diffhunk://#diff-013c660b26d7d75e7041e30dc5320b06b668c5bf375c10120d37f4518ffba5feR573-R593): Added logic in `export_json_updates` to ensure `start_vv` is greater than or equal to `shallow_since_vv` by extending `start_vv` if necessary.

### Error Checking Improvements:

* [`crates/loro-internal/src/oplog/change_store.rs`](diffhunk://#diff-3c45ed5ba5f90a51ffe47156f5a3a8358457831fb664c110c50d0df070549078L300-R311): Added checks to return an empty vector if `next_back` is `None` or if the peer ID does not match `id_span.peer`.

### Testing Enhancements:

* [`crates/loro/tests/loro_rust_test.rs`](diffhunk://#diff-958eab2d7986d211d142944c0af73f6833f1eba38e37239d1235516fc8a189efR3060-R3072): Added a new test `test_export_json_updates_in_shallow_snapshot` to verify the behavior of `export_json_updates` in shallow snapshots.