### PR TITLE
feat: tree compose

### DIFF
--- a/crates/fuzz/fuzz/Cargo.lock
+++ b/crates/fuzz/fuzz/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "loro 0.16.12",
  "loro 0.16.2 (git+https://github.com/loro-dev/loro.git?tag=loro-crdt%400.16.7)",
  "loro 0.16.2 (git+https://github.com/loro-dev/loro.git?rev=90470658435ec4c62b5af59ebb82fe9e1f5aa761)",
- "loro 1.0.0-beta.5",
+ "loro 1.4.1",
  "num_cpus",
  "pretty_assertions",
  "rand",
@@ -298,7 +298,7 @@ version = "0.0.0"
 dependencies = [
  "fuzz",
  "libfuzzer-sys",
- "loro 1.0.0-beta.5",
+ "loro 1.4.1",
 ]
 
 [[package]]
@@ -546,14 +546,15 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.0.0-beta.5"
+version = "1.4.1"
 dependencies = [
  "enum-as-inner 0.6.0",
+ "fxhash",
  "generic-btree",
- "loro-common 1.0.0-beta.5",
- "loro-delta 1.0.0-beta.5",
- "loro-internal 1.0.0-beta.5",
- "loro-kv-store 1.0.0-beta.5",
+ "loro-common 1.4.1",
+ "loro-delta 1.3.1",
+ "loro-internal 1.4.1",
+ "loro-kv-store 1.4.1",
  "tracing",
 ]
 
@@ -609,18 +610,17 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.0.0-beta.5"
+version = "1.4.1"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.0",
  "fxhash",
  "leb128",
- "loro-rle 1.0.0-beta.5",
+ "loro-rle 1.2.7",
  "nonmax",
  "serde",
  "serde_columnar",
  "serde_json",
- "string_cache",
  "thiserror",
 ]
 
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "loro-delta"
-version = "1.0.0-beta.5"
+version = "1.3.1"
 dependencies = [
  "arrayvec",
  "enum-as-inner 0.5.1",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.0.0-beta.5"
+version = "1.4.1"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -798,11 +798,11 @@ dependencies = [
  "im",
  "itertools 0.12.1",
  "leb128",
- "loro-common 1.0.0-beta.5",
- "loro-delta 1.0.0-beta.5",
- "loro-kv-store 1.0.0-beta.5",
- "loro-rle 1.0.0-beta.5",
- "loro_fractional_index 1.0.0-beta.5",
+ "loro-common 1.4.1",
+ "loro-delta 1.3.1",
+ "loro-kv-store 1.4.1",
+ "loro-rle 1.2.7",
+ "loro_fractional_index 1.2.7",
  "md5",
  "nonmax",
  "num",
@@ -838,12 +838,12 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.0.0-beta.5"
+version = "1.4.1"
 dependencies = [
  "bytes",
  "ensure-cov",
  "fxhash",
- "loro-common 1.0.0-beta.5",
+ "loro-common 1.4.1",
  "lz4_flex",
  "once_cell",
  "quick_cache",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "loro-rle"
-version = "1.0.0-beta.5"
+version = "1.2.7"
 dependencies = [
  "append-only-bytes",
  "num",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "loro_fractional_index"
-version = "1.0.0-beta.5"
+version = "1.2.7"
 dependencies = [
  "once_cell",
  "rand",

--- a/crates/fuzz/tests/test_tree.rs
+++ b/crates/fuzz/tests/test_tree.rs
@@ -1551,3 +1551,101 @@ fn btree() {
         },
     ])
 }
+
+#[test]
+fn tree_compose() {
+    test_actions(vec![
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(67108864),
+                bool: false,
+                key: 5120,
+                pos: 18374967950957286400,
+                length: 2244797026329624582,
+                prop: 18434758041542467359,
+            }),
+        },
+        SyncAll,
+        Handle {
+            site: 4,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(0),
+                bool: false,
+                key: 0,
+                pos: 0,
+                length: 0,
+                prop: 18446524175678963712,
+            }),
+        },
+        Checkout {
+            site: 0,
+            to: 520093727,
+        },
+        Handle {
+            site: 126,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: Container(Counter),
+                bool: true,
+                key: 3520188881,
+                pos: 6872316421537386961,
+                length: 6872316419617283935,
+                prop: 6872316419617283935,
+            }),
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(262144),
+                bool: false,
+                key: 20,
+                pos: 504122782800412436,
+                length: 2242554153559866112,
+                prop: 9511555592568334879,
+            }),
+        },
+        SyncAll,
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(0),
+                bool: false,
+                key: 16777216,
+                pos: 0,
+                length: 4107282860161892352,
+                prop: 18390450177879048246,
+            }),
+        },
+        Handle {
+            site: 49,
+            target: 0,
+            container: 31,
+            action: Generic(GenericAction {
+                value: I32(-519962624),
+                bool: true,
+                key: 4294967295,
+                pos: 15119096123158032686,
+                length: 4195730024608485841,
+                prop: 4195730024608447034,
+            }),
+        },
+    ]);
+}

