### PR TITLE
Omit ahash dependency for wasm32-unknown-unknown builds

### DIFF
--- a/crates/kv-store/Cargo.toml
+++ b/crates/kv-store/Cargo.toml
@@ -9,13 +9,18 @@ repository = "https://github.com/loro-dev/loro/"
 authors = ["Liang Zhao", "Zixuan Chen"]
 
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+quick_cache = { version = "0.6.2", default-features = false }
+
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
+quick_cache = { version = "0.6.2" }
+
 [dependencies]
 loro-common = { path = "../loro-common", version = "1.5.8" }
 bytes = { workspace = true }
 fxhash = { workspace = true }
 once_cell = { workspace = true }
 lz4_flex = { version = "0.11" }
-quick_cache = "0.6.2"
 xxhash-rust = { workspace = true }
 ensure-cov = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
This PR is intended to fix #760.

I also created a PR to the ahash project upstream, which would pass the wasm_js feature flag to getrandom when building the wasm32-unknown-unknown target. The ahash project does appear to be actively maintained. However, it looks like on average, their releases are a few months apart, and I don't know for sure that the PR will be accepted by the maintainers there.

Thus, in the meantime, I am also proposing a fix that's entirely self-contained within the Loro project. The quick_cache crates includes ahash as a default feature, but it's not actually required for successful operation of the crate. If default features are disabled, quick_cache reverts back to using a different hash mechanism that doesn't trigger the getrandom build error. The PR modifies the kv_store Cargo.toml to use the quick_cache dependency without the standard features when building for wasm32-unknown-unknown. This will likely cause a modest performance regression in the wasm32-unknown-unknown target (but only that target) unless/until things are sorted out with getrandom and ahash upstream. However, that seems a better option than the build breaking when I try to use loro.