### PR TITLE
fix: --target wasm32-unknown-unknown for loro crate (getrandom dep)

### DIFF
--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -54,6 +54,10 @@ nonmax = "0.5.5"
 ensure-cov = { workspace = true }
 pretty_assertions = "1.4.1"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2.15"
+features = ["js"]
+
 
 [dev-dependencies]
 arbitrary = { version = "1" }


### PR DESCRIPTION
Running
```bash 
cd crates/loro && cargo build --target wasm32-unknown-unknown
```

Gives the following:
```bash
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/synoet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/src/lib.rs:342:9
    |
342 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
343 | |                         default, you may need to enable the \"js\" feature. \
344 | |                         For more information see: \
345 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /Users/synoet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/src/lib.rs:398:9
    |
398 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`
```

Conditionally enabling the `js` feature for `getrandom` in `loro-internal` when target architecture is `wasm-32` fixes the issue.

Allows using the `loro` crate in projects that compile to `wasm32-unknown-unknown` like cloudflare's `worker-rs`, which was the use case where I ran into this issue at first.