--- a/crates/fuzz/tests/test_tree.rs
+++ b/crates/fuzz/tests/test_tree.rs
@@ -1767,3 +1767,168 @@ fn tree_compose_2() {
         },
     ])
 }
+
+#[test]
+fn tree_compose_3() {
+    test_actions(vec![
+        Handle {
+            site: 21,
+            target: 176,
+            container: 2,
+            action: Generic(GenericAction {
+                value: I32(-16777216),
+                bool: true,
+                key: 7798961,
+                pos: 11210466159500719965,
+                length: 17798226829352801060,
+                prop: 18392420167574355759,
+            }),
+        },
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(-202116109),
+                bool: true,
+                key: 4088656883,
+                pos: 12370143473892062199,
+                length: 10636257207010962347,
+                prop: 18446744073709551507,
+            }),
+        },
+        SyncAll,
+        Handle {
+            site: 1,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: Container(Unknown(243)),
+                bool: true,
+                key: 2475887628,
+                pos: 41489603736867731,
+                length: 12823999935435309057,
+                prop: 645127396713789184,
+            }),
+        },
+    ])
+}
+
+#[test]
+fn tree_compose_4() {
+    test_actions(vec![
+        Handle {
+            site: 23,
+            target: 2,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(0),
+                bool: false,
+                key: 0,
+                pos: 11140386617070441728,
+                length: 230699262384794,
+                prop: 14974415777739648301,
+            }),
+        },
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(757974317),
+                bool: true,
+                key: 2502765869,
+                pos: 12239412698313077760,
+                length: 4092364690691218386,
+                prop: 18446742974281767679,
+            }),
+        },
+        SyncAll,
+        Handle {
+            site: 9,
+            target: 56,
+            container: 9,
+            action: Generic(GenericAction {
+                value: Container(Text),
+                bool: true,
+                key: 16844041,
+                pos: 376614626806136575,
+                length: 18374406108585986313,
+                prop: 72340417651275774,
+            }),
+        },
+        Undo {
+            site: 87,
+            op_len: 1465341783,
+        },
+        Undo {
+            site: 87,
+            op_len: 84215127,
+        },
+        Handle {
+            site: 5,
+            target: 5,
+            container: 5,
+            action: Generic(GenericAction {
+                value: I32(84215045),
+                bool: true,
+                key: 17106181,
+                pos: 362831179256234241,
+                length: 72611743586517249,
+                prop: 72340172838076730,
+            }),
+        },
+        Handle {
+            site: 1,
+            target: 1,
+            container: 1,
+            action: Generic(GenericAction {
+                value: I32(16843009),
+                bool: true,
+                key: 16843009,
+                pos: 72340172838076673,
+                length: 72339069014900737,
+                prop: 651061557900814601,
+            }),
+        },
+        Handle {
+            site: 255,
+            target: 254,
+            container: 254,
+            action: Generic(GenericAction {
+                value: I32(0),
+                bool: false,
+                key: 0,
+                pos: 0,
+                length: 72057594037927936,
+                prop: 72340172838077754,
+            }),
+        },
+        Handle {
+            site: 1,
+            target: 45,
+            container: 223,
+            action: Generic(GenericAction {
+                value: I32(17369345),
+                bool: true,
+                key: 16843009,
+                pos: 72340172838076673,
+                length: 72340172838076673,
+                prop: 72340172838076673,
+            }),
+        },
+        Handle {
+            site: 5,
+            target: 5,
+            container: 5,
+            action: Generic(GenericAction {
+                value: I32(84215045),
+                bool: true,
+                key: 84215045,
+                pos: 213649441599586561,
+                length: 9,
+                prop: 0,
+            }),
+        },
+    ])
+}

--- a/crates/fuzz/tests/test_tree.rs
+++ b/crates/fuzz/tests/test_tree.rs
@@ -1649,3 +1649,121 @@ fn tree_compose() {
         },
     ]);
 }
