### PR TITLE
[codex] Fix wasm pre-commit aliasing in barrier APIs

### DIFF
--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -671,7 +671,7 @@ impl LoroDoc {
     /// doc.attach();
     /// text.insert(0, "Hi");
     /// ```
-    pub fn attach(&mut self) {
+    pub fn attach(&self) {
         self.doc.attach();
     }
 
@@ -766,7 +766,7 @@ impl LoroDoc {
     /// text.insert(0, "Hi");
     /// ```
     #[wasm_bindgen(js_name = "checkoutToLatest")]
-    pub fn checkout_to_latest(&mut self) -> JsResult<()> {
+    pub fn checkout_to_latest(&self) -> JsResult<()> {
         self.doc.checkout_to_latest();
         Ok(())
     }
@@ -927,7 +927,7 @@ impl LoroDoc {
     /// doc.checkout(frontiers);
     /// console.log(doc.toJSON()); // {"text": ""}
     /// ```
-    pub fn checkout(&mut self, frontiers: Vec<JsID>) -> JsResult<()> {
+    pub fn checkout(&self, frontiers: Vec<JsID>) -> JsResult<()> {
         self.doc.checkout(&ids_to_frontiers(frontiers)?)?;
         Ok(())
     }
@@ -1585,7 +1585,7 @@ impl LoroDoc {
     /// doc2.importBatch([snapshot, updates]);
     /// ```
     #[wasm_bindgen(js_name = "importUpdateBatch")]
-    pub fn import_update_batch(&mut self, data: JsBinaryArray) -> JsResult<JsImportStatus> {
+    pub fn import_update_batch(&self, data: JsBinaryArray) -> JsResult<JsImportStatus> {
         self.import_batch(data)
     }
 
@@ -1606,7 +1606,7 @@ impl LoroDoc {
     /// doc2.importBatch([snapshot, updates]);
     /// ```
     #[wasm_bindgen(js_name = "importBatch")]
-    pub fn import_batch(&mut self, data: JsBinaryArray) -> JsResult<JsImportStatus> {
+    pub fn import_batch(&self, data: JsBinaryArray) -> JsResult<JsImportStatus> {
         let data: Array = data.dyn_into()?;
         let data = data
             .iter()

--- a/crates/loro-wasm/tests/event.test.ts
+++ b/crates/loro-wasm/tests/event.test.ts
@@ -566,6 +566,36 @@ describe("event", () => {
     }
   });
 
+  it("importBatch flushes pending events", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const source = new LoroDoc();
+      source.getText("text").insert(0, "Hello");
+      source.commit();
+      const snapshot = source.export({ mode: "snapshot" });
+
+      const doc = new LoroDoc();
+      let called = 0;
+      doc.subscribe(() => {
+        called += 1;
+      });
+
+      doc.importBatch([snapshot]);
+      await Promise.resolve();
+
+      expect(called).toBeGreaterThan(0);
+      expect(
+        errorSpy.mock.calls.some((args) =>
+          args.some((arg) =>
+            String(arg).includes("[LORO_INTERNAL_ERROR] Event not called"),
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("setDetachedEditing flushes pending events", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -671,6 +701,77 @@ it("subscribe pre commit", () => {
   doc.getList("list").insert(0, 100);
   doc.commit();
   expect(doc.getChangeAt({ peer: "0", counter: 0 }).message).toBe("test");
+});
+
+it("importBatch can re-enter doc in pre-commit callback", () => {
+  const remote = new LoroDoc();
+  remote.getText("remote").insert(0, "remote");
+  remote.commit();
+  const snapshot = remote.export({ mode: "snapshot" });
+
+  const doc = new LoroDoc();
+  doc.setPeerId(1);
+  doc.getText("local").insert(0, "local");
+
+  let callbackError: unknown;
+  let peerIdStr: string | undefined;
+  doc.subscribePreCommit(() => {
+    try {
+      peerIdStr = doc.peerIdStr;
+    } catch (error) {
+      callbackError = error;
+    }
+  });
+
+  doc.importBatch([snapshot]);
+
+  expect(callbackError).toBeUndefined();
+  expect(peerIdStr).toBe("1");
+});
+
+it("checkoutToLatest can re-enter doc in pre-commit callback", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId(1);
+  doc.getText("local").insert(0, "local");
+
+  let callbackError: unknown;
+  let peerIdStr: string | undefined;
+  doc.subscribePreCommit(() => {
+    try {
+      peerIdStr = doc.peerIdStr;
+    } catch (error) {
+      callbackError = error;
+    }
+  });
+
+  doc.checkoutToLatest();
+
+  expect(callbackError).toBeUndefined();
+  expect(peerIdStr).toBe("1");
+});
+
+it("attach can re-enter doc in pre-commit callback", () => {
+  const doc = new LoroDoc();
+  doc.setPeerId(1);
+  doc.detach();
+  doc.setDetachedEditing(true);
+  doc.getText("local").insert(0, "local");
+
+  let callbackError: unknown;
+  let peerIdStr: string | undefined;
+  doc.subscribePreCommit(() => {
+    try {
+      peerIdStr = doc.peerIdStr;
+    } catch (error) {
+      callbackError = error;
+    }
+  });
+
+  doc.attach();
+
+  expect(callbackError).toBeUndefined();
+  expect(typeof peerIdStr).toBe("string");
+  expect(peerIdStr).not.toBe("");
 });
 
 function oneMs(): Promise<void> {


### PR DESCRIPTION
## Summary

This fixes a `loro-wasm` re-entrancy issue on pre-commit/barrier paths that could surface as:

`Error: recursive use of an object detected which would lead to unsafe aliasing in rust`

`importBatch` was already present in the JS-side pending-event decoration allowlist. The actual problem was that several WASM-exposed `LoroDoc` methods still took `&mut self`, even though the underlying Rust APIs only require `&self` and can synchronously re-enter JS through `subscribePreCommit`.

## What Changed

- changed `attach`, `checkoutToLatest`, `checkout`, `importUpdateBatch`, and `importBatch` to take `&self` in the wasm binding layer
- added regression coverage for `importBatch` pending-event flushing
- added re-entrancy tests for `importBatch`, `checkoutToLatest`, and `attach` when a `subscribePreCommit` callback touches the same `doc`

## Root Cause

The JS decoration list was not the missing piece here.

`importBatch` is already decorated on the JS side, so pending events are flushed correctly after the call returns. The unsafe aliasing error comes from a different path: `subscribePreCommit` invokes JS synchronously before the outer WASM call finishes. If that outer binding holds a mutable wasm-bindgen borrow, touching the same document again from the callback can trigger the recursive aliasing error.

## Impact

This makes the affected `loro-wasm` APIs safe to re-enter from pre-commit callbacks and prevents false attribution of the bug to the pending-event decoration list.

## Validation

- `pnpm --dir crates/loro-wasm test`