### PR TITLE
feat: add container existence check methods & avoid panic in wasm/js

### DIFF
--- a/.changeset/curvy-pens-film.md
+++ b/.changeset/curvy-pens-film.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+feat: add container existence check methods & avoid panic in wasm/js #651

--- a/crates/loro-internal/src/jsonpath.rs
+++ b/crates/loro-internal/src/jsonpath.rs
@@ -397,7 +397,7 @@ impl PathValue for LoroDoc {
         let arena = self.arena();
         for c in arena.root_containers() {
             let cid = arena.idx_to_id(c).unwrap();
-            let h = self.get_handler(cid);
+            let h = self.get_handler(cid).unwrap();
             if f(ValueOrHandler::Handler(h)) == ControlFlow::Break(()) {
                 break;
             }
@@ -410,7 +410,7 @@ impl PathValue for LoroDoc {
     }
 
     fn get_child_by_id(&self, id: ContainerID) -> Option<Handler> {
-        Some(self.get_handler(id))
+        self.get_handler(id)
     }
 
     fn clone_this(&self) -> Result<ValueOrHandler, JsonPathError> {

--- a/crates/loro-internal/src/undo.rs
+++ b/crates/loro-internal/src/undo.rs
@@ -111,7 +111,7 @@ fn transform_cursor(
     };
 
     let new_pos = cursor_with_pos.pos.pos;
-    match doc.get_handler(cid.clone()) {
+    match doc.get_handler(cid.clone()).unwrap() {
         crate::handler::Handler::Text(h) => {
             let Some(new_cursor) = h.get_cursor_internal(new_pos, cursor_with_pos.pos.side, false)
             else {

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1458,13 +1458,13 @@ it("test container existence", () => {
   doc.setPeerId("1");
   const text = doc.getMap("map").setContainer("text", new LoroText());
   const list = doc.getMap("map").setContainer("list", new LoroList());
-  expect(doc.isContainerExists("cid:root-map:Map")).toBe(true);
-  expect(doc.isContainerExists("cid:0@1:Text")).toBe(true);
-  expect(doc.isContainerExists("cid:1@1:List")).toBe(true);
+  expect(doc.hasContainer("cid:root-map:Map")).toBe(true);
+  expect(doc.hasContainer("cid:0@1:Text")).toBe(true);
+  expect(doc.hasContainer("cid:1@1:List")).toBe(true);
   const doc2 = new LoroDoc();
   doc.detach();
   doc2.import(doc.export({ mode: "update" }));
-  expect(doc2.isContainerExists("cid:root-map:Map")).toBe(true);
-  expect(doc2.isContainerExists("cid:0@1:Text")).toBe(true);
-  expect(doc2.isContainerExists("cid:1@1:List")).toBe(true);
+  expect(doc2.hasContainer("cid:root-map:Map")).toBe(true);
+  expect(doc2.hasContainer("cid:0@1:Text")).toBe(true);
+  expect(doc2.hasContainer("cid:1@1:List")).toBe(true);
 })

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1452,3 +1452,19 @@ it("should return map for get_path_by_str", () => {
   })
   expect(doc.getByPath("tree/0/0/0/type")).toBe("grandChild")
 })
+
+it("test container existence", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId("1");
+  const text = doc.getMap("map").setContainer("text", new LoroText());
+  const list = doc.getMap("map").setContainer("list", new LoroList());
+  expect(doc.isContainerExists("cid:root-map:Map")).toBe(true);
+  expect(doc.isContainerExists("cid:0@1:Text")).toBe(true);
+  expect(doc.isContainerExists("cid:1@1:List")).toBe(true);
+  const doc2 = new LoroDoc();
+  doc.detach();
+  doc2.import(doc.export({ mode: "update" }));
+  expect(doc2.isContainerExists("cid:root-map:Map")).toBe(true);
+  expect(doc2.isContainerExists("cid:0@1:Text")).toBe(true);
+  expect(doc2.isContainerExists("cid:1@1:List")).toBe(true);
+})

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -980,6 +980,40 @@ impl LoroDoc {
     pub fn diff(&self, a: &Frontiers, b: &Frontiers) -> LoroResult<DiffBatch> {
         self.doc.diff(a, b).map(|x| x.into())
     }
+
+    /// Check if the doc contains the target container.
+    ///
+    /// A root container always exists, while a normal container exists
+    /// if it has ever been created on the doc.
+    ///
+    /// # Examples
+    /// ```
+    /// use loro::{LoroDoc, LoroText, LoroList, ExportMode};
+    ///
+    /// let doc = LoroDoc::new();
+    /// doc.set_peer_id(1);
+    /// let map = doc.get_map("map");
+    /// map.insert_container("text", LoroText::new()).unwrap();
+    /// map.insert_container("list", LoroList::new()).unwrap();
+    ///
+    /// // Root map container exists
+    /// assert!(doc.has_container(&"cid:root-map:Map".try_into().unwrap()));
+    /// // Text container exists
+    /// assert!(doc.has_container(&"cid:0@1:Text".try_into().unwrap()));
+    /// // List container exists  
+    /// assert!(doc.has_container(&"cid:1@1:List".try_into().unwrap()));
+    ///
+    /// let doc2 = LoroDoc::new();
+    /// // Containers exist as long as the history or doc state includes them
+    /// doc.detach();
+    /// doc2.import(&doc.export(ExportMode::all_updates()).unwrap()).unwrap();
+    /// assert!(doc2.has_container(&"cid:root-map:Map".try_into().unwrap()));
+    /// assert!(doc2.has_container(&"cid:0@1:Text".try_into().unwrap()));
+    /// assert!(doc2.has_container(&"cid:1@1:List".try_into().unwrap()));
+    /// ```
+    pub fn has_container(&self, container_id: &ContainerID) -> bool {
+        self.doc.has_container(container_id)
+    }
 }
 
 /// It's used to prevent the user from implementing the trait directly.


### PR DESCRIPTION
This change introduces a new `has_container` method to check if a container exists in a document. The method is added to both the Rust internal implementation and the WASM bindings.

Key changes:
- Modify `get_handler` to return an `Option<Handler>` instead of panicking
- Add `has_container` method to check container existence