### PR TITLE
feat: add new ways to control commit options

### DIFF
--- a/crates/loro-ffi/src/doc.rs
+++ b/crates/loro-ffi/src/doc.rs
@@ -258,6 +258,33 @@ impl LoroDoc {
         self.doc.set_next_commit_message(msg)
     }
 
+    /// Set `origin` for the current uncommitted changes, it can be used to track the source of changes in an event.
+    ///
+    /// It will NOT be persisted.
+    pub fn set_next_commit_origin(&self, origin: &str) {
+        self.doc.set_next_commit_origin(origin)
+    }
+
+    /// Set the timestamp of the next commit.
+    ///
+    /// It will be persisted and stored in the `OpLog`.
+    /// You can get the timestamp from the [`Change`] type.
+    pub fn set_next_commit_timestamp(&self, timestamp: i64) {
+        self.doc.set_next_commit_timestamp(timestamp)
+    }
+
+    /// Set the options of the next commit.
+    ///
+    /// It will be used when the next commit is performed.
+    pub fn set_next_commit_options(&self, options: CommitOptions) {
+        self.doc.set_next_commit_options(options.into())
+    }
+
+    /// Clear the options of the next commit.
+    pub fn clear_next_commit_options(&self) {
+        self.doc.clear_next_commit_options()
+    }
+
     /// Whether the document is in detached mode, where the [loro_internal::DocState] is not
     /// synchronized with the latest version of the [loro_internal::OpLog].
     #[inline]

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -25,6 +25,7 @@ use crate::{
     event::{Diff, ListDeltaMeta, TextDiff},
     handler::{Handler, ValueOrHandler},
     id::{Counter, PeerID, ID},
+    loro::CommitOptions,
     op::{Op, RawOp, RawOpContent},
     span::HasIdSpan,
     version::Frontiers,
@@ -376,24 +377,24 @@ impl Transaction {
         self.on_commit.take()
     }
 
-    pub fn commit(mut self) -> Result<(), LoroError> {
+    pub fn commit(mut self) -> Result<Option<CommitOptions>, LoroError> {
         self._commit()
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    fn _commit(&mut self) -> Result<(), LoroError> {
+    fn _commit(&mut self) -> Result<Option<CommitOptions>, LoroError> {
         if self.finished {
-            return Ok(());
+            return Ok(None);
         }
 
         let Some(doc) = self.doc.upgrade() else {
-            return Ok(());
+            return Ok(None);
         };
         self.finished = true;
         let mut state = doc.state.try_lock().unwrap();
         if self.local_ops.is_empty() {
             state.abort_txn();
-            return Ok(());
+            return Ok(Some(self.take_options()));
         }
 
         let ops = std::mem::take(&mut self.local_ops);
@@ -453,7 +454,21 @@ impl Transaction {
         if let Some(on_commit) = self.on_commit.take() {
             on_commit(&doc.state.clone(), &doc.oplog.clone(), self.id_span());
         }
-        Ok(())
+        Ok(None)
+    }
+
+    fn take_options(&self) -> CommitOptions {
+        let mut options = CommitOptions::new();
+        if !self.origin.is_empty() {
+            options = options.origin(self.origin.as_str());
+        }
+        if let Some(msg) = self.msg.as_ref() {
+            options = options.commit_msg(msg);
+        }
+        if let Some(timestamp) = self.timestamp {
+            options = options.timestamp(timestamp);
+        }
+        options
     }
 
     pub(super) fn apply_local_op(
@@ -607,6 +622,24 @@ impl Transaction {
 
     pub(crate) fn len(&self) -> usize {
         (self.next_counter - self.start_counter) as usize
+    }
+
+    pub(crate) fn set_options(&mut self, options: CommitOptions) {
+        self.origin = options.origin.unwrap_or_default();
+        self.msg = options.commit_msg;
+        self.timestamp = options.timestamp;
+    }
+
+    pub(crate) fn set_default_options(&mut self, default_options: crate::loro::CommitOptions) {
+        if self.origin.is_empty() {
+            self.origin = default_options.origin.unwrap_or_default();
+        }
+        if self.msg.is_none() {
+            self.msg = default_options.commit_msg;
+        }
+        if self.timestamp.is_none() {
+            self.timestamp = default_options.timestamp;
+        }
     }
 }
 

--- a/crates/loro-internal/src/undo.rs
+++ b/crates/loro-internal/src/undo.rs
@@ -15,6 +15,7 @@ use crate::{
     cursor::{AbsolutePosition, Cursor},
     delta::TreeExternalDiff,
     event::{Diff, EventTriggerKind},
+    loro::CommitOptions,
     version::Frontiers,
     ContainerDiff, DiffEvent, DocDiff, LoroDoc, Subscription,
 };

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -401,7 +401,7 @@ impl LoroDoc {
     /// - `doc.checkout(version)` is called.
     #[inline]
     pub fn commit(&self) {
-        self.doc.commit_then_renew()
+        self.doc.commit_then_renew();
     }
 
     /// Commit the cumulative auto commit transaction with custom configure.
@@ -411,7 +411,7 @@ impl LoroDoc {
     /// The event will be sent after a transaction is committed
     #[inline]
     pub fn commit_with(&self, options: CommitOptions) {
-        self.doc.commit_with(options)
+        self.doc.commit_with(options);
     }
 
     /// Set commit message for the current uncommitted changes
@@ -419,6 +419,33 @@ impl LoroDoc {
     /// It will be persisted.
     pub fn set_next_commit_message(&self, msg: &str) {
         self.doc.set_next_commit_message(msg)
+    }
+
+    /// Set `origin` for the current uncommitted changes, it can be used to track the source of changes in an event.
+    ///
+    /// It will NOT be persisted.
+    pub fn set_next_commit_origin(&self, origin: &str) {
+        self.doc.set_next_commit_origin(origin)
+    }
+
+    /// Set the timestamp of the next commit.
+    ///
+    /// It will be persisted and stored in the `OpLog`.
+    /// You can get the timestamp from the [`Change`] type.
+    pub fn set_next_commit_timestamp(&self, timestamp: Timestamp) {
+        self.doc.set_next_commit_timestamp(timestamp)
+    }
+
+    /// Set the options of the next commit.
+    ///
+    /// It will be used when the next commit is performed.
+    pub fn set_next_commit_options(&self, options: CommitOptions) {
+        self.doc.set_next_commit_options(options);
+    }
+
+    /// Clear the options of the next commit.
+    pub fn clear_next_commit_options(&self) {
+        self.doc.clear_next_commit_options();
     }
 
     /// Whether the document is in detached mode, where the [loro_internal::DocState] is not


### PR DESCRIPTION
This commit introduces new methods for setting commit options, origin, and timestamp in the Loro document. The changes include:

- Add `set_next_commit_origin` to set the origin for the next commit
- Add `set_next_commit_timestamp` to set the timestamp for the next commit
- Add `set_next_commit_options` to set custom commit options
- Add `clear_next_commit_options` to reset commit options
- Update commit methods to handle these new options
- Implement corresponding methods in WASM and FFI bindings

It also makes the commit options of Undo/Redo controllable