+
+#[test]
+fn tree_compose_2() {
+    test_actions(vec![
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(67108864),
+                bool: false,
+                key: 5120,
+                pos: 18374967954648273920,
+                length: 2244797026329624582,
+                prop: 18434758041542467359,
+            }),
+        },
+        SyncAll,
+        Handle {
+            site: 4,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(0),
+                bool: false,
+                key: 0,
+                pos: 0,
+                length: 0,
+                prop: 18446521976655708160,
+            }),
+        },
+        Checkout {
+            site: 0,
+            to: 520093727,
+        },
+        Handle {
+            site: 126,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: Container(Counter),
+                bool: true,
+                key: 3520188881,
+                pos: 6872316421537386961,
+                length: 6872316419617283935,
+                prop: 6872316419617283935,
+            }),
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(262144),
+                bool: false,
+                key: 20,
+                pos: 504122782800412436,
+                length: 2242554153559866112,
+                prop: 9511555592568334879,
+            }),
+        },
+        SyncAll,
+        Handle {
+            site: 0,
+            target: 0,
+            container: 0,
+            action: Generic(GenericAction {
+                value: I32(47),
+                bool: false,
+                key: 0,
+                pos: 0,
+                length: 4107282860161892352,
+                prop: 18390450177879048246,
+            }),
+        },
+        Handle {
+            site: 48,
+            target: 0,
+            container: 31,
+            action: Generic(GenericAction {
+                value: I32(520093696),
+                bool: false,
+                key: 0,
+                pos: 72349003438748113,
+                length: 72340172838076673,
+                prop: 6872316418034041089,
+            }),
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Undo {
+            site: 95,
+            op_len: 1600085855,
+        },
+        Undo {
+            site: 209,
+            op_len: 3520168067,
+        },
+    ])
+}

--- a/crates/loro-internal/src/delta/tree.rs
+++ b/crates/loro-internal/src/delta/tree.rs
@@ -51,7 +51,7 @@ pub enum TreeExternalDiff {
 impl TreeDiff {
     #[allow(clippy::let_and_return)]
     pub(crate) fn compose(self, other: Self) -> Self {
-        println!("\ncompose \n{:?} \n{:?}", self, other);
+        // println!("\ncompose \n{:?} \n{:?}", self, other);
         let mut temp_tree = compose::TempTree::default();
         for (sort_index, item) in self
             .diff
@@ -59,12 +59,12 @@ impl TreeDiff {
             .chain(other.diff.into_iter())
             .enumerate()
         {
-            println!("\napply self {:?}", item);
+            // println!("\napply self {:?}", item);
             temp_tree.apply(item, sort_index);
-            println!("\ntemp_tree {:?}\n", temp_tree);
+            // println!("\ntemp_tree {:?}\n", temp_tree);
         }
         let ans = temp_tree.into_diff();
-        println!("ans {:?}", ans);
+        // println!("ans {:?}", ans);
         ans
     }
 

--- a/crates/loro-internal/src/delta/tree.rs
+++ b/crates/loro-internal/src/delta/tree.rs
@@ -529,8 +529,6 @@ mod compose {
 
         pub fn into_diff(mut self) -> TreeDiff {
             let mut diff = TreeDiff::default();
-            self.roots
-                .sort_by_key(|id| self.tree.get(id).map(|node| node.index()).unwrap());
             self.pre_order_traverse(|mut node| {
                 if node.filter {
                     return;

--- a/crates/loro-internal/src/delta/tree.rs
+++ b/crates/loro-internal/src/delta/tree.rs
@@ -459,6 +459,7 @@ mod compose {
                         });
                         node.filter = true;
                         node.sort_index = sort_index;
+                        node.children = vec![];
                         self.deleted.insert(target, node);
                     } else {
                         self.deleted.insert(
@@ -500,6 +501,8 @@ mod compose {
                                 old_index,
                             });
                             node.filter = true;
+                            node.sort_index = sort_index;
+                            node.children = vec![];
                             self.deleted.insert(target, node);
                         } else {
                             // Parent exists but target is not in batch

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1243,10 +1243,8 @@ impl Handler {
                         }
                         TreeExternalDiff::Move {
                             mut parent,
-                            index: _,
                             position,
-                            old_parent: _,
-                            old_index: _,
+                            ..
                         } => {
                             if let TreeParentId::Node(p) = &mut parent {
                                 remap_tree_id(p, container_remap)

--- a/crates/loro-internal/src/state/tree_state.rs
+++ b/crates/loro-internal/src/state/tree_state.rs
@@ -1098,6 +1098,7 @@ impl ContainerState for TreeState {
                         let old_parent = self.trees.get(&target).unwrap().parent;
                         // If this is some, the node is still alive at the moment
                         let old_index = self.get_index_by_tree_id(&target);
+                        let old_position = self.get_position(&target);
                         let was_alive = !self.is_node_deleted(&target).unwrap();
                         if need_check {
                             if self
@@ -1112,6 +1113,7 @@ impl ContainerState for TreeState {
                                             action: TreeExternalDiff::Delete {
                                                 old_parent,
                                                 old_index: old_index.unwrap(),
+                                                old_position: old_position.unwrap(),
                                             },
                                         });
                                     }
@@ -1126,6 +1128,7 @@ impl ContainerState for TreeState {
                                             position: position.clone(),
                                             old_parent,
                                             old_index: old_index.unwrap(),
+                                            old_position: old_position.unwrap(),
                                         },
                                     });
                                 } else {
@@ -1162,6 +1165,7 @@ impl ContainerState for TreeState {
                                             position: position.clone(),
                                             old_parent,
                                             old_index: old_index.unwrap(),
+                                            old_position: old_position.unwrap(),
                                         },
                                     });
                                 }
@@ -1189,6 +1193,7 @@ impl ContainerState for TreeState {
                                 action: TreeExternalDiff::Delete {
                                     old_parent: self.trees.get(&target).unwrap().parent,
                                     old_index: self.get_index_by_tree_id(&target).unwrap(),
+                                    old_position: self.get_position(&target).unwrap(),
                                 },
                             });
                         }
@@ -1207,6 +1212,7 @@ impl ContainerState for TreeState {
                                 action: TreeExternalDiff::Delete {
                                     old_parent: self.trees.get(&target).unwrap().parent,
                                     old_index: self.get_index_by_tree_id(&target).unwrap(),
+                                    old_position: self.get_position(&target).unwrap(),
                                 },
                             });
                         }

