### PR TITLE
fix(wasm): serialize op with bigint support

### DIFF
--- a/.changeset/strange-onions-eat.md
+++ b/.changeset/strange-onions-eat.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+fix(wasm): serialize op with bigint support @synoet

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -5117,9 +5117,6 @@ impl VersionVector {
     }
 }
 
-
-
-
 const ID_CONVERT_ERROR: &str = "Invalid peer id. It must be a number, a BigInt, or a decimal string that can be parsed to a unsigned 64-bit integer";
 fn js_peer_to_peer(value: JsValue) -> JsResult<u64> {
     if value.is_bigint() {

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -1795,14 +1795,19 @@ impl LoroDoc {
         let id = js_id_to_id(id)?;
         let borrow_mut = &self.0;
         let oplog = borrow_mut.oplog().lock().unwrap();
+
+        let serializer =
+            serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);
+
         let change = oplog
             .get_remote_change_at(id)
             .ok_or_else(|| JsError::new(&format!("Change {:?} not found", id)))?;
         let ops = change
             .ops()
             .iter()
-            .map(|op| serde_wasm_bindgen::to_value(op).unwrap())
+            .map(|op| op.serialize(&serializer).unwrap())
             .collect::<Vec<_>>();
+
         Ok(ops)
     }
 
@@ -5111,6 +5116,9 @@ impl VersionVector {
         self.0.len()
     }
 }
+
+
+
 
 const ID_CONVERT_ERROR: &str = "Invalid peer id. It must be a number, a BigInt, or a decimal string that can be parsed to a unsigned 64-bit integer";
 fn js_peer_to_peer(value: JsValue) -> JsResult<u64> {


### PR DESCRIPTION
Need to serialize op with bigint support otherwhise might run into something like this.

``` 00c11f2e:0x20b225 panicked at crates/loro-wasm/src/lib.rs:1804:56:
called Result::unwrap() on an Err value: Error(JsValue(Error: 5476599770687706205 can't be represented as a JavaScript number ```