### PR TITLE
fix: Disable wasm reference-types for compatibility with devices like iOS 16

### DIFF
--- a/.changeset/rude-items-knock.md
+++ b/.changeset/rude-items-knock.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": minor
+---
+
+Disable WebAssembly reference-types in the wasm build for compatibility with devices like iOS 16.

--- a/crates/loro-wasm-tools/src/main.rs
+++ b/crates/loro-wasm-tools/src/main.rs
@@ -43,6 +43,15 @@ enum Command {
         /// Output Wasm file path.
         output: PathBuf,
     },
+    /// Strip named custom sections from a Wasm binary.
+    StripCustom {
+        /// Input Wasm file to strip.
+        input: PathBuf,
+        /// Output Wasm file path.
+        output: PathBuf,
+        /// Custom section names to remove.
+        names: Vec<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -56,6 +65,11 @@ fn main() -> Result<()> {
             url,
         } => split_debug(input, output, debug_output, url),
         Command::StripDebug { input, output } => strip_debug(input, output),
+        Command::StripCustom {
+            input,
+            output,
+            names,
+        } => strip_custom(input, output, names),
     }
 }
 
@@ -153,6 +167,74 @@ fn strip_debug(input: PathBuf, output: PathBuf) -> Result<()> {
         return Ok(());
     }
 
