### PR TITLE
fix!(rs): make LoroDoc !Sync

### DIFF
--- a/crates/fuzz/tests/compatibility.rs
+++ b/crates/fuzz/tests/compatibility.rs
@@ -282,6 +282,8 @@ fn init() {
 }
 
 mod compatibility_with_10_alpha_4 {
+    use std::sync::Mutex;
+
     use super::*;
     use loro_alpha_4::{self, ToJson};
 
@@ -381,11 +383,11 @@ mod compatibility_with_10_alpha_4 {
     #[test]
     fn test_updates() {
         let doc1 = loro_alpha_4::LoroDoc::new();
-        let doc2 = Arc::new(loro::LoroDoc::new());
+        let doc2 = Arc::new(Mutex::new(loro::LoroDoc::new()));
         let doc2_clone = doc2.clone();
         doc1.set_peer_id(1).unwrap();
         doc1.subscribe_local_update(Box::new(move |updates| {
-            doc2_clone.import(updates).unwrap();
+            doc2_clone.lock().unwrap().import(updates).unwrap();
             true
         }))
         .detach();
@@ -394,7 +396,7 @@ mod compatibility_with_10_alpha_4 {
             gen_random_ops!(doc1, i, 10);
             assert_eq!(
                 doc1.get_deep_value().to_json_value(),
-                doc2.get_deep_value().to_json_value()
+                doc2.lock().unwrap().get_deep_value().to_json_value()
             );
         }
     }

--- a/crates/loro-ffi/src/lib.rs
+++ b/crates/loro-ffi/src/lib.rs
@@ -37,7 +37,7 @@ mod awareness;
 pub use awareness::{Awareness, AwarenessPeerUpdate, PeerInfo};
 
 // https://github.com/mozilla/uniffi-rs/issues/1372
-pub trait ValueOrContainer: Send + Sync {
+pub trait ValueOrContainer {
     fn is_value(&self) -> bool;
     fn is_container(&self) -> bool;
     fn as_value(&self) -> Option<LoroValue>;

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -113,11 +113,16 @@ pub use version::VersionVector;
 #[derive(Debug, Clone)]
 pub struct LoroDoc {
     inner: Arc<LoroDocInner>,
+    _marker: std::marker::PhantomData<*const ()>,
 }
 
+unsafe impl Send for LoroDoc {}
 impl LoroDoc {
     pub(crate) fn from_inner(inner: Arc<LoroDocInner>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
@@ -128,7 +133,6 @@ impl std::ops::Deref for LoroDoc {
         &self.inner
     }
 }
-
 pub struct LoroDocInner {
     oplog: Arc<Mutex<OpLog>>,
     state: Arc<Mutex<DocState>>,

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -94,7 +94,10 @@ impl LoroDoc {
                 peer_id_change_subs: SubscriberSetWithQueue::new(),
             }
         });
-        Self { inner }
+        Self {
+            inner,
+            _marker: std::marker::PhantomData,
+        }
     }
 
     pub fn fork(&self) -> Self {
@@ -1945,9 +1948,9 @@ mod test {
 
     #[test]
     fn test_sync() {
-        fn is_send_sync<T: Send + Sync>(_v: T) {}
+        fn is_send<T: Send>(_v: T) {}
         let loro = super::LoroDoc::new();
-        is_send_sync(loro)
+        is_send(loro)
     }
 
     #[test]

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -130,8 +130,7 @@ impl crate::LoroDoc {
     }
 }
 
-pub(crate) type OnCommitFn =
-    Box<dyn FnOnce(&Arc<Mutex<DocState>>, &Arc<Mutex<OpLog>>, IdSpan) + Sync + Send>;
+pub(crate) type OnCommitFn = Box<dyn FnOnce(&Arc<Mutex<DocState>>, &Arc<Mutex<OpLog>>, IdSpan)>;
 
 pub struct Transaction {
     peer: PeerID,

--- a/crates/loro-internal/src/utils/subscription.rs
+++ b/crates/loro-internal/src/utils/subscription.rs
@@ -268,8 +268,8 @@ struct Subscriber<Callback> {
 
 impl<EmitterKey, Callback> SubscriberSet<EmitterKey, Callback>
 where
-    EmitterKey: 'static + Ord + Clone + Debug + Send + Sync,
-    Callback: 'static + Send + Sync,
+    EmitterKey: 'static + Ord + Clone + Debug,
+    Callback: 'static,
 {
     pub fn new() -> Self {
         Self(Arc::new(Mutex::new(SubscriberSetState {
@@ -424,7 +424,7 @@ fn post_inc(next_subscriber_id: &mut usize) -> usize {
     *next_subscriber_id += 1;
     ans
 }
-type Callback = Box<dyn FnOnce() + 'static + Send + Sync>;
+type Callback = Box<dyn FnOnce() + 'static>;
 
 /// A handle to a subscription created by GPUI. When dropped, the subscription
 /// is cancelled and the callback will no longer be invoked.
@@ -507,9 +507,9 @@ impl<EmitterKey, Callback, Payload> WeakSubscriberSetWithQueue<EmitterKey, Callb
 
 impl<EmitterKey, Callback, Payload> SubscriberSetWithQueue<EmitterKey, Callback, Payload>
 where
-    EmitterKey: 'static + Ord + Clone + Debug + Send + Sync,
-    Callback: 'static + Send + Sync + for<'a> FnMut(&'a Payload) -> bool,
-    Payload: Send + Sync + Debug,
+    EmitterKey: 'static + Ord + Clone + Debug,
+    Callback: 'static + for<'a> FnMut(&'a Payload) -> bool,
+    Payload: Debug,
 {
     pub fn new() -> Self {
         Self {

--- a/crates/loro/src/event.rs
+++ b/crates/loro/src/event.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use crate::ValueOrContainer;
 
 /// A subscriber to the event.
-pub type Subscriber = Arc<dyn (for<'a> Fn(DiffEvent<'a>)) + Send + Sync>;
+pub type Subscriber = Arc<dyn (for<'a> Fn(DiffEvent<'a>))>;
 
 /// An event that is triggered by a change in the state of a [super::LoroDoc].
 #[derive(Debug)]

--- a/crates/loro/tests/loro_rust_test.rs
+++ b/crates/loro/tests/loro_rust_test.rs
@@ -340,10 +340,11 @@ fn travel_back_should_remove_styles() {
 
 #[test]
 fn list() -> LoroResult<()> {
+    let doc = LoroDoc::new();
+    check_send(doc);
     use loro::{LoroDoc, ToJson};
     use serde_json::json;
     let doc = LoroDoc::new();
-    check_sync_send(&doc);
     let list = doc.get_list("list");
     list.insert(0, 123)?;
     list.insert(1, 123)?;
@@ -420,7 +421,7 @@ fn tree() {
     )
 }
 
-fn check_sync_send(_doc: impl Sync + Send) {}
+fn check_send<T: Send>(_doc: T) {}
 
 #[test]
 fn richtext_test() {


### PR DESCRIPTION
Fix #685. It's a breaking change for the `loro` Rust crate.

LoroDoc should not be `Sync` because  `&LoroDoc` is not safe to send to another thread. It may lead to misuse. `!Sync` + `Send` would require users to use `Arc<Mutex<LoroDoc>>` when they need to send LoroDoc to another thread.

This change also simplifies the types of Subscription and Callback since they not longer need to be Sync+Send.