### PR TITLE
fix: getting values by path in LoroTree

### DIFF
--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1632,12 +1632,36 @@ impl DocState {
             }
         };
 
-        let parent_state = self.store.get_container_mut(parent_idx)?;
+        let parent_state = self.store.get_or_create_mut(parent_idx);
         let index = path.last().unwrap();
         let value: LoroValue = match parent_state {
             State::ListState(l) => l.get(*index.as_seq()?).cloned()?,
             State::MovableListState(l) => l.get(*index.as_seq()?, IndexType::ForUser).cloned()?,
-            State::MapState(m) => m.get(index.as_key()?).cloned()?,
+            State::MapState(m) => {
+                if let Some(key) = index.as_key() {
+                    m.get(key).cloned()?
+                } else {
+                    if let CurContainer::TreeNode { tree, node } = state_idx {
+                        match index {
+                            Index::Seq(index) => {
+                                let tree_state =
+                                    self.store.get_container_mut(tree)?.as_tree_state().unwrap();
+                                let parent: TreeParentId = if let Some(node) = node {
+                                    node.into()
+                                } else {
+                                    TreeParentId::Root
+                                };
+                                let child = tree_state.get_children(&parent)?.nth(*index)?;
+                                child.associated_meta_container().into()
+                            }
+                            Index::Node(id) => id.associated_meta_container().into(),
+                            _ => return None,
+                        }
+                    } else {
+                        return None;
+                    }
+                }
+            }
             State::RichtextState(s) => {
                 let s = s.to_string_mut();
                 s.chars()

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1640,26 +1640,24 @@ impl DocState {
             State::MapState(m) => {
                 if let Some(key) = index.as_key() {
                     m.get(key).cloned()?
-                } else {
-                    if let CurContainer::TreeNode { tree, node } = state_idx {
-                        match index {
-                            Index::Seq(index) => {
-                                let tree_state =
-                                    self.store.get_container_mut(tree)?.as_tree_state().unwrap();
-                                let parent: TreeParentId = if let Some(node) = node {
-                                    node.into()
-                                } else {
-                                    TreeParentId::Root
-                                };
-                                let child = tree_state.get_children(&parent)?.nth(*index)?;
-                                child.associated_meta_container().into()
-                            }
-                            Index::Node(id) => id.associated_meta_container().into(),
-                            _ => return None,
+                } else if let CurContainer::TreeNode { tree, node } = state_idx {
+                    match index {
+                        Index::Seq(index) => {
+                            let tree_state =
+                                self.store.get_container_mut(tree)?.as_tree_state().unwrap();
+                            let parent: TreeParentId = if let Some(node) = node {
+                                node.into()
+                            } else {
+                                TreeParentId::Root
+                            };
+                            let child = tree_state.get_children(&parent)?.nth(*index)?;
+                            child.associated_meta_container().into()
                         }
-                    } else {
-                        return None;
+                        Index::Node(id) => id.associated_meta_container().into(),
+                        _ => return None,
                     }
+                } else {
+                    return None;
                 }
             }
             State::RichtextState(s) => {

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1393,3 +1393,18 @@ it("should call subscription after diff", async () => {
   expect(child.data.get("type")).toBe("Hi there");
   expect(called).toBe(true);
 });
+
+it("should return map for get_path_by_str", () => {
+  const doc = new LoroDoc();
+  const tree = doc.getTree("tree");
+  const root = tree.createNode();
+  const child = root.createNode();
+  const grandChild = child.createNode();
+  grandChild.data.set("type", "grandChild");
+  console.log(doc.getByPath("tree/0/0/0"))
+  expect(isContainer(doc.getByPath("tree/0/0/0"))).toBe(true)
+  expect((doc.getByPath("tree/0/0/0") as LoroMap).toJSON()).toStrictEqual({
+    "type": "grandChild"
+  })
+  expect(doc.getByPath("tree/0/0/0/type")).toBe("grandChild")
+})


### PR DESCRIPTION
resolve: get_by_str_path for trees doesn't return the node meta at the index #625