### PR TITLE
fix: exclude wasi from js-specific build deps

### DIFF
--- a/.changeset/tough-eggs-impress.md
+++ b/.changeset/tough-eggs-impress.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Fix WASI builds by using native calls instead of js-only wasm32 bindings (`Date.now`, `getrandom`)

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -64,11 +64,11 @@ loom = { version = "0.7", features = ["checkpoint"] }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies.getrandom]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten"), not(target_os = "wasi")))'.dependencies.getrandom]
 version = "0.2.15"
 features = ["js"]
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten"), not(target_os = "wasi")))'.dependencies]
 wasm-bindgen = "0.2.100"
 
 [dev-dependencies]

--- a/crates/loro-internal/src/change.rs
+++ b/crates/loro-internal/src/change.rs
@@ -284,7 +284,11 @@ impl Change {
 
 /// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
 /// It is the number of milliseconds that have elapsed since 00:00:00 UTC on 1 January 1970.
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    target_os = "emscripten",
+    target_os = "wasi"
+))]
 pub(crate) fn get_sys_timestamp() -> f64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -296,7 +300,11 @@ pub(crate) fn get_sys_timestamp() -> f64 {
 
 /// [Unix time](https://en.wikipedia.org/wiki/Unix_time)
 /// It is the number of milliseconds that have elapsed since 00:00:00 UTC on 1 January 1970.
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(
+    target_arch = "wasm32",
+    not(target_os = "emscripten"),
+    not(target_os = "wasi")
+))]
 pub fn get_sys_timestamp() -> f64 {
     use wasm_bindgen::prelude::wasm_bindgen;
     #[wasm_bindgen]


### PR DESCRIPTION
Problem: `loro-internal` doesn't compile to WASI due to JS-specific timestamp bindings (using `Date`), along with a JS feature for `getrandom`. In my case, it prevents my Loro-based project from running via WASI/WIT.

Seems like a similar issue has come up before for Emscripten in https://github.com/loro-dev/loro/pull/966. This PR does the same fix as for Emscripten, relying on native/WASI capabilities instead. This also fixes the build-side of the existing https://github.com/loro-dev/loro/issues/881.

First time contributing to this project, so LMK if more tests should be run. I've done the testing below (heavily inspired by https://github.com/loro-dev/loro/pull/966).

### Compile / target checks

- [x] `cargo check -p loro-internal`
- [x] `cargo check -p loro-internal --target wasm32-unknown-emscripten`
- [x] `cargo check -p loro --target wasm32-unknown-emscripten`
- [x] `cargo check -p loro-internal --target wasm32-wasip1`
- [x] `cargo check -p loro --target wasm32-wasip1`
- [x] `cargo check -p loro --target wasm32-wasip2`
- [x] `cargo check -p loro-internal --target wasm32-unknown-unknown`
- [x] `cargo check -p loro-internal --target wasm32-wasip2`

### Dependency isolation

- [x] `cargo tree -p loro --target wasm32-unknown-emscripten -e normal -i wasm-bindgen`, no wasm-bindgen
- [x] `cargo tree -p loro-internal --target wasm32-wasip1 -e normal -i wasm-bindgen`, no wasm-bindgen
- [x] `cargo tree -p loro-internal --target wasm32-unknown-unknown -e normal -i wasm-bindgen`, has wasm-bindgen present

### Browser WASM package pipeline (from `crates/loro-wasm`)

- [x] `pnpm exec deno run -A ./scripts/build.ts release`
- [x] `pnpm exec rollup -c`
- [x] `pnpm exec deno run -A ./scripts/post-rollup.ts`
- [x] `node --expose-gc ./node_modules/vitest/vitest.mjs run`
- [x] `pnpm exec tsc --noEmit`
- [x] `deno test -A` from `crates/loro-wasm/deno_tests`

### Timestamp smoke tests

- [x] Node CJS smoke via `crates/loro-wasm/nodejs/index.js`
- [x] Deno smoke via `crates/loro-wasm/web/index.js`

