### PR TITLE
fix: avoid panic when forking a shallow snapshot

### DIFF
--- a/.changeset/silver-snails-own.md
+++ b/.changeset/silver-snails-own.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Fix a panic when calling `fork()` on a document imported from a `shallow-snapshot`.

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -133,7 +133,10 @@ impl LoroDoc {
 
         let snapshot = self.with_barrier(|| encoding::fast_snapshot::encode_snapshot_inner(self));
         let doc = Self::new();
-        encoding::fast_snapshot::decode_snapshot_inner(snapshot, &doc, Default::default()).unwrap();
+        doc.with_barrier(|| {
+            encoding::fast_snapshot::decode_snapshot_inner(snapshot, &doc, Default::default())
+        })
+        .unwrap();
         doc.set_config(&self.config);
         if self.auto_commit.load(std::sync::atomic::Ordering::Relaxed) {
             doc.start_auto_commit();

--- a/crates/loro-wasm/tests/gc.test.ts
+++ b/crates/loro-wasm/tests/gc.test.ts
@@ -48,5 +48,24 @@ describe("gc", () => {
         gcDoc.import(bytes);
 
         expect(() => gcDoc.import(updates)).toThrow();
-    })
+    });
+
+    it("can fork a shallow snapshot", () => {
+        const docA = new LoroDoc();
+        const listA = docA.getList("list");
+        listA.insert(0, "A");
+        listA.insert(1, "B");
+        listA.insert(2, "C");
+
+        const bytes = docA.export({
+            mode: "shallow-snapshot",
+            frontiers: docA.oplogFrontiers(),
+        });
+
+        const docB = new LoroDoc();
+        docB.import(bytes);
+
+        const docC = docB.fork();
+        expect(docC.toJSON()).toEqual(docB.toJSON());
+    });
 });

--- a/crates/loro/tests/issue.rs
+++ b/crates/loro/tests/issue.rs
@@ -361,6 +361,29 @@ fn fix_get_unknown_cursor_position() {
 }
 
 #[test]
+fn issue_924_fork_shallow_snapshot() {
+    let doc_a = LoroDoc::new();
+    let list_a = doc_a.get_list("list");
+    list_a.insert(0, "A").unwrap();
+    list_a.insert(1, "B").unwrap();
+    list_a.insert(2, "C").unwrap();
+
+    let bytes = doc_a
+        .export(ExportMode::shallow_snapshot(&doc_a.oplog_frontiers()))
+        .unwrap();
+
+    let doc_b = LoroDoc::new();
+    doc_b.import(&bytes).unwrap();
+
+    assert!(doc_b.is_shallow());
+    assert!(!doc_b.is_detached());
+
+    let doc_c = doc_b.fork();
+    assert!(doc_c.is_shallow());
+    assert_eq!(doc_b.get_deep_value(), doc_c.get_deep_value());
+}
+
+#[test]
 fn get_unknown_cursor_position_but_its_in_pending() {
     let doc_0 = LoroDoc::new();
     let list = doc_0


### PR DESCRIPTION
## Summary
- wrap shallow snapshot decode in `fork()` with a barrier so the internal checkout path holds the txn lock
- add Rust and WASM regression tests for the shallow-snapshot -> import -> fork flow
- add a patch changeset for `loro-crdt`

Closes #924.

## Testing
- `cargo test -p loro issue_924_fork_shallow_snapshot -- --nocapture`
- `pnpm -C crates/loro-wasm build-release`