### PR TITLE
refactor!(rs): make LoroDoc !Sync

### DIFF
--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+#![allow(clippy::arc_with_non_send_sync)]
 pub mod actions;
 pub mod actor;
 pub mod container;

--- a/crates/fuzz/tests/compatibility.rs
+++ b/crates/fuzz/tests/compatibility.rs
@@ -282,6 +282,8 @@ fn init() {
 }
 
 mod compatibility_with_10_alpha_4 {
+    use std::sync::Mutex;
+
     use super::*;
     use loro_alpha_4::{self, ToJson};
 
@@ -381,11 +383,11 @@ mod compatibility_with_10_alpha_4 {
     #[test]
     fn test_updates() {
         let doc1 = loro_alpha_4::LoroDoc::new();
-        let doc2 = Arc::new(loro::LoroDoc::new());
+        let doc2 = Arc::new(Mutex::new(loro::LoroDoc::new()));
         let doc2_clone = doc2.clone();
         doc1.set_peer_id(1).unwrap();
         doc1.subscribe_local_update(Box::new(move |updates| {
-            doc2_clone.import(updates).unwrap();
+            doc2_clone.lock().unwrap().import(updates).unwrap();
             true
         }))
         .detach();
@@ -394,7 +396,7 @@ mod compatibility_with_10_alpha_4 {
             gen_random_ops!(doc1, i, 10);
             assert_eq!(
                 doc1.get_deep_value().to_json_value(),
-                doc2.get_deep_value().to_json_value()
+                doc2.lock().unwrap().get_deep_value().to_json_value()
             );
         }
     }

--- a/crates/loro-ffi/src/lib.rs
+++ b/crates/loro-ffi/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::arc_with_non_send_sync)]
 mod value;
 
 use loro::Container;

--- a/crates/loro/README.md
+++ b/crates/loro/README.md
@@ -6,6 +6,10 @@ Loro is a high-performance CRDTs framework offering Rust, JavaScript and Swift A
 
 Designed for local-first software, it enables effortless collaboration in app states. 
 
+Loro is a pure library and does not handle network protocols. 
+It is the responsibility of the user to manage the storage, loading, and synchronization
+of the bytes exported by Loro in a manner suitable for their specific environment.
+
 # Examples
 
 ## Map/List/Text

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -25,6 +25,7 @@ use loro_internal::{
     UnknownHandler as InnerUnknownHandler,
 };
 use std::cmp::Ordering;
+use std::marker::PhantomData;
 use std::ops::ControlFlow;
 use std::ops::Deref;
 use std::ops::Range;
@@ -97,8 +98,10 @@ pub struct LoroDoc {
     // This field is here to prevent some weird issues in debug mode
     #[cfg(debug_assertions)]
     _temp: u8,
+    _phantom: PhantomData<*const ()>,
 }
 
+unsafe impl Send for LoroDoc {}
 impl Default for LoroDoc {
     fn default() -> Self {
         Self::new()
@@ -119,6 +122,7 @@ impl LoroDoc {
             doc,
             #[cfg(debug_assertions)]
             _temp: 0,
+            _phantom: PhantomData,
         }
     }
 
@@ -1040,7 +1044,7 @@ impl LoroDoc {
     /// assert!(doc.has_container(&"cid:root-map:Map".try_into().unwrap()));
     /// // Text container exists
     /// assert!(doc.has_container(&"cid:0@1:Text".try_into().unwrap()));
-    /// // List container exists  
+    /// // List container exists
     /// assert!(doc.has_container(&"cid:1@1:List".try_into().unwrap()));
     ///
     /// let doc2 = LoroDoc::new();

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -87,7 +87,10 @@ mod counter;
 pub use counter::LoroCounter;
 
 /// `LoroDoc` is the entry for the whole document.
-/// When it's dropped, all the associated [`Handler`]s will be invalidated.
+///
+/// - When it's dropped, all the associated Containers will be invalidated.
+/// - `LoroDoc` implements `Send` but not `Sync`. If you need to share `LoroDoc` across threads, you probably need to use `Arc<Mutex<LoroDoc>>`.
+/// - Cloning `LoroDoc` creates a new reference to the same document.
 ///
 /// **Important:** Loro is a pure library and does not handle network protocols.
 /// It is the responsibility of the user to manage the storage, loading, and synchronization

--- a/crates/loro/tests/integration_test/undo_test.rs
+++ b/crates/loro/tests/integration_test/undo_test.rs
@@ -1581,6 +1581,7 @@ fn undo_manager_events() -> anyhow::Result<()> {
 #[test]
 fn undo_transform_cursor_position() -> anyhow::Result<()> {
     use loro::cursor::Cursor;
+    #[allow(clippy::arc_with_non_send_sync)]
     let doc = Arc::new(LoroDoc::new());
     let text = doc.get_text("text");
     let mut undo = UndoManager::new(&doc);


### PR DESCRIPTION
Fix #685. It's a breaking change for the loro Rust crate.

LoroDoc should not be Sync because &LoroDoc is not safe to send to another thread. It may lead to misuse. !Sync + Send would require users to use Arc<Mutex<LoroDoc>> when they need to send LoroDoc to another thread.