### PR TITLE
loro-wasm replaceWithShallow

### DIFF
--- a/crates/loro-internal/src/handler/tree.rs
+++ b/crates/loro-internal/src/handler/tree.rs
@@ -309,7 +309,7 @@ impl TreeHandler {
             }
         };
         txn.apply_local_op(
-            inner.container_idx,
+            inner.container_idx(),
             crate::op::RawOpContent::Tree(Arc::new(TreeOp::Delete { target })),
             EventHint::Tree(smallvec![TreeDiffItem {
                 target,
@@ -409,7 +409,7 @@ impl TreeHandler {
             let inner = self.inner.try_attached_state()?;
 
             txn.apply_local_op(
-                inner.container_idx,
+                inner.container_idx(),
                 crate::op::RawOpContent::Tree(Arc::new(TreeOp::Create {
                     target,
                     parent: parent.tree_id(),
@@ -492,7 +492,7 @@ impl TreeHandler {
         a.with_txn(|txn| {
             let inner = self.inner.try_attached_state()?;
             txn.apply_local_op(
-                inner.container_idx,
+                inner.container_idx(),
                 crate::op::RawOpContent::Tree(Arc::new(TreeOp::Move {
                     target,
                     parent: parent.tree_id(),
@@ -671,7 +671,7 @@ impl TreeHandler {
         position: FractionalIndex,
     ) -> LoroResult<TreeID> {
         txn.apply_local_op(
-            inner.container_idx,
+            inner.container_idx(),
             crate::op::RawOpContent::Tree(Arc::new(TreeOp::Create {
                 target: tree_id,
                 parent: parent.tree_id(),
@@ -702,7 +702,7 @@ impl TreeHandler {
         old_index: usize,
     ) -> LoroResult<()> {
         txn.apply_local_op(
-            inner.container_idx,
+            inner.container_idx(),
             crate::op::RawOpContent::Tree(Arc::new(TreeOp::Move {
                 target,
                 parent: parent.tree_id(),

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -13,7 +13,7 @@ pub mod diff;
 pub mod diff_calc;
 pub mod handler;
 pub mod sync;
-use crate::sync::AtomicBool;
+use crate::sync::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 mod change_meta;
 pub(crate) mod lock;
@@ -162,6 +162,12 @@ pub struct LoroDocInner {
     txn: Arc<LoroMutex<Option<Transaction>>>,
     auto_commit: AtomicBool,
     detached: AtomicBool,
+    /// Generation counter for arena invalidation.
+    ///
+    /// This counter is incremented when the document's internals are swapped
+    /// (e.g., during `replace_with_shallow`). Handlers cache this value alongside
+    /// their `ContainerIdx` to detect when re-resolution is needed.
+    arena_generation: AtomicU64,
     local_update_subs: SubscriberSetWithQueue<(), LocalUpdateCallback, Vec<u8>>,
     peer_id_change_subs: SubscriberSetWithQueue<(), PeerIdUpdateCallback, ID>,
     first_commit_from_peer_subs:

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1605,6 +1605,45 @@ impl DocState {
     pub(crate) fn shallow_root_store(&self) -> Option<&Arc<GcStore>> {
         self.store.shallow_root_store()
     }
+
+    /// Swap the data-related contents of this DocState with another.
+    ///
+    /// This swaps:
+    /// - `frontiers` - the version frontiers
+    /// - `store` - the container store with all container states
+    ///
+    /// This does NOT swap (these stay with the original doc):
+    /// - `peer` - peer ID stays with original doc
+    /// - `arena` - arena contents are swapped separately via `SharedArena::swap_contents_with`
+    /// - `config` - configuration stays with original doc
+    /// - `doc` - weak reference stays with original doc
+    /// - `in_txn`, `changed_idx_in_txn` - transaction state stays
+    /// - `event_recorder` - event recording state is cleared
+    /// - `dead_containers_cache` - cache is cleared
+    ///
+    /// # Panics
+    ///
+    /// Panics if either DocState is in a transaction.
+    pub(crate) fn swap_data_with(&mut self, other: &mut DocState) {
+        assert!(!self.in_txn, "Cannot swap DocState while in transaction");
+        assert!(!other.in_txn, "Cannot swap DocState while in transaction");
+
+        // Swap the data fields
+        std::mem::swap(&mut self.frontiers, &mut other.frontiers);
+        std::mem::swap(&mut self.store, &mut other.store);
+
+        // After swapping stores, update their arena references.
+        // The swapped stores still reference their original arenas, so we need
+        // to point them to the correct (now-swapped) arenas.
+        self.store.set_arena(self.arena.clone());
+        other.store.set_arena(other.arena.clone());
+
+        // Clear caches and event recording state since they're now invalid
+        self.event_recorder = Default::default();
+        self.dead_containers_cache = Default::default();
+        other.event_recorder = Default::default();
+        other.dead_containers_cache = Default::default();
+    }
 }
 
 fn create_state_(idx: ContainerIdx, config: &Configure, peer: u64) -> State {

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1628,6 +1628,10 @@ impl DocState {
         assert!(!self.in_txn, "Cannot swap DocState while in transaction");
         assert!(!other.in_txn, "Cannot swap DocState while in transaction");
 
+        // Remember if we were recording before the swap
+        let self_was_recording = self.is_recording();
+        let other_was_recording = other.is_recording();
+
         // Swap the data fields
         std::mem::swap(&mut self.frontiers, &mut other.frontiers);
         std::mem::swap(&mut self.store, &mut other.store);
@@ -1643,6 +1647,14 @@ impl DocState {
         self.dead_containers_cache = Default::default();
         other.event_recorder = Default::default();
         other.dead_containers_cache = Default::default();
+
+        // Restore recording state if it was active before the swap
+        if self_was_recording {
+            self.start_recording();
+        }
+        if other_was_recording {
+            other.start_recording();
+        }
     }
 }
 

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -243,6 +243,16 @@ impl ContainerStore {
         }
     }
 
+    /// Update the arena reference in this store and its inner store.
+    ///
+    /// This is needed after `DocState::swap_data_with` because the swapped store
+    /// still references the old arena. After swapping, we need to update the arena
+    /// reference to point to the correct (swapped) arena.
+    pub(crate) fn set_arena(&mut self, arena: SharedArena) {
+        self.arena = arena.clone();
+        self.store.set_arena(arena);
+    }
+
     #[allow(unused)]
     fn check_eq_after_parsing(&mut self, other: &mut ContainerStore) {
         for (idx, container) in self.store.iter_all_containers_mut() {

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -263,4 +263,12 @@ impl InnerStore {
         new_store.decode(bytes).unwrap();
         new_store
     }
+
+    /// Update the arena reference in this store.
+    ///
+    /// This is needed after `DocState::swap_data_with` because the swapped store
+    /// still references the old arena.
+    pub(crate) fn set_arena(&mut self, arena: SharedArena) {
+        self.arena = arena;
+    }
 }

--- a/crates/loro-wasm/index.ts
+++ b/crates/loro-wasm/index.ts
@@ -502,6 +502,7 @@ decorateMethods(LoroDoc.prototype, [
   "commit",
   "getCursorPos",
   "revertTo",
+  "replaceWithShallow",
   "export",
   "exportJsonUpdates",
   "exportJsonInIdSpan",

--- a/crates/loro-wasm/tests/replace_with_shallow.test.ts
+++ b/crates/loro-wasm/tests/replace_with_shallow.test.ts
@@ -1,0 +1,851 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LoroDoc,
+  LoroMap,
+  type LoroEventBatch,
+  type TextDiff,
+} from "../bundler/index";
+
+function oneMs(): Promise<void> {
+  return new Promise((r) => setTimeout(r));
+}
+
+describe("replaceWithShallow", () => {
+  describe("basic functionality", () => {
+    it("preserves document data", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      const text = doc.getText("text");
+      text.insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+      text.insert(5, " World");
+      doc.commit();
+
+      const valueBefore = doc.toJSON();
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      expect(doc.toJSON()).toEqual(valueBefore);
+    });
+
+    it("makes document shallow", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      expect(doc.isShallow()).toBe(false);
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      expect(doc.isShallow()).toBe(true);
+    });
+
+    it("returns correct shallowSinceVV", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersBefore = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersBefore);
+
+      const shallowVV = doc.shallowSinceVV().toJSON();
+      // "Hello" is 5 chars (counter 0-4), so shallowSinceVV is 4
+      expect(shallowVV.get("1")).toBe(4);
+    });
+
+    it("preserves peer ID after replace", () => {
+      const doc = new LoroDoc();
+      const originalPeerId = "12345";
+      doc.setPeerId(originalPeerId);
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      expect(doc.peerId).toBe(BigInt(originalPeerId));
+    });
+  });
+
+  describe("continued editing", () => {
+    it("can insert after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+
+      expect(doc.getText("text").toString()).toBe("Hello World!");
+    });
+
+    it("can sync with other documents via snapshot", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+
+      const doc2 = new LoroDoc();
+      doc2.import(doc.export({ mode: "snapshot" }));
+
+      expect(doc2.getText("text").toString()).toBe("Hello World!");
+    });
+
+    it("can create new root container after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      const newMap = doc.getMap("brandNewMap");
+      newMap.set("key", "value");
+      doc.commit();
+
+      expect(doc.getMap("brandNewMap").get("key")).toBe("value");
+    });
+
+    it("can create nested containers after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      const list = doc.getList("newList");
+      const nestedMap = list.insertContainer(0, new LoroMap());
+      nestedMap.set("nested", "value");
+      doc.commit();
+
+      expect(
+        (doc.getList("newList").get(0) as LoroMap).get("nested"),
+      ).toBe("value");
+    });
+
+    it("can create multiple new containers after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getMap("map1").set("a", 1);
+      doc.getMap("map2").set("b", 2);
+      doc.getList("list1").insert(0, "x");
+      doc.getText("text2").insert(0, "y");
+      doc.commit();
+
+      expect(doc.getMap("map1").get("a")).toBe(1);
+      expect(doc.getMap("map2").get("b")).toBe(2);
+      expect(doc.getList("list1").get(0)).toBe("x");
+      expect(doc.getText("text2").toString()).toBe("y");
+    });
+  });
+
+  describe("subscriptions", () => {
+    it("doc-level subscriptions continue to fire", async () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      let called = 0;
+      doc.subscribe(() => {
+        called += 1;
+      });
+
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      await oneMs();
+      expect(called).toBeGreaterThan(0);
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+      await oneMs();
+
+      const countBefore = called;
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+      await oneMs();
+      expect(called).toBeGreaterThan(countBefore);
+    });
+
+    it("container subscriptions continue to fire", async () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      const text = doc.getText("text");
+      let called = 0;
+      text.subscribe(() => {
+        called += 1;
+      });
+
+      text.insert(0, "Hello");
+      doc.commit();
+      await oneMs();
+      expect(called).toBeGreaterThan(0);
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      text.insert(5, " World");
+      doc.commit();
+      await oneMs();
+
+      const countBefore = called;
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+      await oneMs();
+      expect(called).toBeGreaterThan(countBefore);
+    });
+
+    it("unsubscribe works after replace", async () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      let called = 0;
+      const unsub = doc.subscribe(() => {
+        called += 1;
+      });
+
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      await oneMs();
+      expect(called).toBeGreaterThan(0);
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+      await oneMs();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      const countAfterReplace = called;
+      unsub();
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+      await oneMs();
+      expect(called).toBe(countAfterReplace);
+    });
+
+    it("subscribeLocalUpdates continues to work", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      let updateCount = 0;
+      doc.subscribeLocalUpdates(() => {
+        updateCount += 1;
+      });
+
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      expect(updateCount).toBe(1);
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+      expect(updateCount).toBe(2);
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+      expect(updateCount).toBe(3);
+    });
+
+    it("does not trigger LORO_INTERNAL_ERROR", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => { });
+      try {
+        const doc = new LoroDoc();
+        doc.setPeerId("1");
+        doc.subscribe(() => { });
+        doc.getText("text").insert(0, "Hello");
+        doc.commit();
+        const frontiersAfterHello = doc.oplogFrontiers();
+
+        doc.getText("text").insert(5, " World");
+        doc.commit();
+
+        doc.replaceWithShallow(frontiersAfterHello);
+        await Promise.resolve();
+
+        expect(
+          errorSpy.mock.calls.some((args) =>
+            args.some((arg) => String(arg).includes("[LORO_INTERNAL_ERROR]")),
+          ),
+        ).toBe(false);
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("event content is correct after replace", async () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      const text = doc.getText("text");
+      text.insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      text.insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      let lastEvent: LoroEventBatch | undefined;
+      doc.subscribe((event) => {
+        lastEvent = event;
+      });
+
+      text.insert(11, "!");
+      doc.commit();
+      await oneMs();
+
+      expect(lastEvent).toBeDefined();
+      if (!lastEvent) throw new Error('lastEvent should be defined')
+
+      expect(lastEvent.events[0].target).toBe(text.id);
+      expect(lastEvent.events[0].path).toStrictEqual(["text"]);
+      expect(lastEvent.events[0].diff).toStrictEqual({
+        type: "text",
+        diff: [{ retain: 11 }, { insert: "!" }],
+      } as TextDiff);
+    });
+
+    it("container subscription event content is correct after replace", async () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      const text = doc.getText("text");
+      text.insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      text.insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      let lastEvent: LoroEventBatch | undefined;
+      text.subscribe((event) => {
+        lastEvent = event;
+      });
+
+      text.insert(0, "Say: ");
+      doc.commit();
+      await oneMs();
+
+      expect(lastEvent).toBeDefined();
+      if (!lastEvent) throw new Error('lastEvent should be defined')
+
+      expect(lastEvent.events[0].target).toBe(text.id);
+      expect(lastEvent.events[0].diff).toStrictEqual({
+        type: "text",
+        diff: [{ insert: "Say: " }],
+      } as TextDiff);
+    });
+  });
+
+  describe("handlers", () => {
+    it("existing handlers remain valid", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      const text = doc.getText("text");
+      text.insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      text.insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      const textAfter = doc.getText("text");
+      expect(textAfter.toString()).toBe("Hello World");
+
+      textAfter.insert(11, "!");
+      doc.commit();
+      expect(textAfter.toString()).toBe("Hello World!");
+    });
+
+    it("can get new handlers after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      const map = doc.getMap("newMap");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      map.set("key", "value");
+      doc.commit();
+
+      expect(doc.getMap("newMap").get("key")).toBe("value");
+    });
+  });
+
+  describe("versions and frontiers", () => {
+    it("oplogFrontiers returns correct value", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersBefore = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+      const frontiersAfter = doc.oplogFrontiers();
+
+      doc.replaceWithShallow(frontiersBefore);
+
+      const frontiersAfterReplace = doc.oplogFrontiers();
+      expect(frontiersAfterReplace).toEqual(frontiersAfter);
+    });
+
+    it("can checkout within shallow range", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "A");
+      doc.commit();
+      const frontiersA = doc.oplogFrontiers();
+
+      doc.getText("text").insert(1, "B");
+      doc.commit();
+      const frontiersB = doc.oplogFrontiers();
+
+      doc.getText("text").insert(2, "C");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersA);
+
+      doc.checkout(frontiersB);
+      expect(doc.getText("text").toString()).toBe("AB");
+    });
+
+    it("throws when checking out before shallow root", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "A");
+      doc.commit();
+
+      doc.getText("text").insert(1, "B");
+      doc.commit();
+      const frontiersB = doc.oplogFrontiers();
+
+      doc.getText("text").insert(2, "C");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersB);
+
+      expect(() => {
+        doc.checkout([{ peer: "1", counter: 0 }]);
+      }).toThrow();
+    });
+
+    it("revertTo before shallow root throws", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "A");
+      doc.commit();
+      const frontiersA = doc.oplogFrontiers();
+
+      doc.getText("text").insert(1, "B");
+      doc.commit();
+      const frontiersB = doc.oplogFrontiers();
+
+      doc.getText("text").insert(2, "C");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersB);
+
+      expect(() => {
+        doc.revertTo(frontiersA);
+      }).toThrow();
+    });
+
+    it("revertTo within shallow range works", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "A");
+      doc.commit();
+      const frontiersA = doc.oplogFrontiers();
+
+      doc.getText("text").insert(1, "B");
+      doc.commit();
+      const frontiersB = doc.oplogFrontiers();
+
+      doc.getText("text").insert(2, "C");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersA);
+
+      doc.revertTo(frontiersB);
+      doc.commit();
+
+      expect(doc.getText("text").toString()).toBe("AB");
+    });
+  });
+
+  describe("export/import", () => {
+    it("can export snapshot after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      const snapshot = doc.export({ mode: "snapshot" });
+      expect(snapshot.length).toBeGreaterThan(0);
+
+      const doc2 = new LoroDoc();
+      doc2.import(snapshot);
+      expect(doc2.getText("text").toString()).toBe("Hello World");
+    });
+
+    it("can export updates after replace", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+
+      const updates = doc.export({ mode: "update" });
+      expect(updates.length).toBeGreaterThan(0);
+    });
+
+    it("other docs can import from replaced doc", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+
+      const doc2 = new LoroDoc();
+      doc2.import(doc.export({ mode: "snapshot" }));
+      expect(doc2.getText("text").toString()).toBe("Hello World!");
+      expect(doc2.isShallow()).toBe(true);
+    });
+
+    it("export updates from shallow doc can be imported", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " World");
+      doc.commit();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      doc.getText("text").insert(11, "!");
+      doc.commit();
+
+      const updates = doc.export({ mode: "update" });
+
+      const doc2 = new LoroDoc();
+      doc2.setPeerId("2");
+      doc2.import(doc.export({ mode: "snapshot" }));
+
+      expect(doc2.getText("text").toString()).toBe("Hello World!");
+      expect(updates.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("concurrent editing", () => {
+    it("shallow doc syncs with non-shallow doc via snapshot", () => {
+      const doc1 = new LoroDoc();
+      doc1.setPeerId("1");
+      doc1.getText("text").insert(0, "Hello");
+      doc1.commit();
+      const frontiersAfterHello = doc1.oplogFrontiers();
+
+      doc1.getText("text").insert(5, " there");
+      doc1.commit();
+
+      const doc2 = new LoroDoc();
+      doc2.setPeerId("2");
+      doc2.import(doc1.export({ mode: "snapshot" }));
+
+      doc1.replaceWithShallow(frontiersAfterHello);
+
+      doc2.getText("text").insert(11, " World");
+      doc2.commit();
+
+      doc1.import(doc2.export({ mode: "snapshot" }));
+
+      expect(doc1.getText("text").toString()).toBe("Hello there World");
+    });
+
+    it("non-shallow doc syncs with shallow doc via snapshot", () => {
+      const doc1 = new LoroDoc();
+      doc1.setPeerId("1");
+      doc1.getText("text").insert(0, "Hello");
+      doc1.commit();
+      const frontiersAfterHello = doc1.oplogFrontiers();
+
+      doc1.getText("text").insert(5, " there");
+      doc1.commit();
+
+      const doc2 = new LoroDoc();
+      doc2.setPeerId("2");
+      doc2.import(doc1.export({ mode: "snapshot" }));
+
+      doc1.replaceWithShallow(frontiersAfterHello);
+
+      doc1.getText("text").insert(11, " World");
+      doc1.commit();
+
+      doc2.import(doc1.export({ mode: "snapshot" }));
+
+      expect(doc2.getText("text").toString()).toBe("Hello there World");
+    });
+
+    it("two peers edit after one does replaceWithShallow", () => {
+      const doc1 = new LoroDoc();
+      doc1.setPeerId("1");
+      doc1.getText("text").insert(0, "Hello");
+      doc1.commit();
+      const frontiersAfterHello = doc1.oplogFrontiers();
+
+      doc1.getText("text").insert(5, " there");
+      doc1.commit();
+
+      const doc2 = new LoroDoc();
+      doc2.setPeerId("2");
+      doc2.import(doc1.export({ mode: "snapshot" }));
+
+      doc1.replaceWithShallow(frontiersAfterHello);
+
+      doc1.getText("text").insert(11, "!");
+      doc1.commit();
+
+      doc2.getText("text").insert(0, "Say: ");
+      doc2.commit();
+
+      const snapshot1 = doc1.export({ mode: "snapshot" });
+      const snapshot2 = doc2.export({ mode: "snapshot" });
+
+      doc1.import(snapshot2);
+      doc2.import(snapshot1);
+
+      expect(doc1.getText("text").toString()).toBe(
+        doc2.getText("text").toString(),
+      );
+      expect(doc1.getText("text").toString()).toContain("Say:");
+      expect(doc1.getText("text").toString()).toContain("Hello");
+      expect(doc1.getText("text").toString()).toContain("!");
+    });
+
+    it("conflict resolution across shallow boundary", () => {
+      const doc1 = new LoroDoc();
+      doc1.setPeerId("1");
+      doc1.getText("text").insert(0, "AB");
+      doc1.commit();
+      const frontiersAfterAB = doc1.oplogFrontiers();
+
+      doc1.getText("text").insert(2, "CD");
+      doc1.commit();
+
+      const doc2 = new LoroDoc();
+      doc2.setPeerId("2");
+      doc2.import(doc1.export({ mode: "snapshot" }));
+
+      doc1.replaceWithShallow(frontiersAfterAB);
+
+      doc1.getText("text").insert(1, "X");
+      doc1.commit();
+
+      doc2.getText("text").insert(1, "Y");
+      doc2.commit();
+
+      doc1.import(doc2.export({ mode: "snapshot" }));
+      doc2.import(doc1.export({ mode: "snapshot" }));
+
+      expect(doc1.getText("text").toString()).toBe(
+        doc2.getText("text").toString(),
+      );
+      expect(doc1.getText("text").toString()).toContain("X");
+      expect(doc1.getText("text").toString()).toContain("Y");
+    });
+  });
+
+  describe("cloned document independence", () => {
+    it("fork before replace creates independent doc", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+      const frontiersAfterHello = doc.oplogFrontiers();
+
+      doc.getText("text").insert(5, " there");
+      doc.commit();
+
+      const forked = doc.fork();
+
+      doc.replaceWithShallow(frontiersAfterHello);
+
+      expect(doc.isShallow()).toBe(true);
+      expect(forked.isShallow()).toBe(false);
+
+      doc.getText("text").insert(11, " World");
+      doc.commit();
+      expect(forked.getText("text").toString()).toBe("Hello there");
+    });
+  });
+
+  describe("size reduction", () => {
+    it("reduces snapshot size", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+
+      const text = doc.getText("text");
+      text.insert(0, "Initial");
+      doc.commit();
+      const frontiersAfterInitial = doc.oplogFrontiers();
+
+      for (let i = 0; i < 10; i++) {
+        doc.setPeerId(BigInt(i + 1));
+        text.insert(text.length, `Line ${i}\n`);
+        doc.commit();
+      }
+
+      const snapshotSizeBefore = doc.export({ mode: "snapshot" }).length;
+
+      doc.replaceWithShallow(frontiersAfterInitial);
+
+      const snapshotSizeAfter = doc.export({ mode: "snapshot" }).length;
+
+      expect(snapshotSizeAfter).toBeLessThanOrEqual(snapshotSizeBefore);
+      expect(doc.isShallow()).toBe(true);
+    });
+
+    it("trimming at earlier version reduces size more", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+
+      const text = doc.getText("text");
+      text.insert(0, "A");
+      doc.commit();
+      const frontiersEarly = doc.oplogFrontiers();
+
+      for (let i = 0; i < 10; i++) {
+        text.insert(text.length, `${i}`);
+        doc.commit();
+      }
+      const frontiersLate = doc.oplogFrontiers();
+
+      const docEarly = doc.fork();
+      const docLate = doc.fork();
+
+      docEarly.replaceWithShallow(frontiersEarly);
+      docLate.replaceWithShallow(frontiersLate);
+
+      const sizeEarly = docEarly.export({ mode: "snapshot" }).length;
+      const sizeLate = docLate.export({ mode: "snapshot" }).length;
+
+      expect(sizeEarly).toBeLessThanOrEqual(sizeLate);
+      expect(docEarly.toJSON()).toEqual(docLate.toJSON());
+    });
+
+    it("reduces change count with multiple peers", () => {
+      const doc = new LoroDoc();
+
+      const text = doc.getText("text");
+      for (let i = 0; i < 5; i++) {
+        doc.setPeerId(BigInt(i + 1));
+        text.insert(text.length, `${i}`);
+        doc.commit();
+      }
+
+      const changeCountBefore = doc.changeCount();
+      expect(changeCountBefore).toBeGreaterThan(1);
+
+      // Use current frontiers - shallow snapshot collapses all changes into one
+      const frontiers = doc.oplogFrontiers();
+      doc.replaceWithShallow(frontiers);
+
+      const changeCountAfter = doc.changeCount();
+      expect(changeCountAfter).toBe(1);
+      expect(changeCountAfter).toBeLessThan(changeCountBefore);
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws on invalid frontiers", () => {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+      doc.getText("text").insert(0, "Hello");
+      doc.commit();
+
+      expect(() => {
+        doc.replaceWithShallow([{ peer: "999", counter: 100 }]);
+      }).toThrow();
+    });
+  });
+});

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -1642,6 +1642,49 @@ impl LoroDoc {
     pub fn swap_internals_from(&self, other: &LoroDoc) {
         self.doc.swap_internals_from(&other.doc);
     }
+
+    /// Replace the current document state with a shallow snapshot at the given frontiers.
+    ///
+    /// This method trims the history in place, discarding operations before the specified
+    /// frontiers while preserving:
+    /// - Subscriptions and observers
+    /// - Configuration
+    /// - Peer ID
+    /// - All existing references to the document
+    ///
+    /// After this call, the document will only contain history from the specified frontiers
+    /// onwards. The state at the frontiers becomes the new "shallow root" of the document.
+    ///
+    /// # Arguments
+    ///
+    /// * `frontiers` - The version to use as the new shallow root. All history before this
+    ///   version will be discarded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The frontiers are not found in the document's history
+    /// - The document cannot export a shallow snapshot at the given frontiers
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use loro::LoroDoc;
+    ///
+    /// let doc = LoroDoc::new();
+    /// doc.get_text("text").insert(0, "Hello").unwrap();
+    /// doc.commit();
+    ///
+    /// // Trim history to only keep operations from the current state onwards
+    /// let frontiers = doc.oplog_frontiers();
+    /// doc.replace_with_shallow(&frontiers).unwrap();
+    ///
+    /// // The document now has a shallow history starting from `frontiers`
+    /// assert!(doc.is_shallow());
+    /// ```
+    pub fn replace_with_shallow(&self, frontiers: &Frontiers) -> LoroResult<()> {
+        self.doc.replace_with_shallow(frontiers)
+    }
 }
 
 /// It's used to prevent the user from implementing the trait directly.


