### PR TITLE
fix: upgrade wasm-bindgen to fix mem leak

### DIFF
--- a/.changeset/old-bananas-appear.md
+++ b/.changeset/old-bananas-appear.md
@@ -1,0 +1,7 @@
+---
+"loro-crdt": patch
+---
+
+Fix memory leak caused by wasm-bindgen
+
+- https://github.com/rustwasm/wasm-bindgen/issues/3854

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - uses: jetli/wasm-bindgen-action@v0.2.0
         with:
-          version: "0.2.92"
+          version: "0.2.100"
       - uses: Swatinem/rust-cache@v2
       - name: Check
         run: cargo clippy --all-features -- -Dwarnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 3. **Node**: Install from the Node.js website.
 4. **pnpm**: Run `npm i -g pnpm` for global installation.
 5. **Rust Target**: Add with `rustup target add wasm32-unknown-unknown`.
-6. **wasm-bindgen-cli**: Install version 0.2.92 via `cargo install wasm-bindgen-cli --version 0.2.92`.
+6. **wasm-bindgen-cli**: Install version 0.2.100 via `cargo install wasm-bindgen-cli --version 0.2.100`.
 6. **wasm-opt**: Install using `cargo install wasm-opt --locked`.
 7. **wasm-snip**: Install using `cargo install wasm-snip`.
 8. **cargo-nextest**: Install using `cargo install cargo-nextest --locked`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,23 +2765,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2 1.0.93",
  "quote 1.0.38",
  "syn 2.0.96",
@@ -2812,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote 1.0.38",
  "wasm-bindgen-macro-support",
@@ -2822,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2 1.0.93",
  "quote 1.0.38",
@@ -2835,9 +2836,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"

--- a/crates/loro-common/Cargo.toml
+++ b/crates/loro-common/Cargo.toml
@@ -18,7 +18,7 @@ rle = { path = "../rle", version = "1.2.7", package = "loro-rle" }
 serde = { workspace = true }
 serde_json = { workspace = true, optional=true }
 thiserror = "1.0.43"
-wasm-bindgen = { version = "=0.2.92", optional = true }
+wasm-bindgen = { version = "=0.2.100", optional = true }
 fxhash = "0.2.1"
 enum-as-inner = "0.6.0"
 arbitrary = { version = "1.3.0", features = ["derive"] }

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -39,7 +39,7 @@ postcard = { version = "1", features = ["use-std"] }
 append-only-bytes = { version = "0.1.12", features = ["u32_range"] }
 im = { version = "15.1.0", features = ["serde"] }
 tabled = { version = "0.10.0", optional = true }
-wasm-bindgen = { version = "=0.2.92", optional = true }
+wasm-bindgen = { version = "=0.2.100", optional = true }
 js-sys = { version = "0.3.60", optional = true }
 num = "0.4.0"
 rand = { version = "0.8.5" }
@@ -66,7 +66,7 @@ version = "0.2.15"
 features = ["js"]
 
 [target.'cfg(all(target_arch = "wasm32", not(feature = "wasm")))'.dependencies]
-wasm-bindgen = "0.2.92"
+wasm-bindgen = "0.2.100"
 
 [dev-dependencies]
 arbitrary = { version = "1" }

--- a/crates/loro-wasm/Cargo.toml
+++ b/crates/loro-wasm/Cargo.toml
@@ -20,7 +20,7 @@ loro-internal = { path = "../loro-internal", features = [
 ] }
 loro-common = { path = "../loro-common" }
 loro-delta = { path = "../delta" }
-wasm-bindgen = "=0.2.92"
+wasm-bindgen = "=0.2.100"
 serde-wasm-bindgen = { version = "^0.6.5" }
 wasm-bindgen-derive = "0.2.1"
 console_error_panic_hook = { version = "0.1.6" }

