### PR TITLE
Restore tree node to original parent when undoing delete

### DIFF
--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1222,6 +1222,13 @@ impl Handler {
                                 // So when we redo the delete operation, we should check if the target is still alive.
                                 // If it's alive, we should move it back instead of creating new one.
                                 x.move_at_with_target_for_apply_diff(parent, position, target)?;
+                            } else if !x.is_node_unexist(&target) {
+                                // Node exists but is deleted — resurrect it with the same
+                                // TreeID so that all references to the original node remain
+                                // valid (e.g. after undoing a tree.delete()).
+                                x.create_at_with_target_for_apply_diff(
+                                    parent, position, target,
+                                )?;
                             } else {
                                 let new_target = x.__internal__next_tree_id();
                                 if x.create_at_with_target_for_apply_diff(
@@ -1246,8 +1253,8 @@ impl Handler {
                             }
                             remap_tree_id(&mut target, container_remap);
                             // determine if the target is deleted
-                            if x.is_node_unexist(&target) || x.is_node_deleted(&target).unwrap() {
-                                // create the target node, we should use the new target id
+                            if x.is_node_unexist(&target) {
+                                // Node truly doesn't exist — create with a new target id
                                 let new_target = x.__internal__next_tree_id();
                                 if x.create_at_with_target_for_apply_diff(
                                     parent, position, new_target,
@@ -1257,6 +1264,11 @@ impl Handler {
                                         new_target.associated_meta_container(),
                                     );
                                 }
+                            } else if x.is_node_deleted(&target).unwrap() {
+                                // Node exists but is deleted — resurrect with same TreeID
+                                x.create_at_with_target_for_apply_diff(
+                                    parent, position, target,
+                                )?;
                             } else {
                                 x.move_at_with_target_for_apply_diff(parent, position, target)?;
                             }

--- a/crates/loro-wasm/tests/undo.test.ts
+++ b/crates/loro-wasm/tests/undo.test.ts
@@ -395,6 +395,91 @@ describe("undo", () => {
     expect(docJson).toStrictEqual(docJson1);
   });
 
+  test("undo tree delete restores node to original parent", () => {
+    const doc = new LoroDoc();
+    doc.setPeerId(1);
+    const undo = new UndoManager(doc, {
+      mergeInterval: 0,
+      maxUndoSteps: 100,
+    });
+
+    const tree = doc.getTree("1");
+    tree.enableFractionalIndex(3);
+
+    // Create parent and child
+    const parent = tree.createNode(undefined, 0);
+    parent.data.set("title", "parent");
+    const child = tree.createNode(parent.id, 0);
+    child.data.set("title", "child");
+    doc.commit();
+
+    const childId = child.id;
+    const snapshotBefore = doc.toJSON();
+
+    // Delete the child
+    tree.delete(childId);
+    doc.commit();
+
+    // Undo the delete
+    undo.undo();
+
+    // The node should be restored with same identity and correct parent
+    const restored = tree.getNodeByID(childId);
+    expect(restored).toBeDefined();
+    expect(restored!.parent()!.id).toStrictEqual(parent.id); // Should have original parent
+    expect(restored!.data.get("title")).toBe("child"); // Data should be intact
+
+    // Full doc state should match pre-delete state
+    expect(doc.toJSON()).toStrictEqual(snapshotBefore);
+  });
+
+  test("undo tree delete restores subtree parent relationships", () => {
+    const doc = new LoroDoc();
+    doc.setPeerId(1);
+    const undo = new UndoManager(doc, {
+      mergeInterval: 0,
+      maxUndoSteps: 100,
+    });
+
+    const tree = doc.getTree("1");
+    tree.enableFractionalIndex(3);
+
+    // Create a subtree: root -> parent -> child
+    const root = tree.createNode(undefined, 0);
+    root.data.set("title", "root");
+    const parent = tree.createNode(root.id, 0);
+    parent.data.set("title", "parent");
+    const child = tree.createNode(parent.id, 0);
+    child.data.set("title", "child");
+    doc.commit();
+
+    const parentId = parent.id;
+    const childId = child.id;
+    const snapshotBefore = doc.toJSON();
+
+    // Delete the parent (which cascades to child)
+    tree.delete(parentId);
+    doc.commit();
+
+    // Undo the delete
+    undo.undo();
+
+    // Parent should be restored under root
+    const restoredParent = tree.getNodeByID(parentId);
+    expect(restoredParent).toBeDefined();
+    expect(restoredParent!.parent()!.id).toStrictEqual(root.id);
+    expect(restoredParent!.data.get("title")).toBe("parent");
+
+    // Child should be restored under parent
+    const restoredChild = tree.getNodeByID(childId);
+    expect(restoredChild).toBeDefined();
+    expect(restoredChild!.parent()!.id).toStrictEqual(parentId);
+    expect(restoredChild!.data.get("title")).toBe("child");
+
+    // Full doc state should match pre-delete state
+    expect(doc.toJSON()).toStrictEqual(snapshotBefore);
+  });
+
   test("avoid rust recursive use error", () => {
     const doc = new LoroDoc();
     const undoManager = new UndoManager(doc, {});


### PR DESCRIPTION
When undoing a `tree.delete()`, the node's parent relationship was broken: the node ended up at Loro's virtual "Deleted" sentinel instead of its original parent.

Root cause seems to be that in `handler.rs apply_diff()`, the `TreeExternalDiff::Create` branch (triggered during undo) only had two code paths:

1. Node exists and is alive → move it back (correct)
2. Everything else → create a NEW node with a different TreeID (wrong for deleted nodes)

When undoing a delete, the target node exists in the tree state but is marked as deleted. This hit path 2, which created a replacement node with a new TreeID. The original node remained deleted, breaking all existing references, cursors, and bookmarks to the original TreeID.

The fix adds a third branch for both Create and Move diff handling: if the node exists but is deleted, call `create_at_with_target_for_apply_diff` with the SAME target TreeID instead of generating a new one. This resurrects the node in-place, preserving its identity and all associated data containers. The existing `create_at_with_target_for_apply_diff` function already handles the Deleted → alive transition correctly via its `TreeParentId::Deleted` match arm.

The same issue existed in the Move diff branch, where deleted nodes were also incorrectly assigned new TreeIDs — fixed with the same pattern.

Tests added:
- undo tree delete restores node to original parent (single node)
- undo tree delete restores subtree parent relationships (cascading)

(This might be a bit light on tests still though with no redo, no multi-peer, no root-level, no Rust tests. Let me know if you think I should cover more cases.)