### PR TITLE
feat: get pending ops from current txn as json

### DIFF
--- a/.changeset/late-gifts-jog.md
+++ b/.changeset/late-gifts-jog.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+feat: get ops from current txn as json #676

--- a/crates/loro-internal/src/change.rs
+++ b/crates/loro-internal/src/change.rs
@@ -38,6 +38,28 @@ pub struct Change<O = Op> {
     pub(crate) ops: RleVec<[O; 1]>,
 }
 
+pub(crate) struct ChangeRef<'a, O = Op> {
+    pub(crate) id: &'a ID,
+    pub(crate) lamport: &'a Lamport,
+    pub(crate) deps: &'a Frontiers,
+    pub(crate) timestamp: &'a Timestamp,
+    pub(crate) commit_msg: &'a Option<Arc<str>>,
+    pub(crate) ops: &'a RleVec<[O; 1]>,
+}
+
+impl<'a, O> ChangeRef<'a, O> {
+    pub fn from_change(change: &'a Change<O>) -> Self {
+        Self {
+            id: &change.id,
+            lamport: &change.lamport,
+            deps: &change.deps,
+            timestamp: &change.timestamp,
+            commit_msg: &change.commit_msg,
+            ops: &change.ops,
+        }
+    }
+}
+
 impl<O> Change<O> {
     pub fn new(
         ops: RleVec<[O; 1]>,

--- a/crates/loro-internal/src/encoding/json_schema.rs
+++ b/crates/loro-internal/src/encoding/json_schema.rs
@@ -263,7 +263,16 @@ fn convert_tree_id(tree: &TreeID, peers: &Option<Vec<PeerID>>) -> TreeID {
         counter: tree.counter,
     }
 }
-
+pub(crate) fn encode_change_to_json(change: Change, arena: &SharedArena) -> JsonSchema {
+    let f = change.deps.clone();
+    let changes = encode_changes(&[Either::Right(change)], arena, None);
+    JsonSchema {
+        changes,
+        schema_version: SCHEMA_VERSION,
+        peers: None,
+        start_version: f,
+    }
+}
 fn encode_changes(
     diff_changes: &[Either<BlockChangeRef, Change>],
     arena: &SharedArena,

--- a/crates/loro-internal/src/encoding/json_schema.rs
+++ b/crates/loro-internal/src/encoding/json_schema.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     arena::SharedArena,
-    change::Change,
+    change::{Change, ChangeRef},
     container::{
         list::list_op::{DeleteSpan, DeleteSpanWithId, InnerListOp},
         map::MapSet,
@@ -17,7 +17,7 @@ use crate::{
     OpLog, VersionVector,
 };
 use either::Either;
-use json::{JsonOpContent, JsonSchema};
+use json::{JsonChange, JsonOpContent, JsonSchema};
 use loro_common::{
     ContainerID, ContainerType, HasCounterSpan, HasId, HasIdSpan, IdLp, IdSpan, LoroError,
     LoroResult, LoroValue, PeerID, TreeID, ID,
@@ -263,9 +263,9 @@ fn convert_tree_id(tree: &TreeID, peers: &Option<Vec<PeerID>>) -> TreeID {
         counter: tree.counter,
     }
 }
-pub(crate) fn encode_change_to_json(change: Change, arena: &SharedArena) -> JsonSchema {
+pub(crate) fn encode_change_to_json(change: ChangeRef<'_>, arena: &SharedArena) -> JsonSchema {
     let f = change.deps.clone();
-    let changes = encode_changes(&[Either::Right(change)], arena, None);
+    let changes = vec![encode_change(change, arena, None)];
     JsonSchema {
         changes,
         schema_version: SCHEMA_VERSION,
@@ -273,6 +273,7 @@ pub(crate) fn encode_change_to_json(change: Change, arena: &SharedArena) -> Json
         start_version: f,
     }
 }
+
 fn encode_changes(
     diff_changes: &[Either<BlockChangeRef, Change>],
     arena: &SharedArena,
@@ -284,251 +285,261 @@ fn encode_changes(
             Either::Left(c) => c,
             Either::Right(c) => c,
         };
-        let mut ops = Vec::with_capacity(change.ops().len());
-        for Op {
-            counter,
-            container,
-            content,
-        } in change.ops().iter()
-        {
-            let mut container = arena.get_container_id(*container).unwrap();
-            if container.is_normal() {
-                container = register_container_id(container, peer_register.as_deref_mut());
-            }
-            let op = match container.container_type() {
-                ContainerType::List => match content {
-                    InnerContent::List(list) => JsonOpContent::List(match list {
-                        InnerListOp::Insert { slice, pos } => {
-                            let mut values =
-                                arena.get_values(slice.0.start as usize..slice.0.end as usize);
-                            values.iter_mut().for_each(|x| {
-                                if let LoroValue::Container(id) = x {
-                                    if id.is_normal() {
-                                        *id = register_container_id(
-                                            id.clone(),
-                                            peer_register.as_deref_mut(),
-                                        );
-                                    }
-                                }
-                            });
-                            json::ListOp::Insert {
-                                pos: *pos as u32,
-                                value: values,
-                            }
-                        }
-                        InnerListOp::Delete(DeleteSpanWithId {
-                            id_start,
-                            span: DeleteSpan { pos, signed_len },
-                        }) => json::ListOp::Delete {
-                            pos: *pos as i32,
-                            len: *signed_len as i32,
-                            start_id: register_id(id_start, peer_register.as_deref_mut()),
-                        },
-                        _ => unreachable!(),
-                    }),
-                    _ => unreachable!(),
-                },
-                ContainerType::MovableList => match content {
-                    InnerContent::List(list) => JsonOpContent::MovableList(match list {
-                        InnerListOp::Insert { slice, pos } => {
-                            let mut values =
-                                arena.get_values(slice.0.start as usize..slice.0.end as usize);
-                            values.iter_mut().for_each(|x| {
-                                if let LoroValue::Container(id) = x {
-                                    if id.is_normal() {
-                                        *id = register_container_id(
-                                            id.clone(),
-                                            peer_register.as_deref_mut(),
-                                        );
-                                    }
-                                }
-                            });
-                            json::MovableListOp::Insert {
-                                pos: *pos as u32,
-                                value: values,
-                            }
-                        }
-                        InnerListOp::Delete(DeleteSpanWithId {
-                            id_start,
-                            span: DeleteSpan { pos, signed_len },
-                        }) => json::MovableListOp::Delete {
-                            pos: *pos as i32,
-                            len: *signed_len as i32,
-                            start_id: register_id(id_start, peer_register.as_deref_mut()),
-                        },
-                        InnerListOp::Move {
-                            from,
-                            elem_id: from_id,
-                            to,
-                        } => json::MovableListOp::Move {
-                            from: *from,
-                            to: *to,
-                            elem_id: register_idlp(from_id, peer_register.as_deref_mut()),
-                        },
-                        InnerListOp::Set { elem_id, value } => {
-                            let value = if let LoroValue::Container(id) = value {
-                                if id.is_normal() {
-                                    LoroValue::Container(register_container_id(
-                                        id.clone(),
-                                        peer_register.as_deref_mut(),
-                                    ))
-                                } else {
-                                    value.clone()
-                                }
-                            } else {
-                                value.clone()
-                            };
-                            json::MovableListOp::Set {
-                                elem_id: register_idlp(elem_id, peer_register.as_deref_mut()),
-                                value,
-                            }
-                        }
-                        _ => unreachable!(),
-                    }),
-                    _ => unreachable!(),
-                },
-                ContainerType::Text => match content {
-                    InnerContent::List(list) => JsonOpContent::Text(match list {
-                        InnerListOp::InsertText {
-                            slice,
-                            unicode_start: _,
-                            unicode_len: _,
-                            pos,
-                        } => {
-                            let text = String::from_utf8(slice.as_bytes().to_vec()).unwrap();
-                            json::TextOp::Insert { pos: *pos, text }
-                        }
-                        InnerListOp::Delete(DeleteSpanWithId {
-                            id_start,
-                            span: DeleteSpan { pos, signed_len },
-                        }) => json::TextOp::Delete {
-                            pos: *pos as i32,
-                            len: *signed_len as i32,
-                            start_id: register_id(id_start, peer_register.as_deref_mut()),
-                        },
-                        InnerListOp::StyleStart {
-                            start,
-                            end,
-                            key,
-                            value,
-                            info,
-                        } => json::TextOp::Mark {
-                            start: *start,
-                            end: *end,
-                            style_key: key.to_string(),
-                            style_value: value.clone(),
-                            info: info.to_byte(),
-                        },
-                        InnerListOp::StyleEnd => json::TextOp::MarkEnd,
-                        _ => unreachable!(),
-                    }),
-                    _ => unreachable!(),
-                },
-                ContainerType::Map => match content {
-                    InnerContent::Map(MapSet { key, value }) => {
-                        JsonOpContent::Map(if let Some(v) = value {
-                            let value = if let LoroValue::Container(id) = v {
-                                if id.is_normal() {
-                                    LoroValue::Container(register_container_id(
-                                        id.clone(),
-                                        peer_register.as_deref_mut(),
-                                    ))
-                                } else {
-                                    v.clone()
-                                }
-                            } else {
-                                v.clone()
-                            };
-                            json::MapOp::Insert {
-                                key: key.to_string(),
-                                value,
-                            }
-                        } else {
-                            json::MapOp::Delete {
-                                key: key.to_string(),
-                            }
-                        })
-                    }
-
-                    _ => unreachable!(),
-                },
-
-                ContainerType::Tree => match content {
-                    InnerContent::Tree(op) => JsonOpContent::Tree(match &**op {
-                        TreeOp::Create {
-                            target,
-                            parent,
-                            position,
-                        } => json::TreeOp::Create {
-                            target: register_tree_id(target, peer_register.as_deref_mut()),
-                            parent: parent
-                                .map(|p| register_tree_id(&p, peer_register.as_deref_mut())),
-                            fractional_index: position.clone(),
-                        },
-                        TreeOp::Move {
-                            target,
-                            parent,
-                            position,
-                        } => json::TreeOp::Move {
-                            target: register_tree_id(target, peer_register.as_deref_mut()),
-                            parent: parent
-                                .map(|p| register_tree_id(&p, peer_register.as_deref_mut())),
-                            fractional_index: position.clone(),
-                        },
-                        TreeOp::Delete { target } => json::TreeOp::Delete {
-                            target: register_tree_id(target, peer_register.as_deref_mut()),
-                        },
-                    }),
-                    _ => unreachable!(),
-                },
-                ContainerType::Unknown(_) => {
-                    let InnerContent::Future(FutureInnerContent::Unknown { prop, value }) = content
-                    else {
-                        unreachable!();
-                    };
-                    JsonOpContent::Future(json::FutureOpWrapper {
-                        prop: *prop,
-                        value: json::FutureOp::Unknown((**value).clone()),
-                    })
-                }
-                #[cfg(feature = "counter")]
-                ContainerType::Counter => {
-                    let InnerContent::Future(f) = content else {
-                        unreachable!()
-                    };
-                    match f {
-                        FutureInnerContent::Counter(x) => {
-                            JsonOpContent::Future(json::FutureOpWrapper {
-                                prop: 0,
-                                value: json::FutureOp::Counter(super::OwnedValue::F64(*x)),
-                            })
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-            };
-            ops.push(json::JsonOp {
-                counter: *counter,
-                container,
-                content: op,
-            });
-        }
-        let c = json::JsonChange {
-            id: register_id(&change.id, peer_register.as_deref_mut()),
-            ops,
-            deps: change
-                .deps
-                .iter()
-                .map(|id| register_id(&id, peer_register.as_deref_mut()))
-                .collect(),
-            lamport: change.lamport,
-            timestamp: change.timestamp,
-            msg: change.message().map(|x| x.to_string()),
-        };
-
+        let c = encode_change(
+            ChangeRef::from_change(change),
+            arena,
+            peer_register.as_deref_mut(),
+        );
         changes.push(c);
     }
     changes
+}
+
+fn encode_change(
+    change: ChangeRef<'_, Op>,
+    arena: &SharedArena,
+    mut peer_register: Option<&mut ValueRegister<PeerID>>,
+) -> JsonChange {
+    let mut ops = Vec::with_capacity(change.ops.len());
+    for Op {
+        counter,
+        container,
+        content,
+    } in change.ops.iter()
+    {
+        let mut container = arena.get_container_id(*container).unwrap();
+        if container.is_normal() {
+            container = register_container_id(container, peer_register.as_deref_mut());
+        }
+        let op = match container.container_type() {
+            ContainerType::List => match content {
+                InnerContent::List(list) => JsonOpContent::List(match list {
+                    InnerListOp::Insert { slice, pos } => {
+                        let mut values =
+                            arena.get_values(slice.0.start as usize..slice.0.end as usize);
+                        values.iter_mut().for_each(|x| {
+                            if let LoroValue::Container(id) = x {
+                                if id.is_normal() {
+                                    *id = register_container_id(
+                                        id.clone(),
+                                        peer_register.as_deref_mut(),
+                                    );
+                                }
+                            }
+                        });
+                        json::ListOp::Insert {
+                            pos: *pos as u32,
+                            value: values,
+                        }
+                    }
+                    InnerListOp::Delete(DeleteSpanWithId {
+                        id_start,
+                        span: DeleteSpan { pos, signed_len },
+                    }) => json::ListOp::Delete {
+                        pos: *pos as i32,
+                        len: *signed_len as i32,
+                        start_id: register_id(id_start, peer_register.as_deref_mut()),
+                    },
+                    _ => unreachable!(),
+                }),
+                _ => unreachable!(),
+            },
+            ContainerType::MovableList => match content {
+                InnerContent::List(list) => JsonOpContent::MovableList(match list {
+                    InnerListOp::Insert { slice, pos } => {
+                        let mut values =
+                            arena.get_values(slice.0.start as usize..slice.0.end as usize);
+                        values.iter_mut().for_each(|x| {
+                            if let LoroValue::Container(id) = x {
+                                if id.is_normal() {
+                                    *id = register_container_id(
+                                        id.clone(),
+                                        peer_register.as_deref_mut(),
+                                    );
+                                }
+                            }
+                        });
+                        json::MovableListOp::Insert {
+                            pos: *pos as u32,
+                            value: values,
+                        }
+                    }
+                    InnerListOp::Delete(DeleteSpanWithId {
+                        id_start,
+                        span: DeleteSpan { pos, signed_len },
+                    }) => json::MovableListOp::Delete {
+                        pos: *pos as i32,
+                        len: *signed_len as i32,
+                        start_id: register_id(id_start, peer_register.as_deref_mut()),
+                    },
+                    InnerListOp::Move {
+                        from,
+                        elem_id: from_id,
+                        to,
+                    } => json::MovableListOp::Move {
+                        from: *from,
+                        to: *to,
+                        elem_id: register_idlp(from_id, peer_register.as_deref_mut()),
+                    },
+                    InnerListOp::Set { elem_id, value } => {
+                        let value = if let LoroValue::Container(id) = value {
+                            if id.is_normal() {
+                                LoroValue::Container(register_container_id(
+                                    id.clone(),
+                                    peer_register.as_deref_mut(),
+                                ))
+                            } else {
+                                value.clone()
+                            }
+                        } else {
+                            value.clone()
+                        };
+                        json::MovableListOp::Set {
+                            elem_id: register_idlp(elem_id, peer_register.as_deref_mut()),
+                            value,
+                        }
+                    }
+                    _ => unreachable!(),
+                }),
+                _ => unreachable!(),
+            },
+            ContainerType::Text => match content {
+                InnerContent::List(list) => JsonOpContent::Text(match list {
+                    InnerListOp::InsertText {
+                        slice,
+                        unicode_start: _,
+                        unicode_len: _,
+                        pos,
+                    } => {
+                        let text = String::from_utf8(slice.as_bytes().to_vec()).unwrap();
+                        json::TextOp::Insert { pos: *pos, text }
+                    }
+                    InnerListOp::Delete(DeleteSpanWithId {
+                        id_start,
+                        span: DeleteSpan { pos, signed_len },
+                    }) => json::TextOp::Delete {
+                        pos: *pos as i32,
+                        len: *signed_len as i32,
+                        start_id: register_id(id_start, peer_register.as_deref_mut()),
+                    },
+                    InnerListOp::StyleStart {
+                        start,
+                        end,
+                        key,
+                        value,
+                        info,
+                    } => json::TextOp::Mark {
+                        start: *start,
+                        end: *end,
+                        style_key: key.to_string(),
+                        style_value: value.clone(),
+                        info: info.to_byte(),
+                    },
+                    InnerListOp::StyleEnd => json::TextOp::MarkEnd,
+                    _ => unreachable!(),
+                }),
+                _ => unreachable!(),
+            },
+            ContainerType::Map => match content {
+                InnerContent::Map(MapSet { key, value }) => {
+                    JsonOpContent::Map(if let Some(v) = value {
+                        let value = if let LoroValue::Container(id) = v {
+                            if id.is_normal() {
+                                LoroValue::Container(register_container_id(
+                                    id.clone(),
+                                    peer_register.as_deref_mut(),
+                                ))
+                            } else {
+                                v.clone()
+                            }
+                        } else {
+                            v.clone()
+                        };
+                        json::MapOp::Insert {
+                            key: key.to_string(),
+                            value,
+                        }
+                    } else {
+                        json::MapOp::Delete {
+                            key: key.to_string(),
+                        }
+                    })
+                }
+
+                _ => unreachable!(),
+            },
+
+            ContainerType::Tree => match content {
+                InnerContent::Tree(op) => JsonOpContent::Tree(match &**op {
+                    TreeOp::Create {
+                        target,
+                        parent,
+                        position,
+                    } => json::TreeOp::Create {
+                        target: register_tree_id(target, peer_register.as_deref_mut()),
+                        parent: parent.map(|p| register_tree_id(&p, peer_register.as_deref_mut())),
+                        fractional_index: position.clone(),
+                    },
+                    TreeOp::Move {
+                        target,
+                        parent,
+                        position,
+                    } => json::TreeOp::Move {
+                        target: register_tree_id(target, peer_register.as_deref_mut()),
+                        parent: parent.map(|p| register_tree_id(&p, peer_register.as_deref_mut())),
+                        fractional_index: position.clone(),
+                    },
+                    TreeOp::Delete { target } => json::TreeOp::Delete {
+                        target: register_tree_id(target, peer_register.as_deref_mut()),
+                    },
+                }),
+                _ => unreachable!(),
+            },
+            ContainerType::Unknown(_) => {
+                let InnerContent::Future(FutureInnerContent::Unknown { prop, value }) = content
+                else {
+                    unreachable!();
+                };
+                JsonOpContent::Future(json::FutureOpWrapper {
+                    prop: *prop,
+                    value: json::FutureOp::Unknown((**value).clone()),
+                })
+            }
+            #[cfg(feature = "counter")]
+            ContainerType::Counter => {
+                let InnerContent::Future(f) = content else {
+                    unreachable!()
+                };
+                match f {
+                    FutureInnerContent::Counter(x) => {
+                        JsonOpContent::Future(json::FutureOpWrapper {
+                            prop: 0,
+                            value: json::FutureOp::Counter(super::OwnedValue::F64(*x)),
+                        })
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        };
+        ops.push(json::JsonOp {
+            counter: *counter,
+            container,
+            content: op,
+        });
+    }
+    let c = json::JsonChange {
+        id: register_id(change.id, peer_register.as_deref_mut()),
+        ops,
+        deps: change
+            .deps
+            .iter()
+            .map(|id| register_id(&id, peer_register.as_deref_mut()))
+            .collect(),
+        lamport: *change.lamport,
+        timestamp: *change.timestamp,
+        msg: change.commit_msg.as_deref().map(|x| x.to_string()),
+    };
+    c
 }
 
 fn decode_changes(json: JsonSchema, arena: &SharedArena) -> LoroResult<Vec<Change>> {

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -698,7 +698,7 @@ impl LoroDoc {
         self.get_by_path(&path)
     }
 
-    pub fn get_txn_ops_in_json(&self) -> Option<JsonSchema> {
+    pub fn get_uncommitted_ops_as_json(&self) -> Option<JsonSchema> {
         let arena = &self.arena;
         let txn = self.txn.try_lock().unwrap();
         let txn = txn.as_ref()?;

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1,9 +1,10 @@
+use crate::change::ChangeRef;
 pub use crate::encoding::ExportMode;
 pub use crate::state::analyzer::{ContainerAnalysisInfo, DocAnalysis};
 pub(crate) use crate::LoroDocInner;
 use crate::{
     arena::SharedArena,
-    change::{Change, Timestamp},
+    change::Timestamp,
     configure::{Configure, DefaultRandom, SecureRandomGenerator, StyleConfig},
     container::{
         idx::ContainerIdx, list::list_op::InnerListOp, richtext::config::StyleConfigMap,
@@ -706,17 +707,17 @@ impl LoroDoc {
             peer: *txn.peer(),
             counter: ops_.first()?.counter,
         };
-        let change = Change {
-            id: new_id,
-            deps: txn.frontiers().clone(),
-            timestamp: txn
+        let change = ChangeRef {
+            id: &new_id,
+            deps: txn.frontiers(),
+            timestamp: &txn
                 .timestamp()
                 .as_ref()
-                .cloned()
+                .copied()
                 .unwrap_or_else(|| self.oplog.try_lock().unwrap().get_timestamp_for_next_txn()),
-            commit_msg: txn.msg().clone(),
-            ops: ops_.clone(),
-            lamport: *txn.lamport(),
+            commit_msg: txn.msg(),
+            ops: ops_,
+            lamport: txn.lamport(),
         };
         let json = encode_change_to_json(change, arena);
         Some(json)

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -372,6 +372,29 @@ impl Transaction {
         self.msg = msg;
     }
 
+    pub fn local_ops(&self) -> &RleVec<[Op; 1]> {
+        &self.local_ops
+    }
+
+    pub fn peer(&self) -> &PeerID {
+        &self.peer
+    }
+
+    pub fn timestamp(&self) -> &Option<Timestamp> {
+        &self.timestamp
+    }
+
+    pub fn frontiers(&self) -> &Frontiers {
+        &self.frontiers
+    }
+    pub fn msg(&self) -> &Option<Arc<str>> {
+        &self.msg
+    }
+
+    pub fn lamport(&self) -> &Lamport {
+        &self.start_lamport
+    }
+
     pub(crate) fn set_on_commit(&mut self, f: OnCommitFn) {
         self.on_commit = Some(f);
     }
@@ -599,7 +622,6 @@ impl Transaction {
             .into_tree()
             .unwrap()
     }
-
     pub fn next_id(&self) -> ID {
         ID {
             peer: self.peer,

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -2051,6 +2051,32 @@ impl LoroDoc {
         let v: JsValue = arr.into();
         Ok(v.into())
     }
+
+    /// Get the pending operations from the current transaction in JSON format
+    ///
+    /// This method returns a JSON representation of operations that have been applied
+    /// but not yet committed in the current transaction.
+    ///
+    /// It will use the same data format as `doc.exportJsonUpdates()`
+    ///
+    /// @example
+    /// ```ts
+    /// const doc = new LoroDoc();
+    /// const text = doc.getText("text");
+    /// text.insert(0, "Hello");
+    /// // Get pending ops before commit
+    /// const pendingOps = doc.getPendingOpsFromCurrentTxnAsJson();
+    /// doc.commit();
+    /// const emptyOps = doc.getPendingOpsFromCurrentTxnAsJson(); // this is undefined
+    /// ```
+    pub fn getPendingOpsFromCurrentTxnAsJson(&self) -> JsResult<Option<JsJsonSchema>> {
+        let json_schema = self.0.get_txn_ops_in_json();
+        let s = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        let v = json_schema
+            .serialize(&s)
+            .map_err(std::convert::Into::<JsValue>::into)?;
+        Ok(Some(v.into()))
+    }
 }
 
 #[allow(unused)]

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -2069,8 +2069,8 @@ impl LoroDoc {
     /// doc.commit();
     /// const emptyOps = doc.getPendingOpsFromCurrentTxnAsJson(); // this is undefined
     /// ```
-    pub fn getPendingOpsFromCurrentTxnAsJson(&self) -> JsResult<Option<JsJsonSchema>> {
-        let json_schema = self.0.get_txn_ops_in_json();
+    pub fn getUncommittedOpsAsJson(&self) -> JsResult<Option<JsJsonSchema>> {
+        let json_schema = self.0.get_uncommitted_ops_as_json();
         let s = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         let v = json_schema
             .serialize(&s)

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1566,10 +1566,10 @@ it("can allow default config for text style", () => {
 it("can get pending ops as json", () => {
   const doc = new LoroDoc();
   doc.setPeerId("1");
-  expect(doc.getPendingOpsFromCurrentTxnAsJson()).toBeUndefined();
+  expect(doc.getUncommittedOpsAsJson()).toBeUndefined();
   const text = doc.getText("text");
   text.insert(0, "Hello");
-  const pendingOps = doc.getPendingOpsFromCurrentTxnAsJson()
+  const pendingOps = doc.getUncommittedOpsAsJson()
   expect(pendingOps).toBeDefined();
   expect(JSON.stringify(pendingOps)).toContain("insert");
   expect(JSON.stringify(pendingOps)).toContain("Hello");

--- a/crates/loro-wasm/tests/basic.test.ts
+++ b/crates/loro-wasm/tests/basic.test.ts
@@ -1563,3 +1563,37 @@ it("can allow default config for text style", () => {
     text.mark({ start: 0, end: 5 }, "size", true);
   }
 })
+it("can get pending ops as json", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId("1");
+  expect(doc.getPendingOpsFromCurrentTxnAsJson()).toBeUndefined();
+  const text = doc.getText("text");
+  text.insert(0, "Hello");
+  const pendingOps = doc.getPendingOpsFromCurrentTxnAsJson()
+  expect(pendingOps).toBeDefined();
+  expect(JSON.stringify(pendingOps)).toContain("insert");
+  expect(JSON.stringify(pendingOps)).toContain("Hello");
+  expect(pendingOps).toEqual({
+    "peers": undefined,
+    "schema_version": 1,
+    "start_version": {},
+    changes: [{
+      "id": "0@1",
+      "deps": [],
+      "msg": undefined,
+      "lamport": 0,
+      "ops": [
+        {
+          "container": "cid:root-text:Text",
+          "counter": 0,
+          "content": {
+            "type": "insert",
+            "pos": 0,
+            "text": "Hello"
+          }
+        }
+      ],
+      "timestamp": 0,
+    }],
+  })
+});


### PR DESCRIPTION
resolve #664

## Example

```ts
  const doc = new LoroDoc();
  doc.setPeerId("1");
  expect(doc.getUncommittedOpsAsJson()).toBeUndefined();
  const text = doc.getText("text");
  text.insert(0, "Hello");
  const pendingOps = doc.getUncommittedOpsAsJson()
  expect(pendingOps).toBeDefined();
  expect(JSON.stringify(pendingOps)).toContain("insert");
  expect(JSON.stringify(pendingOps)).toContain("Hello");
  expect(pendingOps).toEqual({
    "peers": undefined,
    "schema_version": 1,
    "start_version": {},
    changes: [{
      "id": "0@1",
      "deps": [],
      "msg": undefined,
      "lamport": 0,
      "ops": [
        {
          "container": "cid:root-text:Text",
          "counter": 0,
          "content": {
            "type": "insert",
            "pos": 0,
            "text": "Hello"
          }
        }
      ],
      "timestamp": 0,
    }],
  })
```