### PR TITLE
fix(loro-internal): support get_sys_timestamp wasm32 without wasm feature

### DIFF
--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -65,6 +65,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 version = "0.2.15"
 features = ["js"]
 
+[target.'cfg(all(target_arch = "wasm32", not(feature = "wasm")))'.dependencies]
+wasm-bindgen = "0.2.92"
 
 [dev-dependencies]
 arbitrary = { version = "1" }

--- a/crates/loro-internal/src/change.rs
+++ b/crates/loro-internal/src/change.rs
@@ -284,7 +284,7 @@ impl Change {
 
 /// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
 /// It is the number of milliseconds that have elapsed since 00:00:00 UTC on 1 January 1970.
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn get_sys_timestamp() -> f64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -296,7 +296,7 @@ pub(crate) fn get_sys_timestamp() -> f64 {
 
 /// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
 /// It is the number of seconds that have elapsed since 00:00:00 UTC on 1 January 1970.
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 pub fn get_sys_timestamp() -> f64 {
     use wasm_bindgen::prelude::wasm_bindgen;
     #[wasm_bindgen]


### PR DESCRIPTION
`get_sys_timestamp` only properly uses browser time api, if the `wasm` feature flag is enabled. But enabling the `wasm` feature flag pins the `wasm-bindgen` version (assuming because `loro-wasm` crate depends on this specific version), which prevents using `loro-internal` with runtimes that require a higher `wasm-bindgen` version. But when compiling to `wasm32-unknown-unknown` I don't think the pinned restriction is required, and we can keep the browser `get_sys_timestamp` implementation without requiring the `wasm` feature.