+    let stripped = strip_custom_sections(&bytes, &remove_ranges)?;
+
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+    fs::write(&output, &stripped)
+        .with_context(|| format!("failed to write stripped Wasm {}", output.display()))?;
+
+    Ok(())
+}
+
+fn strip_custom(input: PathBuf, output: PathBuf, names: Vec<String>) -> Result<()> {
+    ensure!(
+        !names.is_empty(),
+        "at least one custom section name must be provided"
+    );
+
+    let bytes = fs::read(&input)
+        .with_context(|| format!("failed to read Wasm module {}", input.display()))?;
+    ensure!(
+        bytes.starts_with(&[0x00, 0x61, 0x73, 0x6d]),
+        "input {} is not a valid WebAssembly binary",
+        input.display()
+    );
+
+    let mut remove_ranges = Vec::new();
+    for payload in WasmParser::new(0).parse_all(&bytes) {
+        let payload = payload.context("failed to parse Wasm payload")?;
+        if let Payload::CustomSection(section) = payload {
+            let section_name = section.name();
+            if !names.iter().any(|name| name == section_name) {
+                continue;
+            }
+
+            let payload_range = section.range();
+            let payload_len = payload_range
+                .end
+                .checked_sub(payload_range.start)
+                .context("custom section range underflow")?;
+            let mut leb_len = 1usize;
+            let mut tmp = payload_len;
+            while tmp >= 0x80 {
+                leb_len += 1;
+                tmp >>= 7;
+            }
+            let header_len = 1 + leb_len;
+            let start = payload_range
+                .start
+                .checked_sub(header_len)
+                .context("custom section header underflow")?;
+            remove_ranges.push(start..payload_range.end);
+        }
+    }
+
+    if remove_ranges.is_empty() {
+        if input != output {
+            if let Some(parent) = output.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("failed to create directory {}", parent.display()))?;
+            }
+            fs::write(&output, &bytes)
+                .with_context(|| format!("failed to write Wasm {}", output.display()))?;
+        }
+        return Ok(());
+    }
+
+    remove_ranges.sort_by_key(|r| r.start);
     let stripped = strip_custom_sections(&bytes, &remove_ranges)?;
 
     if let Some(parent) = output.parent() {

--- a/crates/loro-wasm/scripts/build.ts
+++ b/crates/loro-wasm/scripts/build.ts
@@ -26,6 +26,12 @@ const TARGETS = ["bundler", "nodejs", "web"];
 const startTime = performance.now();
 const LoroWasmDir = path.resolve(__dirname, "..");
 const WorkspaceCargoToml = path.resolve(__dirname, "../../../Cargo.toml");
+const RawWasmPath = path.resolve(
+  LoroWasmDir,
+  "../../target/wasm32-unknown-unknown",
+  profileDir,
+  "loro_wasm.wasm",
+);
 const wasmPackageJson = JSON.parse(
   await Deno.readTextFile(path.resolve(LoroWasmDir, "package.json")),
 );
@@ -51,6 +57,7 @@ console.log({
 });
 async function build() {
   await cargoBuild();
+  await stripReferenceTypesFeatureHint();
   const target = Deno.args[1];
   if (target != null) {
     if (!TARGETS.includes(target)) {
@@ -218,7 +225,7 @@ async function buildTarget(target: string) {
 
   // TODO: polyfill FinalizationRegistry
   const cmd =
-    `wasm-bindgen --keep-debug --weak-refs --target ${target} --out-dir ${target} ../../target/wasm32-unknown-unknown/${profileDir}/loro_wasm.wasm`;
+    `wasm-bindgen --keep-debug --weak-refs --target ${target} --out-dir ${target} ${RawWasmPath}`;
   console.log(">", cmd);
   await Deno.run({ cmd: cmd.split(" "), cwd: LoroWasmDir }).status();
   console.log();
@@ -248,6 +255,18 @@ async function buildTarget(target: string) {
       patch,
     );
   }
+}
+
+async function stripReferenceTypesFeatureHint() {
+  // wasm-bindgen 0.2.100 uses the `target_features` custom section to choose
+  // externref table glue. Safari 16.0-16.3 lacks WebAssembly reference-types,
+  // so strip the feature hint and let wasm-bindgen fall back to slab handles.
+  await runWasmTools([
+    "strip-custom",
+    RawWasmPath,
+    RawWasmPath,
+    "target_features",
+  ]);
 }
 
 const resolveSourcemapReference = (target: string): string => {

--- a/crates/loro-wasm/scripts/bundler_patch.js
+++ b/crates/loro-wasm/scripts/bundler_patch.js
@@ -1,11 +1,11 @@
-import * as rawWasm from './loro_wasm_bg.wasm';
-import * as imports from './loro_wasm_bg.js';
+import * as rawWasm from "./loro_wasm_bg.wasm";
+import * as imports from "./loro_wasm_bg.js";
 
 // Normalize how bundlers expose the wasm module/exports.
 const toModuleOrExports = (wasm) => {
   if (!wasm) return wasm;
   if (wasm instanceof WebAssembly.Module) return wasm;
-  if (typeof wasm === 'object' && 'default' in wasm) {
+  if (typeof wasm === "object" && "default" in wasm) {
     return wasm.default ?? wasm;
   }
   // rsbuild doesn't provide a default export when importing wasm.
@@ -14,17 +14,14 @@ const toModuleOrExports = (wasm) => {
 
 const wasmModuleOrExports = toModuleOrExports(rawWasm);
 
-// Helper: ensure we end up with exports + optionally run externref init.
+// Helper: ensure we end up with exports and run the start hook when needed.
 const finalize = (exports) => {
   imports.__wbg_set_wasm(exports);
-  if (typeof imports.__wbindgen_init_externref_table === 'function') {
-    imports.__wbindgen_init_externref_table();
-  }
   tryStart(imports);
 };
 
 function tryStart(imports) {
-  if (typeof imports.__wbindgen_start === 'function') {
+  if (typeof imports.__wbindgen_start === "function") {
     // Some bundlers require explicit start invocation.
     imports.__wbindgen_start();
   }
@@ -35,62 +32,56 @@ if (wasmModuleOrExports && wasmModuleOrExports.__wbindgen_start) {
   // Without this patch, Cloudflare Worker would raise issue like: "Uncaught TypeError: wasm2.__wbindgen_start is not a function"
   // Already the initialized exports object (Cloudflare Workers path).
   finalize(wasmModuleOrExports);
-} else if ('Bun' in globalThis) {
-  // Bun's wasm runtime (1.3.0 as of Oct 2025) sometimes reads externref slot 1
-  // (reserved for booleans by wasm-bindgen) as the global object, causing APIs
-  // like `LoroText.toDelta()` to return cyclic structures. Re-running the
-  // wasm-bindgen externref table initializer after instantiation resets the
-  // table so booleans stay primitives and avoids the infinite recursion seen in
-  // Bun tests during `pnpm release-wasm`.
+} else if ("Bun" in globalThis) {
+  // Bun may expose the imported wasm as a file path. Instantiate it directly so
+  // the shared finalization path receives WebAssembly exports.
   let instance;
   if (wasmModuleOrExports instanceof WebAssembly.Module) {
     ({ instance } = await WebAssembly.instantiate(wasmModuleOrExports, {
-      './loro_wasm_bg.js': imports,
+      "./loro_wasm_bg.js": imports,
     }));
   } else {
     const url = Bun.pathToFileURL(wasmModuleOrExports);
     ({ instance } = await WebAssembly.instantiateStreaming(fetch(url), {
-      './loro_wasm_bg.js': imports,
+      "./loro_wasm_bg.js": imports,
     }));
   }
   finalize(instance.exports);
 } else {
   // Browser/node-like bundlers: either we already have exports, or a Module/URL.
-  const wkmod =
-    wasmModuleOrExports instanceof WebAssembly.Module
-      ? wasmModuleOrExports
-      : await import('./loro_wasm_bg.wasm');
-  const module =
-    wkmod instanceof WebAssembly.Module
-      ? wkmod
-      : (wkmod && wkmod.default) || wkmod;
+  const wkmod = wasmModuleOrExports instanceof WebAssembly.Module
+    ? wasmModuleOrExports
+    : await import("./loro_wasm_bg.wasm");
+  const module = wkmod instanceof WebAssembly.Module
+    ? wkmod
+    : (wkmod && wkmod.default) || wkmod;
   let instance;
   if (module instanceof WebAssembly.Instance) {
     instance = module;
   } else if (module instanceof WebAssembly.Module) {
     instance = await WebAssembly.instantiate(module, {
-      './loro_wasm_bg.js': imports,
+      "./loro_wasm_bg.js": imports,
     });
   } else if (module instanceof ArrayBuffer || ArrayBuffer.isView(module)) {
     const { instance: inst } = await WebAssembly.instantiate(module, {
-      './loro_wasm_bg.js': imports,
+      "./loro_wasm_bg.js": imports,
     });
     instance = inst;
-  } else if (typeof module === 'string' || module instanceof URL) {
+  } else if (typeof module === "string" || module instanceof URL) {
     const response = await fetch(module);
     const { instance: inst } = await WebAssembly.instantiateStreaming(
       response,
       {
-        './loro_wasm_bg.js': imports,
-      }
+        "./loro_wasm_bg.js": imports,
+      },
     );
     instance = inst;
   } else {
-    console.error('Unsupported wasm import type:', module);
-    throw new Error('Unsupported wasm import type: ' + typeof module);
+    console.error("Unsupported wasm import type:", module);
+    throw new Error("Unsupported wasm import type: " + typeof module);
   }
 
   finalize(instance.exports ?? instance);
 }
 
-export * from './loro_wasm_bg.js';
+export * from "./loro_wasm_bg.js";


### PR DESCRIPTION
## Summary

- Strip the `target_features` custom section from the raw `loro_wasm.wasm` before running `wasm-bindgen`, so generated JS falls back to slab-based object handles instead of externref table glue.
- Add a reusable `strip-custom` command to `loro-wasm-tools` and use it in the `loro-wasm` build pipeline.
- Remove the old bundler externref table initialization patch, which is no longer needed after forcing slab mode.

## Root Cause

`wasm-bindgen` 0.2.100 reads the wasm `target_features` custom section. When it sees `+reference-types`, it emits externref table glue. Safari 16.0-16.3 lacks WebAssembly reference-types support, which can surface as an out-of-bounds table access trap.

## Validation

- `git diff --check`
- `cargo check -p loro-wasm-tools`
- `pnpm -C crates/loro-wasm build-release`
- Verified release artifacts contain 0 matches for `externref`, `addToExternrefTable`, and `__wbindgen_init_externref_table` across `bundler`, `nodejs`, `web`, and `base64` outputs.
- Verified release wasm binaries contain 0 matches for `target_features` and `reference-types`.