--- a/crates/loro-internal/src/value.rs
+++ b/crates/loro-internal/src/value.rs
@@ -572,6 +572,7 @@ pub mod wasm {
                     TreeExternalDiff::Delete {
                         old_parent,
                         old_index,
+                        old_position,
                     } => {
                         js_sys::Reflect::set(&obj, &"action".into(), &"delete".into()).unwrap();
                         js_sys::Reflect::set(
@@ -582,6 +583,12 @@ pub mod wasm {
                         .unwrap();
                         js_sys::Reflect::set(&obj, &"oldIndex".into(), &(*old_index).into())
                             .unwrap();
+                        js_sys::Reflect::set(
+                            &obj,
+                            &"oldPosition".into(),
+                            &old_position.to_string().into(),
+                        )
+                        .unwrap();
                     }
                     TreeExternalDiff::Move {
                         parent,
@@ -589,6 +596,7 @@ pub mod wasm {
                         position,
                         old_parent,
                         old_index,
+                        old_position,
                     } => {
                         js_sys::Reflect::set(&obj, &"action".into(), &"move".into()).unwrap();
                         js_sys::Reflect::set(
@@ -612,6 +620,12 @@ pub mod wasm {
                         .unwrap();
                         js_sys::Reflect::set(&obj, &"oldIndex".into(), &(*old_index).into())
                             .unwrap();
+                        js_sys::Reflect::set(
+                            &obj,
+                            &"oldPosition".into(),
+                            &old_position.to_string().into(),
+                        )
+                        .unwrap();
                     }
                 }
                 array.push(&obj);
@@ -728,12 +742,20 @@ pub mod wasm {
                             .ok_or_else(|| "oldIndex is not a number".to_string())?
                             as usize;
 
+                        let old_position = js_sys::Reflect::get(&obj, &"oldPosition".into())
+                            .map_err(|e| format!("Failed to get oldPosition: {:?}", e))?;
+                        let old_position = old_position
+                            .as_string()
+                            .ok_or_else(|| "oldPosition is not a string".to_string())?;
+                        let old_position = FractionalIndex::from_hex_string(old_position);
+
                         TreeExternalDiff::Move {
                             parent,
                             index,
                             position,
                             old_parent,
                             old_index,
+                            old_position,
                         }
                     }
                     "delete" => {
@@ -756,9 +778,17 @@ pub mod wasm {
                             .ok_or_else(|| "oldIndex is not a number".to_string())?
                             as usize;
 
+                        let old_position = js_sys::Reflect::get(&obj, &"oldPosition".into())
+                            .map_err(|e| format!("Failed to get oldPosition: {:?}", e))?;
+                        let old_position = old_position
+                            .as_string()
+                            .ok_or_else(|| "oldPosition is not a string".to_string())?;
+                        let old_position = FractionalIndex::from_hex_string(old_position);
+
                         TreeExternalDiff::Delete {
                             old_parent,
                             old_index,
+                            old_position,
                         }
                     }
                     action => Err(format!("Unknown tree diff action: {}", action))?,


### PR DESCRIPTION
Since we use `undo-do-redo` to implement the movable tree, when there are concurrent edits, redundant events are highly likely to occur. For example, concurrent create operations will emit redundant `delete-delete-delete-create-create-create` events, leading to inefficient event sys at the application layer.

This PR adds a simple algorithm for merging tree events, which can be described as follows:
- Create an empty temporary tree and apply events from the batch sequentially
- For combinations of delete and create(move) operations on the same TreeID, only preserve the final event and eliminate side effects from previous events
- For parent nodes that don't appear in the batch, create virtual nodes and add them to the root collection, marking them as filtered
- Track the causal ordering of events - all final delete events and create/move events for all child nodes starting from the root are emitted following their causal order

Verified through 400k rounds of fuzz testing