### PR TITLE
Add UndoManager `undo_count()` and `redo_count()`

### DIFF
--- a/crates/loro-ffi/src/undo.rs
+++ b/crates/loro-ffi/src/undo.rs
@@ -37,6 +37,16 @@ impl UndoManager {
         self.0.read().unwrap().can_redo()
     }
 
+    /// How many times the undo manager can undo.
+    pub fn undo_count(&self) -> usize {
+        self.0.read().unwrap().undo_count()
+    }
+
+    /// How many times the undo manager can redo.
+    pub fn redo_count(&self) -> usize {
+        self.0.read().unwrap().redo_count()
+    }
+
     /// If a local event's origin matches the given prefix, it will not be recorded in the
     /// undo stack.
     pub fn add_exclude_origin_prefix(&self, prefix: &str) {

--- a/crates/loro-internal/src/undo.rs
+++ b/crates/loro-internal/src/undo.rs
@@ -756,6 +756,14 @@ impl UndoManager {
         !self.inner.lock().unwrap().redo_stack.is_empty()
     }
 
+    pub fn undo_count(&self) -> usize {
+        self.inner.lock().unwrap().undo_stack.len()
+    }
+
+    pub fn redo_count(&self) -> usize {
+        self.inner.lock().unwrap().redo_stack.len()
+    }
+
     pub fn set_on_push(&self, on_push: Option<OnPush>) {
         self.inner.lock().unwrap().on_push = on_push;
     }

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -3028,6 +3028,16 @@ impl UndoManager {
         self.0.can_redo()
     }
 
+    /// How many times the undo manager can undo.
+    pub fn undo_count(&self) -> usize {
+        self.0.undo_count()
+    }
+
+    /// How many times the undo manager can redo.
+    pub fn redo_count(&self) -> usize {
+        self.0.redo_count()
+    }
+
     /// If a local event's origin matches the given prefix, it will not be recorded in the
     /// undo stack.
     pub fn add_exclude_origin_prefix(&mut self, prefix: &str) {


### PR DESCRIPTION
Changes:
- Surface the `undo_stack` and `redo_stack` depths
- Add `undo_count()` and `redo_count()` checks to unit tests

This helps us use Loro's UndoManager as an alternative implementation of Cocoa Foundation's [UndoManager](https://developer.apple.com/documentation/foundation/undomanager/) API, which is obliged to be able to return an `undoCount` and `redoCount`.