### PR DESCRIPTION
This PR replaces #896 , a previous attempt at creating a self-trimming shallow checkout.

I've tried to make each commit in this PR a "logical unit" that can be independently reviewed. It is arranged as a series of these 7 commits:

1. `arena-generation-counter` -- Add arena generation counter for handler invalidation
- Adds an atomic `arena_generation: AtomicU64` counter to `LoroDocInner`
- Provides `arena_generation()` getter and `bump_arena_generation()` method
- Enables detection of when document internals have been swapped

2. `handler-generation-caching` -- Handler generation-based caching
- Modifies `BasicHandler` to cache `(ContainerIdx, generation)` tuple
- Handlers automatically detect stale `ContainerIdx` when generation changes
- Re-resolves `ContainerIdx` from arena on cache miss (cold path)

3. `swap-internals-from` -- Add swap_internals_from to swap internal doc data
- Adds `OpLog::swap_data_with()` to swap dag, change_store, history_cache, pending_changes
- Adds `DocState::swap_data_with()` to swap document state
- Adds `SharedArena::swap_contents_with()` to swap arena contents
- Adds `LoroDocInner::swap_internals_from()` to orchestrate the full swap and bump generation

4. `replace-with-shallow-2` -- replace_with_shallow Loro internal function
- Implements `LoroDoc::replace_with_shallow(frontiers)` API
- Exports shallow snapshot at given frontiers → creates temp doc → swaps internals
- Preserves peer ID, configuration, and handlers across the operation
- Adds Rust tests for basic functionality, peer ID preservation, and continued editing

5. `subscription-container-id-storage` -- Subscription container_id storage
- Adds `extract_all()` method to `SubscriberSet` for extracting active subscriptions
- Adds `container_id_map` to `Observer` to track `ContainerIdx → ContainerID` mapping
- Enables looking up stable `ContainerID` when extracting subscriptions keyed by `ContainerIdx`

6. `subscription-preservation` -- Preserve subscriptions on replace_with_shallow
- Adds `extract_subscriptions()` and `restore_subscriptions()` methods to `Observer`
- Preserves `recording_diff` state in `DocState::swap_data_with()` so events fire
- Integrates subscription migration into `replace_with_shallow()` flow
- Adds Rust tests for root and container subscription preservation

7. `loro-wasm-replace-with-shallow` -- Add replaceWithShallow to loro-wasm
- Exposes `replaceWithShallow(frontiers)` method in WASM bindings
- Adds method to `decorateMethods` allowlist for proper event flushing
- Adds comprehensive TypeScript test suite (36 test cases)