--- a/crates/loro-wasm/src/convert.rs
+++ b/crates/loro-wasm/src/convert.rs
@@ -102,7 +102,7 @@ pub(crate) fn js_to_id_span(js: JsIdSpan) -> Result<IdSpan, JsValue> {
 
 pub(crate) fn js_to_version_vector(
     js: JsValue,
-) -> Result<wasm_bindgen::__rt::Ref<'static, VersionVector>, JsValue> {
+) -> Result<wasm_bindgen::__rt::RcRef<VersionVector>, JsValue> {
     if !js.is_object() {
         return Err(JsValue::from_str(&format!(
             "Value supplied is not an object, but {:?}",

--- a/crates/loro-wasm/src/counter.rs
+++ b/crates/loro-wasm/src/counter.rs
@@ -40,7 +40,7 @@ impl LoroCounter {
     }
 
     /// The container id of this handler.
-    #[wasm_bindgen(js_name = "id", method, getter)]
+    #[wasm_bindgen(js_name = "id", getter)]
     pub fn id(&self) -> JsContainerID {
         let value: JsValue = (&self.handler.id()).into();
         value.into()

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1418,13 +1418,13 @@ impl LoroDoc {
         with_peer_compression: Option<bool>,
     ) -> JsResult<JsJsonSchema> {
         let mut json_start_vv: &InternalVersionVector = &Default::default();
-        let temp_start_vv: Option<wasm_bindgen::__rt::Ref<'static, VersionVector>>;
+        let temp_start_vv: Option<wasm_bindgen::__rt::RcRef<VersionVector>>;
         if !start_vv.is_null() && !start_vv.is_undefined() {
             temp_start_vv = Some(js_to_version_vector(start_vv)?);
             json_start_vv = &temp_start_vv.as_ref().unwrap().0;
         }
         let mut json_end_vv = &self.oplog_version().0;
-        let temp_end_vv: Option<wasm_bindgen::__rt::Ref<'static, VersionVector>>;
+        let temp_end_vv: Option<wasm_bindgen::__rt::RcRef<VersionVector>>;
         if !end_vv.is_null() && !end_vv.is_undefined() {
             temp_end_vv = Some(js_to_version_vector(end_vv)?);
             json_end_vv = &temp_end_vv.as_ref().unwrap().0;

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -867,7 +867,7 @@ impl LoroDoc {
     ///
     /// Note: use it with caution. You need to make sure there is not chance that two peers
     /// have the same peer ID. Otherwise, we cannot ensure the consistency of the document.
-    #[wasm_bindgen(js_name = "setPeerId", method)]
+    #[wasm_bindgen(js_name = "setPeerId")]
     pub fn set_peer_id(&self, peer_id: JsIntoPeerID) -> JsResult<()> {
         let id = js_peer_to_peer(peer_id.into())?;
         self.0.set_peer_id(id)?;
@@ -4997,7 +4997,7 @@ impl VersionVector {
     }
 
     /// Create a new version vector from a Map.
-    #[wasm_bindgen(js_name = "parseJSON", method)]
+    #[wasm_bindgen(js_name = "parseJSON")]
     pub fn from_json(version: JsVersionVectorMap) -> JsResult<VersionVector> {
         let map: JsValue = version.into();
         let map: js_sys::Map = map.into();
@@ -5020,7 +5020,7 @@ impl VersionVector {
     }
 
     /// Convert the version vector to a Map
-    #[wasm_bindgen(js_name = "toJSON", method)]
+    #[wasm_bindgen(js_name = "toJSON")]
     pub fn to_json(&self) -> JsVersionVectorMap {
         let vv = &self.0;
         let map = js_sys::Map::new();

--- a/crates/loro-wasm/tests/mem.test.ts
+++ b/crates/loro-wasm/tests/mem.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { LoroDoc } from "../bundler";
+
+describe("memory", () => {
+    it("should not leak memory", async () => {
+        global.gc && global.gc();
+        const before = process.memoryUsage();
+        const largeString = "A".repeat(1024 * 1024);
+        for (let i = 0; i < 1000; i++) {
+            const doc = new LoroDoc();
+            doc.getMap("map").set("key", largeString);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+
+        global.gc && global.gc();
+        const memoryUsage = process.memoryUsage();
+        // console.log("mem", memoryUsage);
+        console.log(
+            "Memory diff (MB):",
+            `external: ${((memoryUsage.external - before.external) / 1024 / 1024).toFixed(2)}`,
+            `rss: ${((memoryUsage.rss - before.rss) / 1024 / 1024).toFixed(2)}`
+        );
+        expect(memoryUsage.external - before.external).toBeLessThan(100 * 1024 * 1024);
+        expect(memoryUsage.rss - before.rss).toBeLessThan(100 * 1024 * 1024);
+    }, 10000)
+})


### PR DESCRIPTION
wasm-bindgen had a memory leak issue (https://github.com/rustwasm/wasm-bindgen/issues/3854). It causes the document initialized by `new LoroDoc()` to not be garbage collected correctly.