### PR TITLE
feat: add mergeable containers (#759)

### DIFF
--- a/.changeset/mergeable-containers.md
+++ b/.changeset/mergeable-containers.md
@@ -1,0 +1,6 @@
+---
+"loro-crdt": minor
+"loro-crdt-map": minor
+---
+
+Add mergeable child containers: child containers created under a map key that converge across peers on concurrent first-write instead of forking. Exposed as `getMergeable{Counter,Map,List,MovableList,Text,Tree}` on `LoroMap`. A mergeable child lives at a deterministic `ContainerID` derived from `(parent, key, kind)`, and its visibility is driven by the discriminator the parent map stores at the key, so deletes and type conflicts resolve through the map's regular LWW.

--- a/crates/examples/benches/bench_text.rs
+++ b/crates/examples/benches/bench_text.rs
@@ -7,7 +7,7 @@ use std::{
 use bench_utils::TextAction;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use dev_utils::ByteSize;
-use loro::LoroDoc;
+use loro::{LoroDoc, LoroList, LoroMap, LoroText, ToJson};
 use rand::Rng;
 
 fn bench_text(c: &mut Criterion) {
@@ -197,6 +197,111 @@ fn bench_update_text(c: &mut Criterion) {
     });
 }
 
+fn bench_large_snapshot_decode(c: &mut Criterion) {
+    let snapshot: OnceCell<Vec<u8>> = OnceCell::new();
+    let mut g = c.benchmark_group("large_snapshot_decode");
+    g.sample_size(10);
+
+    g.bench_function("mixed doc import snapshot", |b| {
+        b.iter_batched(
+            || large_doc_snapshot(&snapshot),
+            |snapshot| {
+                let doc = LoroDoc::new();
+                doc.import(snapshot).unwrap();
+                black_box(doc);
+            },
+            criterion::BatchSize::LargeInput,
+        )
+    });
+
+    g.bench_function("mixed doc from_snapshot", |b| {
+        b.iter_batched(
+            || large_doc_snapshot(&snapshot),
+            |snapshot| {
+                let doc = LoroDoc::from_snapshot(snapshot).unwrap();
+                black_box(doc);
+            },
+            criterion::BatchSize::LargeInput,
+        )
+    });
+
+    g.bench_function("mixed doc from_snapshot + toJSON", |b| {
+        b.iter_batched(
+            || large_doc_snapshot(&snapshot),
+            |snapshot| {
+                let doc = LoroDoc::from_snapshot(snapshot).unwrap();
+                black_box(doc.get_deep_value().to_json_value());
+            },
+            criterion::BatchSize::LargeInput,
+        )
+    });
+}
+
+fn large_doc_snapshot(snapshot: &OnceCell<Vec<u8>>) -> &[u8] {
+    snapshot
+        .get_or_init(|| {
+            let doc = build_large_mixed_doc();
+            let snapshot = doc.export(loro::ExportMode::Snapshot).unwrap();
+            println!(
+                "large mixed doc snapshot size: {:?}",
+                ByteSize(snapshot.len())
+            );
+            snapshot
+        })
+        .as_slice()
+}
+
+fn build_large_mixed_doc() -> LoroDoc {
+    const SECTIONS: usize = 256;
+    const ITEMS_PER_SECTION: usize = 64;
+    const BODY_REPEAT: usize = 8;
+
+    let doc = LoroDoc::new();
+    let root = doc.get_map("workspace");
+    root.insert("title", "large snapshot decode fixture")
+        .unwrap();
+    root.insert("section_count", SECTIONS as i64).unwrap();
+    let sections = root.insert_container("sections", LoroList::new()).unwrap();
+
+    for section_idx in 0..SECTIONS {
+        let section = sections.push_container(LoroMap::new()).unwrap();
+        section
+            .insert("id", format!("section-{section_idx:04}"))
+            .unwrap();
+        section.insert("archived", section_idx % 11 == 0).unwrap();
+        let body = section.insert_container("body", LoroText::new()).unwrap();
+        body.insert(0, &large_body(section_idx, BODY_REPEAT))
+            .unwrap();
+
+        let items = section.insert_container("items", LoroList::new()).unwrap();
+        for item_idx in 0..ITEMS_PER_SECTION {
+            let item = items.push_container(LoroMap::new()).unwrap();
+            item.insert("id", format!("{section_idx:04}-{item_idx:02}"))
+                .unwrap();
+            item.insert("rank", item_idx as i64).unwrap();
+            item.insert("done", (section_idx + item_idx) % 7 == 0)
+                .unwrap();
+            item.insert(
+                "label",
+                format!("section {section_idx} item {item_idx} repeated metadata"),
+            )
+            .unwrap();
+        }
+    }
+
+    doc
+}
+
+fn large_body(section_idx: usize, repeat: usize) -> String {
+    let mut body = String::new();
+    for i in 0..repeat {
+        body.push_str(&format!(
+            "section={section_idx}; paragraph={i}; lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+        ));
+    }
+    body
+}
+
 fn apply_text_actions(actions: &[bench_utils::TextAction], n: usize) -> LoroDoc {
     let loro = LoroDoc::new();
     let text = loro.get_text("text");
@@ -209,5 +314,10 @@ fn apply_text_actions(actions: &[bench_utils::TextAction], n: usize) -> LoroDoc 
     loro
 }
 
-criterion_group!(benches, bench_text, bench_update_text);
+criterion_group!(
+    benches,
+    bench_text,
+    bench_update_text,
+    bench_large_snapshot_decode
+);
 criterion_main!(benches);

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -9,6 +9,12 @@ release = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+# Enable the mergeable-container fuzz surface (MapAction::GetMergeable etc.).
+# Off by default so the saved-seed corpus decodes identically to today.
+mergeable = []
+
 [dependencies]
 loro = { path = "../loro", features = ["counter", "logging"], package = "loro" }
 loro-without-counter = { git = "https://github.com/loro-dev/loro.git", rev = "c897c346d9fd46dccf44de7ef4e72799fa9c9769", package = "loro", default-features = false }

--- a/crates/fuzz/fuzz/Cargo.toml
+++ b/crates/fuzz/fuzz/Cargo.toml
@@ -13,6 +13,9 @@ libfuzzer-sys = "0.4"
 [dependencies.fuzz]
 path = ".."
 
+[features]
+mergeable = ["fuzz/mergeable"]
+
 [dependencies.loro]
 path = "../../loro"
 
@@ -87,5 +90,11 @@ doc = false
 [[bin]]
 name = "random_import"
 path = "fuzz_targets/random_import.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "mergeable"
+path = "fuzz_targets/mergeable.rs"
 test = false
 doc = false

--- a/crates/fuzz/fuzz/fuzz_targets/mergeable.rs
+++ b/crates/fuzz/fuzz/fuzz_targets/mergeable.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use fuzz::{test_multi_sites, Action, FuzzTarget};
+
+fuzz_target!(|actions: Vec<Action>| {
+    test_multi_sites(5, vec![FuzzTarget::All], &mut actions.clone())
+});

--- a/crates/fuzz/src/container/counter.rs
+++ b/crates/fuzz/src/container/counter.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use loro::{
-    event::Diff, Container, ContainerID, ContainerType, ExportMode, LoroCounter, LoroDoc, LoroValue,
+    event::Diff, Container, ContainerID, ContainerTrait, ContainerType, ExportMode, LoroCounter,
+    LoroDoc, LoroValue,
 };
 use tracing::debug_span;
 
@@ -152,6 +153,11 @@ impl ActorTrait for CounterActor {
     }
 
     fn add_new_container(&mut self, container: Container) {
+        // Dedup by cid so mergeable children don't bias the dispatch index.
+        let cid = container.id();
+        if self.containers.iter().any(|c| c.id() == cid) {
+            return;
+        }
         self.containers.push(container.into_counter().unwrap());
     }
 }

--- a/crates/fuzz/src/container/list.rs
+++ b/crates/fuzz/src/container/list.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use loro::{Container, ContainerID, ContainerType, LoroDoc, LoroList};
+use loro::{Container, ContainerID, ContainerTrait, ContainerType, LoroDoc, LoroList};
 use tracing::debug_span;
 
 use crate::{
@@ -82,6 +82,11 @@ impl ActorTrait for ListActor {
     }
 
     fn add_new_container(&mut self, container: Container) {
+        // Dedup by cid so mergeable children don't bias the dispatch index.
+        let cid = container.id();
+        if self.containers.iter().any(|c| c.id() == cid) {
+            return;
+        }
         self.containers.push(container.into_list().unwrap());
     }
 }

--- a/crates/fuzz/src/container/map.rs
+++ b/crates/fuzz/src/container/map.rs
@@ -97,7 +97,7 @@ pub enum MapAction {
     },
     Clear,
     #[cfg(feature = "mergeable")]
-    GetMergeable {
+    EnsureMergeable {
         key: u8,
         kind: ContainerType,
     },
@@ -116,9 +116,9 @@ impl Debug for MapAction {
             MapAction::Delete { key } => write!(f, "MapAction::Delete {{ key: {} }}", key),
             MapAction::Clear => write!(f, "MapAction::Clear"),
             #[cfg(feature = "mergeable")]
-            MapAction::GetMergeable { key, kind } => write!(
+            MapAction::EnsureMergeable { key, kind } => write!(
                 f,
-                "MapAction::GetMergeable {{ key: {}, kind: {:?} }}",
+                "MapAction::EnsureMergeable {{ key: {}, kind: {:?} }}",
                 key, kind
             ),
         }
@@ -132,7 +132,7 @@ impl MapAction {
             MapAction::Delete { key, .. } => *key,
             MapAction::Clear => 0,
             #[cfg(feature = "mergeable")]
-            MapAction::GetMergeable { key, .. } => *key,
+            MapAction::EnsureMergeable { key, .. } => *key,
         }
     }
 
@@ -142,7 +142,7 @@ impl MapAction {
             MapAction::Delete { .. } => "null".to_string(),
             MapAction::Clear => "null".to_string(),
             #[cfg(feature = "mergeable")]
-            MapAction::GetMergeable { kind, .. } => format!("mergeable {:?}", kind),
+            MapAction::EnsureMergeable { kind, .. } => format!("mergeable {:?}", kind),
         }
     }
 }
@@ -163,7 +163,7 @@ impl FromGenericAction for MapAction {
             },
             2 => MapAction::Clear,
             #[cfg(feature = "mergeable")]
-            3 => MapAction::GetMergeable {
+            3 => MapAction::EnsureMergeable {
                 key: (action.key % 256) as u8,
                 kind: match action.value {
                     FuzzValue::Container(c) => c,
@@ -204,26 +204,26 @@ impl Actionable for MapAction {
                 None
             }
             #[cfg(feature = "mergeable")]
-            MapAction::GetMergeable { key, kind } => {
+            MapAction::EnsureMergeable { key, kind } => {
                 let key = &key.to_string();
                 // Type-conflict rejection (`ArgErr`) is an expected outcome — swallow it
                 // here rather than via `unwrap` so unrelated `ArgErr` sources still panic.
                 let result = match kind {
-                    ContainerType::Map => handler.get_mergeable_map(key).map(|m| m.to_container()),
+                    ContainerType::Map => handler.ensure_mergeable_map(key).map(|m| m.to_container()),
                     ContainerType::List => {
-                        handler.get_mergeable_list(key).map(|l| l.to_container())
+                        handler.ensure_mergeable_list(key).map(|l| l.to_container())
                     }
                     ContainerType::MovableList => handler
-                        .get_mergeable_movable_list(key)
+                        .ensure_mergeable_movable_list(key)
                         .map(|l| l.to_container()),
                     ContainerType::Text => {
-                        handler.get_mergeable_text(key).map(|t| t.to_container())
+                        handler.ensure_mergeable_text(key).map(|t| t.to_container())
                     }
                     ContainerType::Tree => {
-                        handler.get_mergeable_tree(key).map(|t| t.to_container())
+                        handler.ensure_mergeable_tree(key).map(|t| t.to_container())
                     }
                     ContainerType::Counter => {
-                        handler.get_mergeable_counter(key).map(|c| c.to_container())
+                        handler.ensure_mergeable_counter(key).map(|c| c.to_container())
                     }
                     ContainerType::Unknown(_) => return None,
                 };
@@ -245,7 +245,7 @@ impl Actionable for MapAction {
             MapAction::Delete { .. } => None,
             MapAction::Clear => None,
             #[cfg(feature = "mergeable")]
-            MapAction::GetMergeable { kind, .. } => Some(kind),
+            MapAction::EnsureMergeable { kind, .. } => Some(kind),
         }
     }
 

--- a/crates/fuzz/src/container/map.rs
+++ b/crates/fuzz/src/container/map.rs
@@ -3,7 +3,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use loro::{Container, ContainerID, ContainerType, LoroDoc, LoroMap, LoroValue};
+#[cfg(feature = "mergeable")]
+use loro::LoroError;
+use loro::{Container, ContainerID, ContainerTrait, ContainerType, LoroDoc, LoroMap, LoroValue};
 
 use crate::{
     actions::{Actionable, FromGenericAction, GenericAction},
@@ -60,6 +62,11 @@ impl MapActor {
 
 impl ActorTrait for MapActor {
     fn add_new_container(&mut self, container: Container) {
+        // Dedup by cid so mergeable children don't bias the dispatch index.
+        let cid = container.id();
+        if self.containers.iter().any(|c| c.id() == cid) {
+            return;
+        }
         self.containers.push(container.into_map().unwrap());
     }
 
@@ -81,9 +88,19 @@ impl ActorTrait for MapActor {
 
 #[derive(Clone)]
 pub enum MapAction {
-    Insert { key: u8, value: FuzzValue },
-    Delete { key: u8 },
+    Insert {
+        key: u8,
+        value: FuzzValue,
+    },
+    Delete {
+        key: u8,
+    },
     Clear,
+    #[cfg(feature = "mergeable")]
+    GetMergeable {
+        key: u8,
+        kind: ContainerType,
+    },
 }
 
 impl Debug for MapAction {
@@ -98,6 +115,12 @@ impl Debug for MapAction {
             }
             MapAction::Delete { key } => write!(f, "MapAction::Delete {{ key: {} }}", key),
             MapAction::Clear => write!(f, "MapAction::Clear"),
+            #[cfg(feature = "mergeable")]
+            MapAction::GetMergeable { key, kind } => write!(
+                f,
+                "MapAction::GetMergeable {{ key: {}, kind: {:?} }}",
+                key, kind
+            ),
         }
     }
 }
@@ -108,6 +131,8 @@ impl MapAction {
             MapAction::Insert { key, .. } => *key,
             MapAction::Delete { key, .. } => *key,
             MapAction::Clear => 0,
+            #[cfg(feature = "mergeable")]
+            MapAction::GetMergeable { key, .. } => *key,
         }
     }
 
@@ -116,13 +141,19 @@ impl MapAction {
             MapAction::Insert { value, .. } => value.to_string(),
             MapAction::Delete { .. } => "null".to_string(),
             MapAction::Clear => "null".to_string(),
+            #[cfg(feature = "mergeable")]
+            MapAction::GetMergeable { kind, .. } => format!("mergeable {:?}", kind),
         }
     }
 }
 
 impl FromGenericAction for MapAction {
     fn from_generic_action(action: &GenericAction) -> Self {
-        match action.prop % 3 {
+        #[cfg(not(feature = "mergeable"))]
+        let modulus = 3;
+        #[cfg(feature = "mergeable")]
+        let modulus = 4;
+        match action.prop % modulus {
             0 => MapAction::Insert {
                 key: (action.key % 256) as u8,
                 value: action.value,
@@ -131,6 +162,14 @@ impl FromGenericAction for MapAction {
                 key: (action.key % 256) as u8,
             },
             2 => MapAction::Clear,
+            #[cfg(feature = "mergeable")]
+            3 => MapAction::GetMergeable {
+                key: (action.key % 256) as u8,
+                kind: match action.value {
+                    FuzzValue::Container(c) => c,
+                    FuzzValue::I32(_) => ContainerType::Map,
+                },
+            },
             _ => unreachable!(),
         }
     }
@@ -164,6 +203,36 @@ impl Actionable for MapAction {
                 unwrap(handler.clear());
                 None
             }
+            #[cfg(feature = "mergeable")]
+            MapAction::GetMergeable { key, kind } => {
+                let key = &key.to_string();
+                // Type-conflict rejection (`ArgErr`) is an expected outcome — swallow it
+                // here rather than via `unwrap` so unrelated `ArgErr` sources still panic.
+                let result = match kind {
+                    ContainerType::Map => handler.get_mergeable_map(key).map(|m| m.to_container()),
+                    ContainerType::List => {
+                        handler.get_mergeable_list(key).map(|l| l.to_container())
+                    }
+                    ContainerType::MovableList => handler
+                        .get_mergeable_movable_list(key)
+                        .map(|l| l.to_container()),
+                    ContainerType::Text => {
+                        handler.get_mergeable_text(key).map(|t| t.to_container())
+                    }
+                    ContainerType::Tree => {
+                        handler.get_mergeable_tree(key).map(|t| t.to_container())
+                    }
+                    ContainerType::Counter => {
+                        handler.get_mergeable_counter(key).map(|c| c.to_container())
+                    }
+                    ContainerType::Unknown(_) => return None,
+                };
+                match result {
+                    Ok(c) => Some(c),
+                    Err(LoroError::ArgErr(_)) => None,
+                    Err(e) => panic!("Error: {}", e),
+                }
+            }
         }
     }
 
@@ -175,6 +244,8 @@ impl Actionable for MapAction {
             },
             MapAction::Delete { .. } => None,
             MapAction::Clear => None,
+            #[cfg(feature = "mergeable")]
+            MapAction::GetMergeable { kind, .. } => Some(kind),
         }
     }
 

--- a/crates/fuzz/src/container/movable_list.rs
+++ b/crates/fuzz/src/container/movable_list.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use loro::{Container, ContainerID, ContainerType, LoroDoc, LoroMovableList};
+use loro::{Container, ContainerID, ContainerTrait, ContainerType, LoroDoc, LoroMovableList};
 
 use crate::{
     actions::{Actionable, FromGenericAction, GenericAction},
@@ -92,6 +92,11 @@ impl ActorTrait for MovableListActor {
     }
 
     fn add_new_container(&mut self, container: Container) {
+        // Dedup by cid so mergeable children don't bias the dispatch index.
+        let cid = container.id();
+        if self.containers.iter().any(|c| c.id() == cid) {
+            return;
+        }
         self.containers.push(container.into_movable_list().unwrap());
     }
 }

--- a/crates/fuzz/src/container/text.rs
+++ b/crates/fuzz/src/container/text.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use loro::{Container, ContainerID, ContainerType, LoroDoc, LoroText};
+use loro::{Container, ContainerID, ContainerTrait, ContainerType, LoroDoc, LoroText};
 
 use crate::{
     actions::{Actionable, FromGenericAction, GenericAction},
@@ -87,6 +87,11 @@ impl ActorTrait for TextActor {
     }
 
     fn add_new_container(&mut self, container: Container) {
+        // Dedup by cid so mergeable children don't bias the dispatch index.
+        let cid = container.id();
+        if self.containers.iter().any(|c| c.id() == cid) {
+            return;
+        }
         self.containers.push(container.into_text().unwrap());
     }
 }

--- a/crates/fuzz/src/container/tree.rs
+++ b/crates/fuzz/src/container/tree.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use loro::{
-    event::Diff, Container, ContainerID, ContainerType, LoroDoc, LoroError, LoroTree, LoroValue,
-    TreeExternalDiff, TreeID,
+    event::Diff, Container, ContainerID, ContainerTrait, ContainerType, LoroDoc, LoroError,
+    LoroTree, LoroValue, TreeExternalDiff, TreeID,
 };
 use rustc_hash::FxHashMap;
 
@@ -167,6 +167,11 @@ impl ActorTrait for TreeActor {
     }
 
     fn add_new_container(&mut self, container: Container) {
+        // Dedup by cid so mergeable children don't bias the dispatch index.
+        let cid = container.id();
+        if self.containers.iter().any(|c| c.id() == cid) {
+            return;
+        }
         self.containers.push(container.into_tree().unwrap());
     }
 }

--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+#![allow(unused_assignments)]
 #![allow(clippy::uninlined_format_args)]
 pub mod actions;
 pub mod actor;

--- a/crates/fuzz/src/one_doc_fuzzer.rs
+++ b/crates/fuzz/src/one_doc_fuzzer.rs
@@ -420,6 +420,10 @@ impl OneDocFuzzer {
                                 let map = doc.get_map("map");
                                 map.clear().unwrap();
                             }
+                            // Mergeable containers exercise multi-peer convergence, which the
+                            // single-doc harness can't test; skip here.
+                            #[cfg(feature = "mergeable")]
+                            crate::actions::MapAction::GetMergeable { .. } => {}
                         },
                         crate::actions::ActionInner::Counter(counter_action) => {
                             let counter = doc.get_counter("counter");

--- a/crates/fuzz/src/one_doc_fuzzer.rs
+++ b/crates/fuzz/src/one_doc_fuzzer.rs
@@ -423,7 +423,7 @@ impl OneDocFuzzer {
                             // Mergeable containers exercise multi-peer convergence, which the
                             // single-doc harness can't test; skip here.
                             #[cfg(feature = "mergeable")]
-                            crate::actions::MapAction::GetMergeable { .. } => {}
+                            crate::actions::MapAction::EnsureMergeable { .. } => {}
                         },
                         crate::actions::ActionInner::Counter(counter_action) => {
                             let counter = doc.get_counter("counter");

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -68,9 +68,106 @@ pub struct CompactId {
     pub counter: NonMaxI32,
 }
 
+/// Namespace prefix used to encode mergeable container IDs into Root container names.
+///
+/// The 🤝 ("handshake") sentinel mirrors Loro's existing 🦜 brand convention
+/// (`crates/loro-common/src/value.rs::LORO_CONTAINER_ID_PREFIX`) and signals
+/// "two peers agreeing on the same cid." The trailing `:` separates the brand
+/// from the hex-encoded `(parent, key, container_type)` payload; hex characters
+/// (`0-9a-f`) cannot collide with the prefix bytes, so no closing sentinel is
+/// needed. User-created root container names are rejected by
+/// `check_root_container_name` if they start with this prefix.
+pub const MERGEABLE_NAMESPACE_PREFIX: &str = "🤝:";
+
+fn write_len_prefixed_segment(out: &mut Vec<u8>, bytes: &[u8]) {
+    leb128::write::unsigned(out, bytes.len() as u64).unwrap();
+    out.extend_from_slice(bytes);
+}
+
+fn read_len_prefixed_segment(input: &mut &[u8]) -> Option<Vec<u8>> {
+    let len = leb128::read::unsigned(input).ok()? as usize;
+    if input.len() < len {
+        return None;
+    }
+    let (segment, rest) = input.split_at(len);
+    *input = rest;
+    Some(segment.to_vec())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    fn value(byte: u8) -> Option<u8> {
+        match byte {
+            b'0'..=b'9' => Some(byte - b'0'),
+            b'a'..=b'f' => Some(byte - b'a' + 10),
+            b'A'..=b'F' => Some(byte - b'A' + 10),
+            _ => None,
+        }
+    }
+
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for pair in s.as_bytes().chunks_exact(2) {
+        out.push((value(pair[0])? << 4) | value(pair[1])?);
+    }
+    Some(out)
+}
+
 /// Return whether the given name is a valid root container name.
 pub fn check_root_container_name(name: &str) -> bool {
-    !name.is_empty() && name.char_indices().all(|(_, x)| x != '/' && x != '\0')
+    !name.is_empty()
+        && !name.starts_with(MERGEABLE_NAMESPACE_PREFIX)
+        && name.char_indices().all(|(_, x)| x != '/' && x != '\0')
+}
+
+/// Build the discriminator string a parent map stores at a mergeable key.
+///
+/// The value written into the parent map's slot is `LoroValue::String("🤝:<kind>")`,
+/// reusing [`MERGEABLE_NAMESPACE_PREFIX`] so the string is recognizable as a
+/// mergeable sentinel (and so older clients that don't understand it at least
+/// see a value in the reserved namespace rather than a plausible user string).
+///
+/// The active mergeable child at `(parent, key)` is whichever discriminator the
+/// parent map's regular LWW resolves to; the corresponding deterministic cid is
+/// [`ContainerID::new_mergeable(parent, key, kind)`]. See loro-dev/loro#759.
+pub fn mergeable_discriminator_string(container_type: ContainerType) -> String {
+    format!("{}{}", MERGEABLE_NAMESPACE_PREFIX, container_type)
+}
+
+/// Build the [`LoroValue`] a parent map stores at a mergeable key for `container_type`.
+///
+/// This is the value form of [`mergeable_discriminator_string`]; it is what
+/// `get_mergeable_<kind>` writes via a `MapSet` op against the parent map.
+pub fn mergeable_discriminator(container_type: ContainerType) -> LoroValue {
+    LoroValue::String(mergeable_discriminator_string(container_type).into())
+}
+
+/// Parse a parent map slot value back into the [`ContainerType`] it discriminates,
+/// or `None` if the value is not a recognized mergeable discriminator.
+///
+/// Inverse of [`mergeable_discriminator`]. Returns `None` for non-string values,
+/// strings that don't carry the mergeable prefix, the bare prefix, and prefixed
+/// strings whose suffix is not a known container-type name.
+pub fn parse_mergeable_discriminator(value: &LoroValue) -> Option<ContainerType> {
+    let LoroValue::String(s) = value else {
+        return None;
+    };
+    let suffix = s.as_str().strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
+    // `ContainerType::try_from` accepts the canonical `Display` names ("Map",
+    // "List", ...) plus the `Unknown(n)` form. A bare/empty suffix is rejected.
+    ContainerType::try_from(suffix).ok()
 }
 
 impl CompactId {
@@ -617,6 +714,58 @@ mod container {
         pub fn is_unknown(&self) -> bool {
             matches!(self.container_type(), ContainerType::Unknown(_))
         }
+
+        /// Create a mergeable container ID for the given parent, key, and container type.
+        /// The ID is encoded as a Root container with a reserved namespace prefix so that
+        /// two peers calling this with the same arguments produce the identical `ContainerID`.
+        pub fn new_mergeable(
+            parent: &ContainerID,
+            key: &str,
+            container_type: ContainerType,
+        ) -> Self {
+            let mut encoded = Vec::new();
+            write_len_prefixed_segment(&mut encoded, &parent.to_bytes());
+            write_len_prefixed_segment(&mut encoded, key.as_bytes());
+            encoded.push(container_type.to_u8());
+
+            let name = format!("{}{}", MERGEABLE_NAMESPACE_PREFIX, hex_encode(&encoded));
+
+            Self::Root {
+                name: name.into(),
+                container_type,
+            }
+        }
+
+        /// Returns `true` if this is a mergeable container ID (i.e. created via `new_mergeable`).
+        pub fn is_mergeable(&self) -> bool {
+            matches!(self, Self::Root { name, .. } if name.starts_with(MERGEABLE_NAMESPACE_PREFIX))
+        }
+
+        /// Decode a mergeable container ID back into its `(parent, key, container_type)` components.
+        /// Returns `None` if this is not a valid mergeable container ID.
+        pub fn parse_mergeable(&self) -> Option<(ContainerID, String, ContainerType)> {
+            let Self::Root {
+                name,
+                container_type,
+            } = self
+            else {
+                return None;
+            };
+            let payload = name.strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
+            let decoded = hex_decode(payload)?;
+            let mut input = decoded.as_slice();
+            let parent_bytes = read_len_prefixed_segment(&mut input)?;
+            let key_bytes = read_len_prefixed_segment(&mut input)?;
+            if input.len() != 1 {
+                return None;
+            }
+            let encoded_type = ContainerType::try_from_u8(input[0]).ok()?;
+            if encoded_type != *container_type {
+                return None;
+            }
+            let key = String::from_utf8(key_bytes).ok()?;
+            Some((ContainerID::from_bytes(&parent_bytes), key, encoded_type))
+        }
     }
 
     impl TryFrom<&str> for ContainerType {
@@ -756,7 +905,77 @@ pub mod wasm {
 
 #[cfg(test)]
 mod test {
-    use crate::{ContainerID, ContainerType, ID};
+    use crate::{
+        mergeable_discriminator, mergeable_discriminator_string, parse_mergeable_discriminator,
+        ContainerID, ContainerType, LoroValue, ID,
+    };
+
+    #[test]
+    fn mergeable_discriminator_string_round_trips_every_kind() {
+        let kinds = [
+            ContainerType::Map,
+            ContainerType::List,
+            ContainerType::Text,
+            ContainerType::Tree,
+            ContainerType::MovableList,
+            #[cfg(feature = "counter")]
+            ContainerType::Counter,
+        ];
+        for kind in kinds {
+            let s = mergeable_discriminator_string(kind);
+            // The string reuses the reserved mergeable namespace prefix so older
+            // clients that don't understand it at least see it as a sentinel.
+            assert!(
+                s.starts_with(crate::MERGEABLE_NAMESPACE_PREFIX),
+                "discriminator {s:?} must start with the mergeable namespace prefix"
+            );
+            let value = mergeable_discriminator(kind);
+            assert_eq!(value, LoroValue::String(s.clone().into()));
+            assert_eq!(
+                parse_mergeable_discriminator(&value),
+                Some(kind),
+                "discriminator value {value:?} must parse back to {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mergeable_discriminator_exact_bytes() {
+        // The exact shape agreed upon in loro-dev/loro#759: `LoroValue::String("🤝:Map")`.
+        assert_eq!(
+            mergeable_discriminator(ContainerType::Map),
+            LoroValue::String("🤝:Map".into())
+        );
+        assert_eq!(
+            mergeable_discriminator(ContainerType::List),
+            LoroValue::String("🤝:List".into())
+        );
+    }
+
+    #[test]
+    fn parse_mergeable_discriminator_rejects_non_discriminators() {
+        // Plain user strings, even ones that look map-ish, are not discriminators.
+        assert_eq!(
+            parse_mergeable_discriminator(&LoroValue::String("Map".into())),
+            None
+        );
+        assert_eq!(
+            parse_mergeable_discriminator(&LoroValue::String("hello".into())),
+            None
+        );
+        // The bare prefix with no/unknown kind is not a valid discriminator.
+        assert_eq!(
+            parse_mergeable_discriminator(&LoroValue::String("🤝:".into())),
+            None
+        );
+        assert_eq!(
+            parse_mergeable_discriminator(&LoroValue::String("🤝:NotAKind".into())),
+            None
+        );
+        // Non-string values are never discriminators.
+        assert_eq!(parse_mergeable_discriminator(&LoroValue::Double(1.0)), None);
+        assert_eq!(parse_mergeable_discriminator(&LoroValue::Null), None);
+    }
 
     #[test]
     fn test_container_id_convert_to_and_from_str() {

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -772,7 +772,8 @@ mod container {
                 return None;
             }
             let key = String::from_utf8(key_bytes).ok()?;
-            Some((ContainerID::from_bytes(&parent_bytes), key, encoded_type))
+            let parent = ContainerID::try_from_bytes(&parent_bytes).ok()?;
+            Some((parent, key, encoded_type))
         }
     }
 
@@ -1006,6 +1007,54 @@ mod test {
         let parent = ContainerID::new_root("state", ContainerType::Map);
         let real = ContainerID::new_mergeable(&parent, "field", ContainerType::Map);
         assert!(real.is_mergeable(), "valid mergeable cid must remain mergeable");
+    }
+
+    /// A `🤝:` payload can be valid hex with a well-formed len-prefixed structure and a
+    /// valid trailing type byte, yet still carry a parent segment whose bytes do not decode
+    /// to a `ContainerID`. `parse_mergeable` returns `Option`, so such input must yield
+    /// `None`, never a panic from an internal `ContainerID::from_bytes` unwrap.
+    #[test]
+    fn parse_mergeable_rejects_undecodable_parent_bytes() {
+        // Hand-encode a payload whose parent segment is empty. An empty byte slice is a
+        // valid len-prefixed segment but `ContainerID::try_from_bytes(&[])` is an error.
+        let mut encoded = Vec::new();
+        crate::write_len_prefixed_segment(&mut encoded, &[]); // empty parent bytes
+        crate::write_len_prefixed_segment(&mut encoded, b"key");
+        encoded.push(ContainerType::Map.to_u8());
+
+        let name = format!(
+            "{}{}",
+            crate::MERGEABLE_NAMESPACE_PREFIX,
+            crate::hex_encode(&encoded)
+        );
+        let cid = ContainerID::Root {
+            name: name.into(),
+            container_type: ContainerType::Map,
+        };
+
+        assert_eq!(
+            cid.parse_mergeable(),
+            None,
+            "undecodable parent bytes must reject, not panic"
+        );
+        assert!(!cid.is_mergeable());
+
+        // A parent segment of arbitrary garbage bytes must also reject rather than panic.
+        let mut encoded = Vec::new();
+        crate::write_len_prefixed_segment(&mut encoded, &[0xff, 0xff, 0xff]);
+        crate::write_len_prefixed_segment(&mut encoded, b"key");
+        encoded.push(ContainerType::Map.to_u8());
+
+        let name = format!(
+            "{}{}",
+            crate::MERGEABLE_NAMESPACE_PREFIX,
+            crate::hex_encode(&encoded)
+        );
+        let cid = ContainerID::Root {
+            name: name.into(),
+            container_type: ContainerType::Map,
+        };
+        assert_eq!(cid.parse_mergeable(), None);
     }
 
     #[test]

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -167,7 +167,12 @@ pub fn parse_mergeable_discriminator(value: &LoroValue) -> Option<ContainerType>
     let suffix = s.as_str().strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
     // `ContainerType::try_from` accepts the canonical `Display` names ("Map",
     // "List", ...) plus the `Unknown(n)` form. A bare/empty suffix is rejected.
-    ContainerType::try_from(suffix).ok()
+    // `Unknown(_)` is not a valid mergeable child kind, so it is rejected too.
+    let kind = ContainerType::try_from(suffix).ok()?;
+    if matches!(kind, ContainerType::Unknown(_)) {
+        return None;
+    }
+    Some(kind)
 }
 
 impl CompactId {
@@ -736,9 +741,12 @@ mod container {
             }
         }
 
-        /// Returns `true` if this is a mergeable container ID (i.e. created via `new_mergeable`).
+        /// Returns `true` if this is a valid mergeable container ID (i.e. created via
+        /// `new_mergeable`). A Root whose name merely starts with the reserved mergeable
+        /// prefix but does not decode to a valid `(parent, key, kind)` payload is an
+        /// ordinary root, not a mergeable container.
         pub fn is_mergeable(&self) -> bool {
-            matches!(self, Self::Root { name, .. } if name.starts_with(MERGEABLE_NAMESPACE_PREFIX))
+            self.parse_mergeable().is_some()
         }
 
         /// Decode a mergeable container ID back into its `(parent, key, container_type)` components.
@@ -975,6 +983,37 @@ mod test {
         // Non-string values are never discriminators.
         assert_eq!(parse_mergeable_discriminator(&LoroValue::Double(1.0)), None);
         assert_eq!(parse_mergeable_discriminator(&LoroValue::Null), None);
+    }
+
+    #[test]
+    fn is_mergeable_rejects_prefix_only_roots() {
+        let prefix_only = ContainerID::Root {
+            name: "🤝:abc".into(),
+            container_type: ContainerType::Map,
+        };
+        assert!(
+            !prefix_only.is_mergeable(),
+            "prefix-only root must not be mergeable"
+        );
+        assert!(prefix_only.parse_mergeable().is_none());
+
+        let bad_hex = ContainerID::Root {
+            name: "🤝:not-valid-hex".into(),
+            container_type: ContainerType::Map,
+        };
+        assert!(!bad_hex.is_mergeable(), "non-hex payload must not be mergeable");
+
+        let parent = ContainerID::new_root("state", ContainerType::Map);
+        let real = ContainerID::new_mergeable(&parent, "field", ContainerType::Map);
+        assert!(real.is_mergeable(), "valid mergeable cid must remain mergeable");
+    }
+
+    #[test]
+    fn parse_mergeable_discriminator_rejects_unknown_kind() {
+        assert_eq!(
+            parse_mergeable_discriminator(&LoroValue::String("🤝:Unknown(7)".into())),
+            None
+        );
     }
 
     #[test]

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unused_assignments)]
+
 use std::{fmt::Display, io::Write};
 
 use arbitrary::Arbitrary;
@@ -138,14 +140,7 @@ pub fn check_root_container_name(name: &str) -> bool {
 /// derived deterministically from `(parent, key, kind)`; this value only records that the parent map
 /// slot currently activates that child kind.
 ///
-/// Design intent: do not reserve strings such as `"🤝:Map"` in user value space. Applications often
-/// let users edit titles, metadata, imported JSON, or other map fields directly. If an ordinary
-/// string could be parsed as an internal mergeable edge, curious or malicious user input could
-/// collide with Loro's reserved structure and make valid document data look like container
-/// topology. Storing the ref as binary avoids that string-level reserved word.
-///
-/// The digest is not an anti-forgery mechanism. It makes accidental construction or wrong-slot
-/// copying fail closed by binding the marker to `(parent, key, kind)` while keeping the value small.
+/// Only this specially constructed binary value activates a mergeable child.
 /// Old clients that do not understand mergeable containers should see an inert binary scalar rather
 /// than a fake child container edge or a reserved-looking user string.
 pub const MERGEABLE_MARKER_MAGIC: [u8; 4] = [0x00, b'L', b'M', 0x01];
@@ -173,8 +168,8 @@ pub fn mergeable_marker(
 /// Parse a parent map slot value back into the mergeable [`ContainerType`] it activates.
 ///
 /// The marker is bound to `(parent, key, kind)`, so copying it to another map/key does not activate
-/// a mergeable child there. Malformed markers and old textual sentinels are treated as ordinary
-/// user values.
+/// a mergeable child there. Malformed markers and arbitrary non-marker values are treated as
+/// ordinary user values.
 pub fn parse_mergeable_marker(
     parent: &ContainerID,
     key: &str,
@@ -1017,13 +1012,13 @@ mod test {
     fn parse_mergeable_marker_rejects_non_markers() {
         let parent = ContainerID::new_root("state", ContainerType::Map);
 
-        // Plain user strings, even ones that look like the old sentinel, are never markers.
+        // Plain user strings are never markers.
         assert_eq!(
             parse_mergeable_marker(&parent, "field", &LoroValue::String("Map".into())),
             None
         );
         assert_eq!(
-            parse_mergeable_marker(&parent, "field", &LoroValue::String("🤝:Map".into())),
+            parse_mergeable_marker(&parent, "field", &LoroValue::String("not-a-marker".into())),
             None
         );
 

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -132,47 +132,100 @@ pub fn check_root_container_name(name: &str) -> bool {
         && name.char_indices().all(|(_, x)| x != '/' && x != '\0')
 }
 
-/// Build the discriminator string a parent map stores at a mergeable key.
+/// Binary marker stored in a parent map slot to activate a mergeable child.
 ///
-/// The value written into the parent map's slot is `LoroValue::String("🤝:<kind>")`,
-/// reusing [`MERGEABLE_NAMESPACE_PREFIX`] so the string is recognizable as a
-/// mergeable sentinel (and so older clients that don't understand it at least
-/// see a value in the reserved namespace rather than a plausible user string).
+/// This is a compact mergeable-child container ref, not the child cid itself. The child cid is
+/// derived deterministically from `(parent, key, kind)`; this value only records that the parent map
+/// slot currently activates that child kind.
 ///
-/// The active mergeable child at `(parent, key)` is whichever discriminator the
-/// parent map's regular LWW resolves to; the corresponding deterministic cid is
-/// [`ContainerID::new_mergeable(parent, key, kind)`]. See loro-dev/loro#759.
-pub fn mergeable_discriminator_string(container_type: ContainerType) -> String {
-    format!("{}{}", MERGEABLE_NAMESPACE_PREFIX, container_type)
-}
+/// Design intent: do not reserve strings such as `"🤝:Map"` in user value space. Applications often
+/// let users edit titles, metadata, imported JSON, or other map fields directly. If an ordinary
+/// string could be parsed as an internal mergeable edge, curious or malicious user input could
+/// collide with Loro's reserved structure and make valid document data look like container
+/// topology. Storing the ref as binary avoids that string-level reserved word.
+///
+/// The digest is not an anti-forgery mechanism. It makes accidental construction or wrong-slot
+/// copying fail closed by binding the marker to `(parent, key, kind)` while keeping the value small.
+/// Old clients that do not understand mergeable containers should see an inert binary scalar rather
+/// than a fake child container edge or a reserved-looking user string.
+pub const MERGEABLE_MARKER_MAGIC: [u8; 4] = [0x00, b'L', b'M', 0x01];
+
+const MERGEABLE_MARKER_DIGEST_LEN: usize = 3;
+const MERGEABLE_MARKER_LEN: usize = 4 + 1 + MERGEABLE_MARKER_DIGEST_LEN;
+const MERGEABLE_MARKER_CRC_DOMAIN: &[u8] = b"loro.mergeable.marker.v1";
 
 /// Build the [`LoroValue`] a parent map stores at a mergeable key for `container_type`.
 ///
-/// This is the value form of [`mergeable_discriminator_string`]; it is what
-/// `get_mergeable_<kind>` writes via a `MapSet` op against the parent map.
-pub fn mergeable_discriminator(container_type: ContainerType) -> LoroValue {
-    LoroValue::String(mergeable_discriminator_string(container_type).into())
+/// Layout: `MAGIC[4] + KIND[1] + CRC24(parent_id, key, kind)[3]`.
+pub fn mergeable_marker(
+    parent: &ContainerID,
+    key: &str,
+    container_type: ContainerType,
+) -> LoroValue {
+    let mut marker = Vec::with_capacity(MERGEABLE_MARKER_LEN);
+    marker.extend_from_slice(&MERGEABLE_MARKER_MAGIC);
+    marker.push(container_type.to_u8());
+    let digest = mergeable_marker_crc24(parent, key, container_type);
+    marker.extend_from_slice(&digest);
+    LoroValue::Binary(marker.into())
 }
 
-/// Parse a parent map slot value back into the [`ContainerType`] it discriminates,
-/// or `None` if the value is not a recognized mergeable discriminator.
+/// Parse a parent map slot value back into the mergeable [`ContainerType`] it activates.
 ///
-/// Inverse of [`mergeable_discriminator`]. Returns `None` for non-string values,
-/// strings that don't carry the mergeable prefix, the bare prefix, and prefixed
-/// strings whose suffix is not a known container-type name.
-pub fn parse_mergeable_discriminator(value: &LoroValue) -> Option<ContainerType> {
-    let LoroValue::String(s) = value else {
+/// The marker is bound to `(parent, key, kind)`, so copying it to another map/key does not activate
+/// a mergeable child there. Malformed markers and old textual sentinels are treated as ordinary
+/// user values.
+pub fn parse_mergeable_marker(
+    parent: &ContainerID,
+    key: &str,
+    value: &LoroValue,
+) -> Option<ContainerType> {
+    let LoroValue::Binary(bytes) = value else {
         return None;
     };
-    let suffix = s.as_str().strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
-    // `ContainerType::try_from` accepts the canonical `Display` names ("Map",
-    // "List", ...) plus the `Unknown(n)` form. A bare/empty suffix is rejected.
-    // `Unknown(_)` is not a valid mergeable child kind, so it is rejected too.
-    let kind = ContainerType::try_from(suffix).ok()?;
+    if bytes.len() != MERGEABLE_MARKER_LEN || !bytes.starts_with(&MERGEABLE_MARKER_MAGIC) {
+        return None;
+    }
+
+    let kind = ContainerType::try_from_u8(bytes[MERGEABLE_MARKER_MAGIC.len()]).ok()?;
     if matches!(kind, ContainerType::Unknown(_)) {
         return None;
     }
+
+    let digest_start = MERGEABLE_MARKER_MAGIC.len() + 1;
+    let expected = mergeable_marker_crc24(parent, key, kind);
+    if &bytes[digest_start..] != expected.as_slice() {
+        return None;
+    }
+
     Some(kind)
+}
+
+fn mergeable_marker_crc24(parent: &ContainerID, key: &str, kind: ContainerType) -> [u8; 3] {
+    let mut input = Vec::new();
+    input.extend_from_slice(MERGEABLE_MARKER_CRC_DOMAIN);
+    write_len_prefixed_segment(&mut input, &parent.to_bytes());
+    write_len_prefixed_segment(&mut input, key.as_bytes());
+    input.push(kind.to_u8());
+
+    let crc = crc32(&input) & 0x00ff_ffff;
+    [
+        ((crc >> 16) & 0xff) as u8,
+        ((crc >> 8) & 0xff) as u8,
+        (crc & 0xff) as u8,
+    ]
+}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffff_u32;
+    for &byte in bytes {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xedb8_8320 & mask);
+        }
+    }
+    !crc
 }
 
 impl CompactId {
@@ -915,12 +968,14 @@ pub mod wasm {
 #[cfg(test)]
 mod test {
     use crate::{
-        mergeable_discriminator, mergeable_discriminator_string, parse_mergeable_discriminator,
-        ContainerID, ContainerType, LoroValue, ID,
+        mergeable_marker, parse_mergeable_marker, ContainerID, ContainerType, LoroValue, ID,
+        MERGEABLE_MARKER_MAGIC,
     };
 
     #[test]
-    fn mergeable_discriminator_string_round_trips_every_kind() {
+    fn mergeable_marker_round_trips_every_kind() {
+        let parent = ContainerID::new_root("state", ContainerType::Map);
+        let key = "field";
         let kinds = [
             ContainerType::Map,
             ContainerType::List,
@@ -931,59 +986,94 @@ mod test {
             ContainerType::Counter,
         ];
         for kind in kinds {
-            let s = mergeable_discriminator_string(kind);
-            // The string reuses the reserved mergeable namespace prefix so older
-            // clients that don't understand it at least see it as a sentinel.
-            assert!(
-                s.starts_with(crate::MERGEABLE_NAMESPACE_PREFIX),
-                "discriminator {s:?} must start with the mergeable namespace prefix"
-            );
-            let value = mergeable_discriminator(kind);
-            assert_eq!(value, LoroValue::String(s.clone().into()));
             assert_eq!(
-                parse_mergeable_discriminator(&value),
+                parse_mergeable_marker(&parent, key, &mergeable_marker(&parent, key, kind)),
                 Some(kind),
-                "discriminator value {value:?} must parse back to {kind:?}"
+                "marker value must parse back to {kind:?}"
             );
         }
     }
 
     #[test]
-    fn mergeable_discriminator_exact_bytes() {
-        // The exact shape agreed upon in loro-dev/loro#759: `LoroValue::String("🤝:Map")`.
+    fn mergeable_marker_exact_layout() {
+        let parent = ContainerID::new_root("state", ContainerType::Map);
+        let value = mergeable_marker(&parent, "field", ContainerType::List);
+        let LoroValue::Binary(bytes) = value else {
+            panic!("mergeable marker must be a binary value");
+        };
+
+        assert_eq!(bytes.len(), 8);
         assert_eq!(
-            mergeable_discriminator(ContainerType::Map),
-            LoroValue::String("🤝:Map".into())
+            &bytes[..MERGEABLE_MARKER_MAGIC.len()],
+            MERGEABLE_MARKER_MAGIC
         );
         assert_eq!(
-            mergeable_discriminator(ContainerType::List),
-            LoroValue::String("🤝:List".into())
+            bytes[MERGEABLE_MARKER_MAGIC.len()],
+            ContainerType::List.to_u8()
         );
     }
 
     #[test]
-    fn parse_mergeable_discriminator_rejects_non_discriminators() {
-        // Plain user strings, even ones that look map-ish, are not discriminators.
+    fn parse_mergeable_marker_rejects_non_markers() {
+        let parent = ContainerID::new_root("state", ContainerType::Map);
+
+        // Plain user strings, even ones that look like the old sentinel, are never markers.
         assert_eq!(
-            parse_mergeable_discriminator(&LoroValue::String("Map".into())),
+            parse_mergeable_marker(&parent, "field", &LoroValue::String("Map".into())),
             None
         );
         assert_eq!(
-            parse_mergeable_discriminator(&LoroValue::String("hello".into())),
+            parse_mergeable_marker(&parent, "field", &LoroValue::String("🤝:Map".into())),
             None
         );
-        // The bare prefix with no/unknown kind is not a valid discriminator.
+
+        // Non-binary values are never markers.
         assert_eq!(
-            parse_mergeable_discriminator(&LoroValue::String("🤝:".into())),
+            parse_mergeable_marker(&parent, "field", &LoroValue::Double(1.0)),
             None
         );
         assert_eq!(
-            parse_mergeable_discriminator(&LoroValue::String("🤝:NotAKind".into())),
+            parse_mergeable_marker(&parent, "field", &LoroValue::Null),
             None
         );
-        // Non-string values are never discriminators.
-        assert_eq!(parse_mergeable_discriminator(&LoroValue::Double(1.0)), None);
-        assert_eq!(parse_mergeable_discriminator(&LoroValue::Null), None);
+
+        // Malformed binary values stay ordinary binary values.
+        assert_eq!(
+            parse_mergeable_marker(
+                &parent,
+                "field",
+                &LoroValue::Binary(vec![0x00, b'L', b'M'].into()),
+            ),
+            None
+        );
+
+        let mut wrong_magic = marker_bytes(mergeable_marker(&parent, "field", ContainerType::Map));
+        wrong_magic[0] = 0xff;
+        assert_eq!(
+            parse_mergeable_marker(&parent, "field", &LoroValue::Binary(wrong_magic.into()),),
+            None
+        );
+
+        let marker = mergeable_marker(&parent, "field", ContainerType::Map);
+        assert_eq!(
+            parse_mergeable_marker(&parent, "other", &marker),
+            None,
+            "marker digest binds the marker to its map key"
+        );
+
+        let other_parent = ContainerID::new_root("other", ContainerType::Map);
+        assert_eq!(
+            parse_mergeable_marker(&other_parent, "field", &marker),
+            None,
+            "marker digest binds the marker to its parent container"
+        );
+
+        let mut wrong_digest = marker_bytes(marker);
+        *wrong_digest.last_mut().unwrap() ^= 1;
+        assert_eq!(
+            parse_mergeable_marker(&parent, "field", &LoroValue::Binary(wrong_digest.into()),),
+            None
+        );
     }
 
     #[test]
@@ -1002,11 +1092,17 @@ mod test {
             name: "🤝:not-valid-hex".into(),
             container_type: ContainerType::Map,
         };
-        assert!(!bad_hex.is_mergeable(), "non-hex payload must not be mergeable");
+        assert!(
+            !bad_hex.is_mergeable(),
+            "non-hex payload must not be mergeable"
+        );
 
         let parent = ContainerID::new_root("state", ContainerType::Map);
         let real = ContainerID::new_mergeable(&parent, "field", ContainerType::Map);
-        assert!(real.is_mergeable(), "valid mergeable cid must remain mergeable");
+        assert!(
+            real.is_mergeable(),
+            "valid mergeable cid must remain mergeable"
+        );
     }
 
     /// A `🤝:` payload can be valid hex with a well-formed len-prefixed structure and a
@@ -1058,11 +1154,22 @@ mod test {
     }
 
     #[test]
-    fn parse_mergeable_discriminator_rejects_unknown_kind() {
+    fn parse_mergeable_marker_rejects_unknown_kind() {
+        let parent = ContainerID::new_root("state", ContainerType::Map);
+        let mut marker = marker_bytes(mergeable_marker(&parent, "field", ContainerType::Map));
+        marker[MERGEABLE_MARKER_MAGIC.len()] = u8::MAX;
+
         assert_eq!(
-            parse_mergeable_discriminator(&LoroValue::String("🤝:Unknown(7)".into())),
+            parse_mergeable_marker(&parent, "field", &LoroValue::Binary(marker.into())),
             None
         );
+    }
+
+    fn marker_bytes(value: LoroValue) -> Vec<u8> {
+        let LoroValue::Binary(bytes) = value else {
+            panic!("expected binary mergeable marker");
+        };
+        bytes.to_vec()
     }
 
     #[test]

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -92,10 +92,19 @@ impl ArenaContainers {
         self.container_idx_to_id.push(id.clone());
         let idx = ContainerIdx::from_index_and_type(idx as u32, id.container_type());
         self.container_id_to_idx.insert(id.clone(), idx);
-        if id.is_root() {
+        if id.is_root() && !id.is_mergeable() {
             self.root_c_idx.push(idx);
             self.parents.insert(idx, None);
             self.depth.push(NonZeroU16::new(1));
+        } else if id.is_mergeable() {
+            // Mergeable Roots look like roots at the cid layer but conceptually live under a
+            // parent map. Push a placeholder depth so the vector stays in sync, then recurse to
+            // register the parent and link the edge via `set_parent`, which recomputes depth.
+            self.depth.push(None);
+            if let Some((parent_id, _key, _kind)) = id.parse_mergeable() {
+                let parent_idx = self.register_container(&parent_id);
+                self.set_parent(idx, Some(parent_idx));
+            }
         } else {
             self.depth.push(None);
         }
@@ -337,7 +346,7 @@ impl SharedArena {
         let (child_id, resolver) = {
             let containers = self.inner.containers.read();
             let child_id = containers.container_id(child).unwrap();
-            if child_id.is_root() {
+            if child_id.is_root() && !child_id.is_mergeable() {
                 // TODO: PERF: we can speed this up by use a special bit in ContainerIdx to indicate
                 // whether the target is a root container
                 return None;
@@ -659,11 +668,11 @@ fn get_depth(
         *p
     } else {
         let id = idx_to_id.get(target.to_index() as usize).unwrap();
-        if id.is_root() {
+        if id.is_root() && !id.is_mergeable() {
             None
         } else if let Some(parent_resolver) = parent_resolver.as_ref() {
             let parent_id = parent_resolver(id.clone())?;
-            let parent_is_root = parent_id.is_root();
+            let parent_is_top_level_root = parent_id.is_root() && !parent_id.is_mergeable();
             let mut parent_was_new = false;
             // If the parent is not registered yet, register it lazily instead of unwrapping.
             let parent_idx = if let Some(idx) = id_to_idx.get(&parent_id).copied() {
@@ -675,7 +684,7 @@ fn get_depth(
                     ContainerIdx::from_index_and_type(new_index as u32, parent_id.container_type());
                 id_to_idx.insert(parent_id.clone(), new_idx);
                 // Keep depth vector in sync with containers list.
-                if parent_is_root {
+                if parent_is_top_level_root {
                     depth.push(NonZeroU16::new(1));
                 } else {
                     depth.push(None);
@@ -684,7 +693,7 @@ fn get_depth(
                 new_idx
             };
 
-            if parent_is_root {
+            if parent_is_top_level_root {
                 if parent_was_new {
                     parents.insert(parent_idx, None);
                     root_c_idx.push(parent_idx);

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4435,6 +4435,24 @@ impl MapHandler {
         let MaybeDetached::Attached(parent) = &self.inner else {
             return self.get_or_create_container(key, child);
         };
+
+        // The slot may only be empty or already hold a mergeable discriminator. A non-mergeable
+        // occupant (a scalar or a regular child container) would be silently clobbered by the
+        // discriminator write, so reject it rather than overwrite under a `get_`-named API.
+        if let Some(existing) = self.get(key) {
+            if !matches!(existing, LoroValue::Null)
+                && loro_common::parse_mergeable_discriminator(&existing).is_none()
+            {
+                return Err(LoroError::ArgErr(
+                    format!(
+                        "Cannot create a mergeable {} at key {key:?}: the key already holds a non-mergeable value",
+                        child.kind()
+                    )
+                    .into_boxed_str(),
+                ));
+            }
+        }
+
         let cid = ContainerID::new_mergeable(&parent.id, key, child.kind());
 
         // Record which kind is active at `(parent, key)` by writing a discriminator string into

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4413,6 +4413,82 @@ impl MapHandler {
         self.insert_container(key, child)
     }
 
+    /// Shared implementation for all `get_mergeable_*` methods.
+    ///
+    /// For detached handlers (no doc state yet), falls back to
+    /// [`Self::get_or_create_container`].
+    ///
+    /// For attached handlers, computes a deterministic [`ContainerID::Root`] in
+    /// the mergeable namespace from `(parent.id, key, child.kind())` and
+    /// constructs the handler from it. Two peers calling this with the same
+    /// `(parent, key, kind)` receive handlers with identical container ids,
+    /// which is what makes the child container mergeable on concurrent
+    /// first-write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoroError::ArgErr`] if `C::from_handler` rejects the handler
+    /// built from the deterministic cid. By construction this is unreachable
+    /// because the cid carries `child.kind()`; the check guards against
+    /// future drift between `from_handler` and `kind`.
+    fn get_mergeable_container<C: HandlerTrait>(&self, key: &str, child: C) -> LoroResult<C> {
+        let MaybeDetached::Attached(parent) = &self.inner else {
+            return self.get_or_create_container(key, child);
+        };
+        let cid = ContainerID::new_mergeable(&parent.id, key, child.kind());
+
+        // Record which kind is active at `(parent, key)` by writing a discriminator string into
+        // the parent map's slot for `key`. The active mergeable child is whichever discriminator
+        // the parent map's regular LWW resolves to (see loro-dev/loro#759), so this op is what
+        // realizes the child and drives all read-time resolution, parent-edge registration
+        // (via the op-apply hook), and conflict resolution.
+        //
+        // Requesting a different kind under a key that already holds another kind's discriminator
+        // is a deliberate kind change: it overwrites the discriminator, exactly like setting a
+        // different value, and the previous kind's container stays reachable by its deterministic
+        // name so re-requesting it later resurfaces its preserved contents (the List -> Map ->
+        // List cycle). Idempotent for the same kind: `insert_with_txn` skips when the slot
+        // already holds the matching discriminator.
+        let discriminator = loro_common::mergeable_discriminator(child.kind());
+        self.insert(key, discriminator)?;
+
+        C::from_handler(create_handler(parent, cid.clone())).ok_or_else(|| {
+            LoroError::ArgErr(
+                format!(
+                    "Expected value type {} but found {}",
+                    child.kind(),
+                    cid.container_type()
+                )
+                .into_boxed_str(),
+            )
+        })
+    }
+
+    #[cfg(feature = "counter")]
+    pub fn get_mergeable_counter(&self, key: &str) -> LoroResult<counter::CounterHandler> {
+        self.get_mergeable_container(key, counter::CounterHandler::new_detached())
+    }
+
+    pub fn get_mergeable_map(&self, key: &str) -> LoroResult<MapHandler> {
+        self.get_mergeable_container(key, MapHandler::new_detached())
+    }
+
+    pub fn get_mergeable_list(&self, key: &str) -> LoroResult<ListHandler> {
+        self.get_mergeable_container(key, ListHandler::new_detached())
+    }
+
+    pub fn get_mergeable_movable_list(&self, key: &str) -> LoroResult<MovableListHandler> {
+        self.get_mergeable_container(key, MovableListHandler::new_detached())
+    }
+
+    pub fn get_mergeable_text(&self, key: &str) -> LoroResult<TextHandler> {
+        self.get_mergeable_container(key, TextHandler::new_detached())
+    }
+
+    pub fn get_mergeable_tree(&self, key: &str) -> LoroResult<TreeHandler> {
+        self.get_mergeable_container(key, TreeHandler::new_detached())
+    }
+
     pub fn contains_key(&self, key: &str) -> bool {
         self.get(key).is_some()
     }

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4413,7 +4413,7 @@ impl MapHandler {
         self.insert_container(key, child)
     }
 
-    /// Shared implementation for all `get_mergeable_*` methods.
+    /// Shared implementation for all `ensure_mergeable_*` methods.
     ///
     /// For detached handlers (no doc state yet), falls back to
     /// [`Self::get_or_create_container`].
@@ -4431,7 +4431,7 @@ impl MapHandler {
     /// built from the deterministic cid. By construction this is unreachable
     /// because the cid carries `child.kind()`; the check guards against
     /// future drift between `from_handler` and `kind`.
-    fn get_mergeable_container<C: HandlerTrait>(&self, key: &str, child: C) -> LoroResult<C> {
+    fn ensure_mergeable_container<C: HandlerTrait>(&self, key: &str, child: C) -> LoroResult<C> {
         let MaybeDetached::Attached(parent) = &self.inner else {
             return self.get_or_create_container(key, child);
         };
@@ -4442,9 +4442,10 @@ impl MapHandler {
         // `get_`-named API.
         //
         // This guard is also part of the marker-format safety story: user-editable fields should
-        // not become mergeable child edges just because they contain a reserved-looking value.
-        // Only the exact binary ref for this `(parent, key, kind)` is accepted as an existing
-        // mergeable occupant; everything else remains ordinary user data and blocks creation.
+        // not become mergeable child edges just because they contain a user-authored string or
+        // arbitrary bytes. Only the exact binary ref for this `(parent, key, kind)` is accepted as
+        // an existing mergeable occupant; everything else remains ordinary user data and blocks
+        // creation.
         if let Some(existing) = self.get(key) {
             if !matches!(existing, LoroValue::Null)
                 && loro_common::parse_mergeable_marker(&parent.id, key, &existing).is_none()
@@ -4467,9 +4468,9 @@ impl MapHandler {
         // op is what realizes the child and drives all read-time resolution and conflict
         // resolution.
         //
-        // This is deliberately binary rather than a string sentinel. End users can often edit map
-        // fields such as titles or metadata directly; using a string-level reserved word would let
-        // curious or malicious user input collide with Loro's internal container-edge structure.
+        // This is deliberately a specially constructed binary value. End users can often edit map
+        // fields such as titles or metadata directly; those strings must stay user data instead of
+        // being treated as internal container-edge structure.
         // The ref's small digest binds it to this exact `(parent, key, kind)`, which makes
         // accidental construction or wrong-slot copying fail closed without storing the full child
         // cid bytes.
@@ -4496,28 +4497,28 @@ impl MapHandler {
     }
 
     #[cfg(feature = "counter")]
-    pub fn get_mergeable_counter(&self, key: &str) -> LoroResult<counter::CounterHandler> {
-        self.get_mergeable_container(key, counter::CounterHandler::new_detached())
+    pub fn ensure_mergeable_counter(&self, key: &str) -> LoroResult<counter::CounterHandler> {
+        self.ensure_mergeable_container(key, counter::CounterHandler::new_detached())
     }
 
-    pub fn get_mergeable_map(&self, key: &str) -> LoroResult<MapHandler> {
-        self.get_mergeable_container(key, MapHandler::new_detached())
+    pub fn ensure_mergeable_map(&self, key: &str) -> LoroResult<MapHandler> {
+        self.ensure_mergeable_container(key, MapHandler::new_detached())
     }
 
-    pub fn get_mergeable_list(&self, key: &str) -> LoroResult<ListHandler> {
-        self.get_mergeable_container(key, ListHandler::new_detached())
+    pub fn ensure_mergeable_list(&self, key: &str) -> LoroResult<ListHandler> {
+        self.ensure_mergeable_container(key, ListHandler::new_detached())
     }
 
-    pub fn get_mergeable_movable_list(&self, key: &str) -> LoroResult<MovableListHandler> {
-        self.get_mergeable_container(key, MovableListHandler::new_detached())
+    pub fn ensure_mergeable_movable_list(&self, key: &str) -> LoroResult<MovableListHandler> {
+        self.ensure_mergeable_container(key, MovableListHandler::new_detached())
     }
 
-    pub fn get_mergeable_text(&self, key: &str) -> LoroResult<TextHandler> {
-        self.get_mergeable_container(key, TextHandler::new_detached())
+    pub fn ensure_mergeable_text(&self, key: &str) -> LoroResult<TextHandler> {
+        self.ensure_mergeable_container(key, TextHandler::new_detached())
     }
 
-    pub fn get_mergeable_tree(&self, key: &str) -> LoroResult<TreeHandler> {
-        self.get_mergeable_container(key, TreeHandler::new_detached())
+    pub fn ensure_mergeable_tree(&self, key: &str) -> LoroResult<TreeHandler> {
+        self.ensure_mergeable_container(key, TreeHandler::new_detached())
     }
 
     pub fn contains_key(&self, key: &str) -> bool {

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4436,12 +4436,18 @@ impl MapHandler {
             return self.get_or_create_container(key, child);
         };
 
-        // The slot may only be empty or already hold a mergeable discriminator. A non-mergeable
-        // occupant (a scalar or a regular child container) would be silently clobbered by the
-        // discriminator write, so reject it rather than overwrite under a `get_`-named API.
+        // The slot may only be empty or already hold a mergeable marker for this parent/key. A
+        // non-mergeable occupant (a scalar, arbitrary binary, or a regular child container) would
+        // be silently clobbered by the marker write, so reject it rather than overwrite under a
+        // `get_`-named API.
+        //
+        // This guard is also part of the marker-format safety story: user-editable fields should
+        // not become mergeable child edges just because they contain a reserved-looking value.
+        // Only the exact binary ref for this `(parent, key, kind)` is accepted as an existing
+        // mergeable occupant; everything else remains ordinary user data and blocks creation.
         if let Some(existing) = self.get(key) {
             if !matches!(existing, LoroValue::Null)
-                && loro_common::parse_mergeable_discriminator(&existing).is_none()
+                && loro_common::parse_mergeable_marker(&parent.id, key, &existing).is_none()
             {
                 return Err(LoroError::ArgErr(
                     format!(
@@ -4455,20 +4461,27 @@ impl MapHandler {
 
         let cid = ContainerID::new_mergeable(&parent.id, key, child.kind());
 
-        // Record which kind is active at `(parent, key)` by writing a discriminator string into
-        // the parent map's slot for `key`. The active mergeable child is whichever discriminator
-        // the parent map's regular LWW resolves to (see loro-dev/loro#759), so this op is what
-        // realizes the child and drives all read-time resolution, parent-edge registration
-        // (via the op-apply hook), and conflict resolution.
+        // Record which kind is active at `(parent, key)` by writing a compact binary
+        // mergeable-child ref into the parent map's slot for `key`. The active mergeable child is
+        // whichever ref the parent map's regular LWW resolves to (see loro-dev/loro#759), so this
+        // op is what realizes the child and drives all read-time resolution and conflict
+        // resolution.
         //
-        // Requesting a different kind under a key that already holds another kind's discriminator
-        // is a deliberate kind change: it overwrites the discriminator, exactly like setting a
+        // This is deliberately binary rather than a string sentinel. End users can often edit map
+        // fields such as titles or metadata directly; using a string-level reserved word would let
+        // curious or malicious user input collide with Loro's internal container-edge structure.
+        // The ref's small digest binds it to this exact `(parent, key, kind)`, which makes
+        // accidental construction or wrong-slot copying fail closed without storing the full child
+        // cid bytes.
+        //
+        // Requesting a different kind under a key that already holds another kind's marker is a
+        // deliberate kind change: it overwrites the marker, exactly like setting a
         // different value, and the previous kind's container stays reachable by its deterministic
         // name so re-requesting it later resurfaces its preserved contents (the List -> Map ->
         // List cycle). Idempotent for the same kind: `insert_with_txn` skips when the slot
-        // already holds the matching discriminator.
-        let discriminator = loro_common::mergeable_discriminator(child.kind());
-        self.insert(key, discriminator)?;
+        // already holds the matching marker.
+        let marker = loro_common::mergeable_marker(&parent.id, key, child.kind());
+        self.insert(key, marker)?;
 
         C::from_handler(create_handler(parent, cid.clone())).ok_or_else(|| {
             LoroError::ArgErr(

--- a/crates/loro-internal/src/lib.rs
+++ b/crates/loro-internal/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //!
 #![deny(clippy::undocumented_unsafe_blocks)]
+#![allow(unused_assignments)]
 #![allow(clippy::uninlined_format_args)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(missing_debug_implementations)]

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1095,7 +1095,7 @@ impl LoroDoc {
 
     #[must_use]
     pub fn has_container(&self, id: &ContainerID) -> bool {
-        if id.is_root() {
+        if id.is_root() && !id.is_mergeable() {
             return true;
         }
 

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1990,10 +1990,16 @@ impl LoroDoc {
     pub fn get_path_to_container(&self, id: &ContainerID) -> Option<Vec<(ContainerID, Index)>> {
         let mut state = self.state.lock();
         if state.arena.id_to_idx(id).is_none() {
-            if !state.does_container_exist(id) {
+            if id.is_mergeable() {
+                // Mergeable children can be logically active via the parent map marker
+                // before they have their own encoded state. Register only the arena edge; do not
+                // create container state or change `has_container` semantics.
+                state.arena.register_container(id);
+            } else if !state.does_container_exist(id) {
                 return None;
+            } else {
+                state.ensure_container(id);
             }
-            state.ensure_container(id);
         }
         let idx = state.arena.id_to_idx(id).unwrap();
         state.get_path(idx)

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -1866,7 +1866,7 @@ impl DocState {
                             let Some(LoroValue::Container(c)) = l.get(*index.as_seq()?) else {
                                 return None;
                             };
-                            state_idx = CurContainer::Container(self.arena.register_container(&c));
+                            state_idx = CurContainer::Container(self.arena.register_container(c));
                         }
                         State::MovableListState(l) => {
                             let Some(LoroValue::Container(c)) =
@@ -1874,7 +1874,7 @@ impl DocState {
                             else {
                                 return None;
                             };
-                            state_idx = CurContainer::Container(self.arena.register_container(&c));
+                            state_idx = CurContainer::Container(self.arena.register_container(c));
                         }
                         State::MapState(m) => {
                             let key = index.as_key()?;

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -37,6 +37,7 @@ mod counter_state;
 mod dead_containers_cache;
 mod list_state;
 mod map_state;
+mod mergeable;
 mod movable_list_state;
 mod richtext_state;
 mod tree_state;
@@ -660,6 +661,12 @@ impl DocState {
         // Suppose A is revived and B is A's child, and B also needs to be revived; therefore,
         // we should process each level alternately.
 
+        // Capture the parent map idxs touched by the diff batch BEFORE the main loop mutates
+        // `diffs`. Used by the post-loop hook to register mergeable parent edges from the
+        // discriminators the batch just applied, keeping update-import cost proportional to the
+        // diff size.
+        let map_parent_idxs = self.capture_mergeable_diff_batch(&diffs);
+
         // We need to ensure diff is processed in order
         diffs.sort_by_cached_key(|diff| self.arena.get_depth(diff.idx));
         let mut to_revive_in_next_layer: FxHashSet<ContainerIdx> = FxHashSet::default();
@@ -812,6 +819,22 @@ impl DocState {
 
         diff.diff = diffs.into();
         self.frontiers = diff.new_version.clone().into_owned();
+
+        // Register mergeable parent edges from the discriminators the diff batch just applied to
+        // their parent maps. This is the update-import counterpart of
+        // `repopulate_mergeable_child_side_tables` (which fires on snapshot import). Without it, a
+        // peer that imports a discriminator op — without first locally calling `get_mergeable_*` —
+        // would resolve the child in deep value (which reads the discriminator directly) but miss
+        // the parent edge that path resolution and reachability use. The walk reads the current
+        // discriminators, so it naturally drops edges for keys whose discriminator was cleared.
+        if !map_parent_idxs.is_empty() {
+            let parent_ids: Vec<ContainerID> = map_parent_idxs
+                .iter()
+                .filter_map(|idx| self.arena.idx_to_id(*idx))
+                .collect();
+            self.register_mergeable_children(parent_ids);
+        }
+
         if self.is_recording() {
             self.record_diff(diff)
         }
@@ -846,6 +869,10 @@ impl DocState {
             self.dead_containers_cache.clear_alive();
         }
 
+        // Keep the mergeable parent-edge index in sync with the discriminator this op may have
+        // written or cleared on a parent map.
+        self.sync_mergeable_side_table_for_op(raw_op, op);
+
         Ok(())
     }
 
@@ -871,7 +898,7 @@ impl DocState {
     pub fn does_container_exist(&mut self, id: &ContainerID) -> bool {
         // A container may exist even if not yet registered in the arena.
         // Check arena first, then fall back to KV presence in the store.
-        if id.is_root() {
+        if id.is_root() && !id.is_mergeable() {
             return true;
         }
 
@@ -998,6 +1025,17 @@ impl DocState {
                 }
             }
         }
+
+        // Re-register mergeable child containers in their parent MapState's
+        // side table. Mergeable children are real containers with their own
+        // state entries in KV (so they round-trip through snapshot), but the
+        // `MapState::child_containers` side table that drives deep-value walks
+        // and path resolution is NOT serialized (see
+        // `MapState::encode_snapshot_fast`). After import we walk all known
+        // container IDs, find the mergeable ones, and call
+        // `register_mergeable_child` on their parent MapStates to rebuild
+        // that side table from the deterministic cids.
+        self.repopulate_mergeable_child_side_tables(oplog);
 
         if !unknown_containers.is_empty() {
             let mut diff_calc = DiffCalculator::new(false);
@@ -1192,6 +1230,17 @@ impl DocState {
             let Some(name) = self.root_container_name(idx) else {
                 continue;
             };
+            // Mergeable Roots live in a private cid namespace and are
+            // logically parented to a regular Map. They must not appear in
+            // the doc's top-level root enumeration — they are nested under
+            // their parent in deep value / events / paths.
+            if self
+                .arena
+                .idx_to_id(idx)
+                .is_some_and(|id| id.is_mergeable())
+            {
+                continue;
+            }
             let is_empty = self.root_container_is_empty(idx);
             match selected.entry(name.clone()) {
                 std::collections::hash_map::Entry::Vacant(entry) => {
@@ -1325,6 +1374,13 @@ impl DocState {
                 )
             }
             LoroValue::Map(mut map) => {
+                // A map's mergeable children are encoded as `"🤝:<kind>"` discriminator
+                // strings in the map's own value table (loro-dev/loro#759), so they are
+                // already present in `map` here. Derive the active children straight from
+                // that value — re-fetching the `MapState` would force the snapshot-backed
+                // container to decode and break the lazy-value invariant for roots.
+                let mergeable_children = self.mergeable_children_from_value(&id, &map);
+
                 let map_mut = map.make_mut();
                 for (_key, value) in map_mut.iter_mut() {
                     if value.is_container() {
@@ -1336,6 +1392,13 @@ impl DocState {
                         );
                         *value = new_value;
                     }
+                }
+                // Replace each discriminator string with the nested deep value of its
+                // resolved child, keyed under the same logical key.
+                for (key, cid) in mergeable_children {
+                    let child_idx = self.arena.register_container(&cid);
+                    let new_value = self.get_container_deep_value_with_id(child_idx, Some(cid));
+                    map_mut.insert(key.to_string(), new_value);
                 }
 
                 LoroValue::Map(
@@ -1387,7 +1450,18 @@ impl DocState {
                 LoroValue::List(list)
             }
             LoroValue::Map(mut map) => {
-                if map.iter().all(|x| !x.1.is_container()) {
+                // A map's mergeable children are encoded as `"🤝:<kind>"` discriminator
+                // strings in the map's own value table (loro-dev/loro#759), so they are
+                // already present in `map` here. Derive the active children straight from
+                // that value — re-fetching the `MapState` would force the snapshot-backed
+                // container to decode and break the lazy-value invariant for roots.
+                let mergeable_children = self
+                    .arena
+                    .idx_to_id(container)
+                    .map(|parent_id| self.mergeable_children_from_value(&parent_id, &map))
+                    .unwrap_or_default();
+
+                if mergeable_children.is_empty() && map.iter().all(|x| !x.1.is_container()) {
                     return LoroValue::Map(map);
                 }
 
@@ -1399,6 +1473,13 @@ impl DocState {
                         let new_value = self.get_container_deep_value(container_idx);
                         *value = new_value;
                     }
+                }
+                // Replace each discriminator string with the nested deep value of its
+                // resolved child, keyed under the same logical key.
+                for (key, cid) in mergeable_children {
+                    let child_idx = self.arena.register_container(&cid);
+                    let new_value = self.get_container_deep_value(child_idx);
+                    map_mut.insert(key.to_string(), new_value);
                 }
                 LoroValue::Map(map)
             }
@@ -1464,6 +1545,28 @@ impl DocState {
                     if let LoroValue::Container(id) = value {
                         ans.push(id.clone());
                     }
+                }
+                // Mergeable children are resolved from the discriminator strings stored in this
+                // map's own value table (loro-dev/loro#759): the active child at each key is the
+                // deterministic cid for whichever `"🤝:<kind>"` discriminator the map's regular
+                // LWW resolved to. Derive them from the value we already fetched lazily above —
+                // re-reading the decoded `MapState` would force a snapshot-backed map to
+                // materialize its full state. Pull them in so alive-container walks (notably
+                // shallow snapshot export) include mergeable cids and don't filter their KV out by
+                // `retain_keys`.
+                let mergeable_cids: Vec<ContainerID> = self
+                    .arena
+                    .idx_to_id(idx)
+                    .map(|parent_id| {
+                        self.mergeable_children_from_value(&parent_id, &map)
+                            .into_iter()
+                            .map(|(_key, cid)| cid)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                for cid in mergeable_cids {
+                    self.arena.register_container(&cid);
+                    ans.push(cid);
                 }
             }
             _ => {}
@@ -1552,7 +1655,7 @@ impl DocState {
     }
 
     pub(crate) fn get_reachable(&mut self, id: &ContainerID) -> bool {
-        if matches!(id, ContainerID::Root { .. }) {
+        if id.is_root() && !id.is_mergeable() {
             return true;
         }
 
@@ -1577,7 +1680,7 @@ impl DocState {
                 }
                 idx = parent_idx;
             } else {
-                if id.is_root() {
+                if id.is_root() && !id.is_mergeable() {
                     return true;
                 }
 
@@ -1592,6 +1695,9 @@ impl DocState {
         let mut idx = idx;
         loop {
             let id = self.arena.idx_to_id(idx).unwrap();
+            // Mergeable Roots are parented in the arena and their cid is registered in the parent
+            // MapState's child side table, so the normal `get_child_index` lookup below resolves
+            // the logical path entry without needing to decode `(parent, key)` from the cid here.
             if let Some(parent_idx) = self.arena.get_parent(idx) {
                 let parent_state = self.store.get_container_mut(parent_idx)?;
                 let Some(prop) = parent_state.get_child_index(&id) else {

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -661,12 +661,6 @@ impl DocState {
         // Suppose A is revived and B is A's child, and B also needs to be revived; therefore,
         // we should process each level alternately.
 
-        // Capture the parent map idxs touched by the diff batch BEFORE the main loop mutates
-        // `diffs`. Used by the post-loop hook to register mergeable parent edges from the
-        // discriminators the batch just applied, keeping update-import cost proportional to the
-        // diff size.
-        let map_parent_idxs = self.capture_mergeable_diff_batch(&diffs);
-
         // We need to ensure diff is processed in order
         diffs.sort_by_cached_key(|diff| self.arena.get_depth(diff.idx));
         let mut to_revive_in_next_layer: FxHashSet<ContainerIdx> = FxHashSet::default();
@@ -820,21 +814,6 @@ impl DocState {
         diff.diff = diffs.into();
         self.frontiers = diff.new_version.clone().into_owned();
 
-        // Register mergeable parent edges from the discriminators the diff batch just applied to
-        // their parent maps. This is the update-import counterpart of
-        // `repopulate_mergeable_child_side_tables` (which fires on snapshot import). Without it, a
-        // peer that imports a discriminator op — without first locally calling `get_mergeable_*` —
-        // would resolve the child in deep value (which reads the discriminator directly) but miss
-        // the parent edge that path resolution and reachability use. The walk reads the current
-        // discriminators, so it naturally drops edges for keys whose discriminator was cleared.
-        if !map_parent_idxs.is_empty() {
-            let parent_ids: Vec<ContainerID> = map_parent_idxs
-                .iter()
-                .filter_map(|idx| self.arena.idx_to_id(*idx))
-                .collect();
-            self.register_mergeable_children(parent_ids);
-        }
-
         if self.is_recording() {
             self.record_diff(diff)
         }
@@ -869,10 +848,6 @@ impl DocState {
             self.dead_containers_cache.clear_alive();
         }
 
-        // Keep the mergeable parent-edge index in sync with the discriminator this op may have
-        // written or cleared on a parent map.
-        self.sync_mergeable_side_table_for_op(raw_op, op);
-
         Ok(())
     }
 
@@ -898,13 +873,16 @@ impl DocState {
     pub fn does_container_exist(&mut self, id: &ContainerID) -> bool {
         // A container may exist even if not yet registered in the arena.
         // Check arena first, then fall back to KV presence in the store.
-        if id.is_root() && !id.is_mergeable() {
+        let is_mergeable = id.is_mergeable();
+        if id.is_root() && !is_mergeable {
             return true;
         }
 
-        if let Some(idx) = self.arena.id_to_idx(id) {
-            if self.arena.get_depth(idx).is_some() {
-                return true;
+        if !is_mergeable {
+            if let Some(idx) = self.arena.id_to_idx(id) {
+                if self.arena.get_depth(idx).is_some() {
+                    return true;
+                }
             }
         }
 
@@ -1025,17 +1003,6 @@ impl DocState {
                 }
             }
         }
-
-        // Re-register mergeable child containers in their parent MapState's
-        // side table. Mergeable children are real containers with their own
-        // state entries in KV (so they round-trip through snapshot), but the
-        // `MapState::child_containers` side table that drives deep-value walks
-        // and path resolution is NOT serialized (see
-        // `MapState::encode_snapshot_fast`). After import we walk all known
-        // container IDs, find the mergeable ones, and call
-        // `register_mergeable_child` on their parent MapStates to rebuild
-        // that side table from the deterministic cids.
-        self.repopulate_mergeable_child_side_tables(oplog);
 
         if !unknown_containers.is_empty() {
             let mut diff_calc = DiffCalculator::new(false);
@@ -1374,11 +1341,11 @@ impl DocState {
                 )
             }
             LoroValue::Map(mut map) => {
-                // A map's mergeable children are encoded as `"🤝:<kind>"` discriminator
-                // strings in the map's own value table (loro-dev/loro#759), so they are
-                // already present in `map` here. Derive the active children straight from
-                // that value — re-fetching the `MapState` would force the snapshot-backed
-                // container to decode and break the lazy-value invariant for roots.
+                // A map's mergeable children are encoded as compact binary markers in the map's
+                // own value table (loro-dev/loro#759), so they are already present in `map` here.
+                // Derive the active children straight from that value — re-fetching the
+                // `MapState` would force the snapshot-backed container to decode and break the
+                // lazy-value invariant for roots.
                 let mergeable_children = self.mergeable_children_from_value(&id, &map);
 
                 let map_mut = map.make_mut();
@@ -1393,8 +1360,8 @@ impl DocState {
                         *value = new_value;
                     }
                 }
-                // Replace each discriminator string with the nested deep value of its
-                // resolved child, keyed under the same logical key.
+                // Replace each marker with the nested deep value of its resolved child, keyed
+                // under the same logical key.
                 for (key, cid) in mergeable_children {
                     let child_idx = self.arena.register_container(&cid);
                     let new_value = self.get_container_deep_value_with_id(child_idx, Some(cid));
@@ -1450,11 +1417,11 @@ impl DocState {
                 LoroValue::List(list)
             }
             LoroValue::Map(mut map) => {
-                // A map's mergeable children are encoded as `"🤝:<kind>"` discriminator
-                // strings in the map's own value table (loro-dev/loro#759), so they are
-                // already present in `map` here. Derive the active children straight from
-                // that value — re-fetching the `MapState` would force the snapshot-backed
-                // container to decode and break the lazy-value invariant for roots.
+                // A map's mergeable children are encoded as compact binary markers in the map's
+                // own value table (loro-dev/loro#759), so they are already present in `map` here.
+                // Derive the active children straight from that value — re-fetching the
+                // `MapState` would force the snapshot-backed container to decode and break the
+                // lazy-value invariant for roots.
                 let mergeable_children = self
                     .arena
                     .idx_to_id(container)
@@ -1474,8 +1441,8 @@ impl DocState {
                         *value = new_value;
                     }
                 }
-                // Replace each discriminator string with the nested deep value of its
-                // resolved child, keyed under the same logical key.
+                // Replace each marker with the nested deep value of its resolved child, keyed
+                // under the same logical key.
                 for (key, cid) in mergeable_children {
                     let child_idx = self.arena.register_container(&cid);
                     let new_value = self.get_container_deep_value(child_idx);
@@ -1546,14 +1513,13 @@ impl DocState {
                         ans.push(id.clone());
                     }
                 }
-                // Mergeable children are resolved from the discriminator strings stored in this
+                // Mergeable children are resolved from compact binary markers stored in this
                 // map's own value table (loro-dev/loro#759): the active child at each key is the
-                // deterministic cid for whichever `"🤝:<kind>"` discriminator the map's regular
-                // LWW resolved to. Derive them from the value we already fetched lazily above —
-                // re-reading the decoded `MapState` would force a snapshot-backed map to
-                // materialize its full state. Pull them in so alive-container walks (notably
-                // shallow snapshot export) include mergeable cids and don't filter their KV out by
-                // `retain_keys`.
+                // deterministic cid for whichever marker the map's regular LWW resolved to.
+                // Derive them from the value we already fetched lazily above — re-reading the
+                // decoded `MapState` would force a snapshot-backed map to materialize its full
+                // state. Pull them in so alive-container walks (notably shallow snapshot export)
+                // include mergeable cids and don't filter their KV out by `retain_keys`.
                 let mergeable_cids: Vec<ContainerID> = self
                     .arena
                     .idx_to_id(idx)
@@ -1659,12 +1625,13 @@ impl DocState {
             return true;
         }
 
-        // If not registered yet, check KV presence, then register lazily
+        // If not registered yet, check KV presence for ordinary containers, then register lazily.
+        // Mergeable children can be active through a parent marker before they have their
+        // own KV state, so their reachability must be resolved by the logical edge walk below.
         if self.arena.id_to_idx(id).is_none() {
-            if !self.does_container_exist(id) {
+            if !id.is_mergeable() && !self.does_container_exist(id) {
                 return false;
             }
-            // Ensure it is registered so ancestor walk can resolve parents via resolver
             self.arena.register_container(id);
         }
 
@@ -1672,10 +1639,7 @@ impl DocState {
         loop {
             let id = self.arena.idx_to_id(idx).unwrap();
             if let Some(parent_idx) = self.arena.get_parent(idx) {
-                let Some(parent_state) = self.store.get_container_mut(parent_idx) else {
-                    return false;
-                };
-                if !parent_state.contains_child(&id) {
+                if !self.contains_logical_child(parent_idx, &id) {
                     return false;
                 }
                 idx = parent_idx;
@@ -1695,12 +1659,8 @@ impl DocState {
         let mut idx = idx;
         loop {
             let id = self.arena.idx_to_id(idx).unwrap();
-            // Mergeable Roots are parented in the arena and their cid is registered in the parent
-            // MapState's child side table, so the normal `get_child_index` lookup below resolves
-            // the logical path entry without needing to decode `(parent, key)` from the cid here.
             if let Some(parent_idx) = self.arena.get_parent(idx) {
-                let parent_state = self.store.get_container_mut(parent_idx)?;
-                let Some(prop) = parent_state.get_child_index(&id) else {
+                let Some(prop) = self.get_logical_child_index(parent_idx, &id) else {
                     tracing::warn!("Missing in parent's children");
                     return None;
                 };
@@ -1708,6 +1668,10 @@ impl DocState {
                 idx = parent_idx;
             } else {
                 // this container may be deleted
+                if id.is_mergeable() {
+                    tracing::info!(id = %id, "Missing parent - mergeable container is inactive");
+                    return None;
+                }
                 let Ok(prop) = id.clone().into_root() else {
                     let id = format!("{}", &id);
                     tracing::info!(?id, "Missing parent - container is deleted");
@@ -1895,13 +1859,14 @@ impl DocState {
             let index = &path[i];
             match state_idx {
                 CurContainer::Container(idx) => {
+                    let parent_id = self.arena.idx_to_id(idx);
                     let parent_state = self.store.get_container_mut(idx)?;
                     match parent_state {
                         State::ListState(l) => {
                             let Some(LoroValue::Container(c)) = l.get(*index.as_seq()?) else {
                                 return None;
                             };
-                            state_idx = CurContainer::Container(self.arena.register_container(c));
+                            state_idx = CurContainer::Container(self.arena.register_container(&c));
                         }
                         State::MovableListState(l) => {
                             let Some(LoroValue::Container(c)) =
@@ -1909,13 +1874,22 @@ impl DocState {
                             else {
                                 return None;
                             };
-                            state_idx = CurContainer::Container(self.arena.register_container(c));
+                            state_idx = CurContainer::Container(self.arena.register_container(&c));
                         }
                         State::MapState(m) => {
-                            let Some(LoroValue::Container(c)) = m.get(index.as_key()?) else {
-                                return None;
+                            let key = index.as_key()?;
+                            let value = m.get(key)?;
+                            let c = match value {
+                                LoroValue::Container(c) => c.clone(),
+                                value => {
+                                    let parent_id = parent_id?;
+                                    let kind = loro_common::parse_mergeable_marker(
+                                        &parent_id, key, value,
+                                    )?;
+                                    ContainerID::new_mergeable(&parent_id, key, kind)
+                                }
                             };
-                            state_idx = CurContainer::Container(self.arena.register_container(c));
+                            state_idx = CurContainer::Container(self.arena.register_container(&c));
                         }
                         State::RichtextState(_) => return None,
                         State::TreeState(_) => {
@@ -1988,14 +1962,27 @@ impl DocState {
             }
         };
 
-        let parent_state = self.store.get_or_create_mut(parent_idx);
         let index = path.last().unwrap();
+        let parent_id = self.arena.idx_to_id(parent_idx);
+        let parent_state = self.store.get_or_create_mut(parent_idx);
         let value: LoroValue = match parent_state {
             State::ListState(l) => l.get(*index.as_seq()?).cloned()?,
             State::MovableListState(l) => l.get(*index.as_seq()?, IndexType::ForUser).cloned()?,
             State::MapState(m) => {
                 if let Some(key) = index.as_key() {
-                    m.get(key).cloned()?
+                    let value = m.get(key).cloned()?;
+                    if let Some(parent_id) = &parent_id {
+                        if let Some(kind) =
+                            loro_common::parse_mergeable_marker(parent_id, key, &value)
+                        {
+                            let cid = ContainerID::new_mergeable(parent_id, key, kind);
+                            LoroValue::Container(cid)
+                        } else {
+                            value
+                        }
+                    } else {
+                        value
+                    }
                 } else if let CurContainer::TreeNode { tree, node } = state_idx {
                     match index {
                         Index::Seq(index) => {

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -265,6 +265,10 @@ impl ContainerStore {
         self.store.iter_all_container_ids()
     }
 
+    pub fn mergeable_container_ids(&self) -> Vec<ContainerID> {
+        self.store.mergeable_container_ids()
+    }
+
     pub fn load_all(&mut self) -> LoadAllFlag {
         self.store.load_all();
         LoadAllFlag

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -265,10 +265,6 @@ impl ContainerStore {
         self.store.iter_all_container_ids()
     }
 
-    pub fn mergeable_container_ids(&self) -> Vec<ContainerID> {
-        self.store.mergeable_container_ids()
-    }
-
     pub fn load_all(&mut self) -> LoadAllFlag {
         self.store.load_all();
         LoadAllFlag

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -367,6 +367,25 @@ impl InnerStore {
         self.load_state = LoadState::RootsLoaded;
     }
 
+    /// Scan KV keys for mergeable container ids without deserializing any container state.
+    ///
+    /// Mergeable children that have state entries round-trip through the snapshot as their own KV
+    /// entries; their cid alone encodes `(parent, key, kind)`. This decodes the cid from each KV
+    /// key (like `load_roots`) and keeps only the ones that parse as valid mergeable cids. It does
+    /// not load values, register containers, or change `load_state`.
+    pub(crate) fn mergeable_container_ids(&self) -> Vec<ContainerID> {
+        let mut ans = Vec::new();
+        self.kv.with_kv(|kv| {
+            for (k, _v) in kv.scan(Bound::Unbounded, Bound::Unbounded) {
+                let cid = ContainerID::from_bytes(&k);
+                if cid.is_mergeable() {
+                    ans.push(cid);
+                }
+            }
+        });
+        ans
+    }
+
     pub(crate) fn can_import_snapshot(&self) -> bool {
         if !self.kv.is_empty() {
             return false;

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -367,25 +367,6 @@ impl InnerStore {
         self.load_state = LoadState::RootsLoaded;
     }
 
-    /// Scan KV keys for mergeable container ids without deserializing any container state.
-    ///
-    /// Mergeable children that have state entries round-trip through the snapshot as their own KV
-    /// entries; their cid alone encodes `(parent, key, kind)`. This decodes the cid from each KV
-    /// key (like `load_roots`) and keeps only the ones that parse as valid mergeable cids. It does
-    /// not load values, register containers, or change `load_state`.
-    pub(crate) fn mergeable_container_ids(&self) -> Vec<ContainerID> {
-        let mut ans = Vec::new();
-        self.kv.with_kv(|kv| {
-            for (k, _v) in kv.scan(Bound::Unbounded, Bound::Unbounded) {
-                let cid = ContainerID::from_bytes(&k);
-                if cid.is_mergeable() {
-                    ans.push(cid);
-                }
-            }
-        });
-        ans
-    }
-
     pub(crate) fn can_import_snapshot(&self) -> bool {
         if !self.kv.is_empty() {
             return false;

--- a/crates/loro-internal/src/state/dead_containers_cache.rs
+++ b/crates/loro-internal/src/state/dead_containers_cache.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::{cursor::PosType, HandlerTrait, LoroDoc, TextHandler};
 
     /// A mergeable child can be deleted and then reactivated: `delete(key)` clears its
-    /// marker (child unreachable), and a later `get_mergeable_<kind>(key)` writes the
+    /// marker (child unreachable), and a later `ensure_mergeable_<kind>(key)` writes the
     /// marker back (child reachable again). While the child is unreachable, querying its
     /// liveness must not cache a `deleted` entry because that answer depends on the mutable
     /// mergeable marker edge.
@@ -117,7 +117,7 @@ mod tests {
         let doc = LoroDoc::new_auto_commit();
         doc.set_peer_id(1).unwrap();
         let root = doc.get_map("state");
-        let counter = root.get_mergeable_counter("revision").unwrap();
+        let counter = root.ensure_mergeable_counter("revision").unwrap();
         counter.increment(1.0).unwrap();
         doc.commit_then_renew();
 
@@ -133,7 +133,7 @@ mod tests {
             "mergeable-dependent deletion must not be cached"
         );
 
-        root.get_mergeable_counter("revision").unwrap();
+        root.ensure_mergeable_counter("revision").unwrap();
         doc.commit_then_renew();
         assert_eq!(
             doc.state.lock().dead_cache_entry(idx),
@@ -150,7 +150,7 @@ mod tests {
         let doc = LoroDoc::new_auto_commit();
         doc.set_peer_id(1).unwrap();
         let root = doc.get_map("state");
-        let profile = root.get_mergeable_map("profile").unwrap();
+        let profile = root.ensure_mergeable_map("profile").unwrap();
         let text = profile
             .insert_container("bio", TextHandler::new_detached())
             .unwrap();
@@ -169,7 +169,7 @@ mod tests {
             "ordinary descendants behind a mergeable edge must not be cached as deleted"
         );
 
-        root.get_mergeable_map("profile").unwrap();
+        root.ensure_mergeable_map("profile").unwrap();
         doc.commit_then_renew();
         assert!(!text.is_deleted());
         assert_eq!(
@@ -180,7 +180,7 @@ mod tests {
     }
 
     /// The same stale-cache hazard exists when reactivation arrives from a *peer* via import,
-    /// not just from a local `get_mergeable_*` call. The importing peer must not cache the
+    /// not just from a local `ensure_mergeable_*` call. The importing peer must not cache the
     /// mergeable-dependent deleted result before the reactivation update arrives.
     ///
     /// The scenario, with two peers A (author) and B (importer):
@@ -202,7 +202,7 @@ mod tests {
         let doc_a = LoroDoc::new_auto_commit();
         doc_a.set_peer_id(1).unwrap();
         let root_a = doc_a.get_map("state");
-        let counter_a = root_a.get_mergeable_counter("revision").unwrap();
+        let counter_a = root_a.ensure_mergeable_counter("revision").unwrap();
         counter_a.increment(1.0).unwrap();
         doc_a.commit_then_renew();
         root_a.delete("revision").unwrap();
@@ -227,7 +227,7 @@ mod tests {
 
         // A reactivates the child locally and exports just the new update.
         let vv_before = doc_a.oplog_vv();
-        root_a.get_mergeable_counter("revision").unwrap();
+        root_a.ensure_mergeable_counter("revision").unwrap();
         doc_a.commit_then_renew();
         let reactivation = doc_a.export(ExportMode::updates(&vv_before)).unwrap();
 

--- a/crates/loro-internal/src/state/dead_containers_cache.rs
+++ b/crates/loro-internal/src/state/dead_containers_cache.rs
@@ -138,4 +138,68 @@ mod tests {
             "reactivation must drop the stale deleted-cache entry"
         );
     }
+
+    /// The same stale-cache hazard exists when reactivation arrives from a *peer* via import,
+    /// not just from a local `get_mergeable_*` call. The update-import side-table rebuild
+    /// (`register_mergeable_children` -> `register_mergeable_edges_of_map`) re-registers the
+    /// active child, and must also clear the importing peer's poisoned deleted-cache entry.
+    ///
+    /// The scenario, with two peers A (author) and B (importer):
+    /// 1. A creates the mergeable counter and deletes the key, then exports.
+    /// 2. B imports A's updates so the child exists but is unreachable, and queries
+    ///    `is_deleted()` to poison B's `dead_containers_cache` with a `deleted` entry.
+    /// 3. A re-gets the counter (rewriting the discriminator, reactivating the child) and
+    ///    exports just that new update.
+    /// 4. B imports the reactivation update; the import path re-registers the parent edge.
+    /// 5. Assert B's cache no longer holds a `deleted` entry for that idx.
+    ///
+    /// Like the local-reactivation test, this asserts cache contents directly rather than
+    /// through `is_deleted()`, because `is_deleted()` only trusts the cache via a release-only
+    /// early return; a public-API assertion would pass in debug even with the bug present.
+    #[test]
+    fn imported_mergeable_child_reactivation_clears_dead_cache() {
+        use crate::loro::ExportMode;
+
+        let doc_a = LoroDoc::new_auto_commit();
+        doc_a.set_peer_id(1).unwrap();
+        let root_a = doc_a.get_map("state");
+        let counter_a = root_a.get_mergeable_counter("revision").unwrap();
+        counter_a.increment(1.0).unwrap();
+        doc_a.commit_then_renew();
+        root_a.delete("revision").unwrap();
+        doc_a.commit_then_renew();
+
+        let cid: ContainerID = counter_a.id();
+
+        // B imports A's history: the child exists but is unreachable (discriminator cleared).
+        let doc_b = LoroDoc::new_auto_commit();
+        doc_b.set_peer_id(2).unwrap();
+        doc_b
+            .import(&doc_a.export(ExportMode::all_updates()).unwrap())
+            .unwrap();
+
+        let idx = doc_b.state.lock().arena.id_to_idx(&cid).unwrap();
+        // Poison B's cache: querying the unreachable child records it as deleted.
+        assert!(doc_b.state.lock().is_deleted(idx));
+        assert_eq!(
+            doc_b.state.lock().dead_cache_entry(idx),
+            Some(true),
+            "import of a deleted child must record it as deleted in the cache"
+        );
+
+        // A reactivates the child locally and exports just the new update.
+        let vv_before = doc_a.oplog_vv();
+        root_a.get_mergeable_counter("revision").unwrap();
+        doc_a.commit_then_renew();
+        let reactivation = doc_a.export(ExportMode::updates(&vv_before)).unwrap();
+
+        // B imports the reactivation: the import path re-registers the parent edge and must
+        // drop the stale deleted-cache entry.
+        doc_b.import(&reactivation).unwrap();
+        assert_eq!(
+            doc_b.state.lock().dead_cache_entry(idx),
+            None,
+            "imported reactivation must drop the stale deleted-cache entry"
+        );
+    }
 }

--- a/crates/loro-internal/src/state/dead_containers_cache.rs
+++ b/crates/loro-internal/src/state/dead_containers_cache.rs
@@ -15,6 +15,10 @@ impl DeadContainersCache {
     pub(crate) fn clear_alive(&mut self) {
         self.cache.retain(|_, is_deleted| *is_deleted);
     }
+
+    pub(crate) fn remove(&mut self, idx: ContainerIdx) {
+        self.cache.remove(&idx);
+    }
 }
 
 impl DocState {
@@ -72,5 +76,66 @@ impl DocState {
         }
 
         is_deleted
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dead_cache_entry(&self, idx: ContainerIdx) -> Option<bool> {
+        self.dead_containers_cache.cache.get(&idx).copied()
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "counter")]
+mod tests {
+    use loro_common::ContainerID;
+
+    use crate::{HandlerTrait, LoroDoc};
+
+    /// A mergeable child can be deleted and then reactivated: `delete(key)` clears its
+    /// discriminator (child unreachable), and a later `get_mergeable_<kind>(key)` writes the
+    /// discriminator back (child reachable again). While the child is unreachable, querying its
+    /// liveness records it in `dead_containers_cache` as deleted. This test verifies that
+    /// reactivation removes that entry, so the cache cannot keep reporting the resurrected child
+    /// as deleted.
+    ///
+    /// The scenario:
+    /// 1. Create the mergeable counter and capture its container idx.
+    /// 2. Delete the key, then query `is_deleted()` to poison the cache with a `deleted` entry.
+    /// 3. Re-get the counter to rewrite the discriminator and reactivate the child.
+    /// 4. Assert the cache no longer holds a `deleted` entry for that idx.
+    ///
+    /// It asserts the cache contents directly rather than going through `is_deleted()`, because
+    /// `is_deleted()` only trusts the cache via a release-only early return; a public-API
+    /// assertion would pass in debug even with the bug present. Inspecting the cache makes the
+    /// regression fail in both debug and release builds.
+    #[test]
+    fn reactivated_mergeable_child_has_no_stale_dead_cache_entry() {
+        let doc = LoroDoc::new_auto_commit();
+        doc.set_peer_id(1).unwrap();
+        let root = doc.get_map("state");
+        let counter = root.get_mergeable_counter("revision").unwrap();
+        counter.increment(1.0).unwrap();
+        doc.commit_then_renew();
+
+        let cid: ContainerID = counter.id();
+        let idx = doc.state.lock().arena.id_to_idx(&cid).unwrap();
+
+        root.delete("revision").unwrap();
+        doc.commit_then_renew();
+        // Poison the cache: querying the unreachable child records it as deleted.
+        assert!(counter.is_deleted());
+        assert_eq!(
+            doc.state.lock().dead_cache_entry(idx),
+            Some(true),
+            "delete must record the child as deleted in the cache"
+        );
+
+        root.get_mergeable_counter("revision").unwrap();
+        doc.commit_then_renew();
+        assert_eq!(
+            doc.state.lock().dead_cache_entry(idx),
+            None,
+            "reactivation must drop the stale deleted-cache entry"
+        );
     }
 }

--- a/crates/loro-internal/src/state/dead_containers_cache.rs
+++ b/crates/loro-internal/src/state/dead_containers_cache.rs
@@ -36,13 +36,21 @@ impl DocState {
                     break true;
                 };
                 if !parent_state.contains_child(&id) {
+                    // The parent has no edge to this child. For a mergeable child this means its
+                    // discriminator is no longer active at the key (it was deleted or its kind
+                    // changed), so the child is unreachable — exactly like a regular container
+                    // whose value slot was overwritten. Re-`get_mergeable_<kind>` rewrites the
+                    // discriminator and brings it back.
                     break true;
                 }
 
                 idx = parent_idx;
                 visited.push(idx);
             } else {
-                break !id.is_root();
+                // No parent in the arena: top-level Roots are always alive; anything else
+                // (including a mergeable Root whose parent edge was never wired) is treated
+                // as deleted.
+                break !id.is_root() || id.is_mergeable();
             }
         };
 

--- a/crates/loro-internal/src/state/dead_containers_cache.rs
+++ b/crates/loro-internal/src/state/dead_containers_cache.rs
@@ -1,4 +1,4 @@
-use super::{ContainerState, DocState};
+use super::DocState;
 use crate::container::idx::ContainerIdx;
 use rustc_hash::FxHashMap;
 
@@ -15,10 +15,6 @@ impl DeadContainersCache {
     pub(crate) fn clear_alive(&mut self) {
         self.cache.retain(|_, is_deleted| *is_deleted);
     }
-
-    pub(crate) fn remove(&mut self, idx: ContainerIdx) {
-        self.cache.remove(&idx);
-    }
 }
 
 impl DocState {
@@ -33,18 +29,14 @@ impl DocState {
 
         let mut visited = vec![idx];
         let mut idx = idx;
+        let mut depends_on_mergeable_edge = false;
         let is_deleted = loop {
             let id = self.arena.idx_to_id(idx).unwrap();
+            if id.is_mergeable() {
+                depends_on_mergeable_edge = true;
+            }
             if let Some(parent_idx) = self.arena.get_parent(idx) {
-                let Some(parent_state) = self.store.get_container_mut(parent_idx) else {
-                    break true;
-                };
-                if !parent_state.contains_child(&id) {
-                    // The parent has no edge to this child. For a mergeable child this means its
-                    // discriminator is no longer active at the key (it was deleted or its kind
-                    // changed), so the child is unreachable — exactly like a regular container
-                    // whose value slot was overwritten. Re-`get_mergeable_<kind>` rewrites the
-                    // discriminator and brings it back.
+                if !self.contains_logical_child(parent_idx, &id) {
                     break true;
                 }
 
@@ -60,9 +52,23 @@ impl DocState {
 
         #[cfg(debug_assertions)]
         {
-            if let Some(cached_is_deleted) = self.dead_containers_cache.cache.get(&idx) {
-                assert_eq!(is_deleted, *cached_is_deleted);
+            if !depends_on_mergeable_edge {
+                if let Some(cached_is_deleted) = self.dead_containers_cache.cache.get(&idx) {
+                    assert_eq!(is_deleted, *cached_is_deleted);
+                }
             }
+        }
+
+        // A mergeable ancestor can be deleted and later reactivated by changing the parent map's
+        // marker. Do not cache deletion for any descendant whose liveness depends on that
+        // logical edge, including ordinary children nested inside a mergeable map.
+        if depends_on_mergeable_edge {
+            if !is_deleted {
+                for idx in visited {
+                    self.dead_containers_cache.cache.remove(&idx);
+                }
+            }
+            return is_deleted;
         }
 
         if is_deleted {
@@ -89,25 +95,23 @@ impl DocState {
 mod tests {
     use loro_common::ContainerID;
 
-    use crate::{HandlerTrait, LoroDoc};
+    use crate::{cursor::PosType, HandlerTrait, LoroDoc, TextHandler};
 
     /// A mergeable child can be deleted and then reactivated: `delete(key)` clears its
-    /// discriminator (child unreachable), and a later `get_mergeable_<kind>(key)` writes the
-    /// discriminator back (child reachable again). While the child is unreachable, querying its
-    /// liveness records it in `dead_containers_cache` as deleted. This test verifies that
-    /// reactivation removes that entry, so the cache cannot keep reporting the resurrected child
-    /// as deleted.
+    /// marker (child unreachable), and a later `get_mergeable_<kind>(key)` writes the
+    /// marker back (child reachable again). While the child is unreachable, querying its
+    /// liveness must not cache a `deleted` entry because that answer depends on the mutable
+    /// mergeable marker edge.
     ///
     /// The scenario:
     /// 1. Create the mergeable counter and capture its container idx.
-    /// 2. Delete the key, then query `is_deleted()` to poison the cache with a `deleted` entry.
-    /// 3. Re-get the counter to rewrite the discriminator and reactivate the child.
-    /// 4. Assert the cache no longer holds a `deleted` entry for that idx.
+    /// 2. Delete the key, then query `is_deleted()`.
+    /// 3. Re-get the counter to rewrite the marker and reactivate the child.
+    /// 4. Assert the cache never held a `deleted` entry for that idx.
     ///
-    /// It asserts the cache contents directly rather than going through `is_deleted()`, because
-    /// `is_deleted()` only trusts the cache via a release-only early return; a public-API
-    /// assertion would pass in debug even with the bug present. Inspecting the cache makes the
-    /// regression fail in both debug and release builds.
+    /// It asserts the cache contents directly because `is_deleted()` only trusts the cache via a
+    /// release-only early return; inspecting the cache makes stale-cache regressions fail in both
+    /// debug and release builds.
     #[test]
     fn reactivated_mergeable_child_has_no_stale_dead_cache_entry() {
         let doc = LoroDoc::new_auto_commit();
@@ -122,12 +126,11 @@ mod tests {
 
         root.delete("revision").unwrap();
         doc.commit_then_renew();
-        // Poison the cache: querying the unreachable child records it as deleted.
         assert!(counter.is_deleted());
         assert_eq!(
             doc.state.lock().dead_cache_entry(idx),
-            Some(true),
-            "delete must record the child as deleted in the cache"
+            None,
+            "mergeable-dependent deletion must not be cached"
         );
 
         root.get_mergeable_counter("revision").unwrap();
@@ -139,19 +142,55 @@ mod tests {
         );
     }
 
+    /// The no-cache rule also applies to ordinary descendants under a mergeable ancestor. A
+    /// regular child container can look cache-safe by cid shape, but its liveness still depends on
+    /// the ancestor's marker edge.
+    #[test]
+    fn ordinary_child_under_reactivated_mergeable_map_has_no_stale_dead_cache_entry() {
+        let doc = LoroDoc::new_auto_commit();
+        doc.set_peer_id(1).unwrap();
+        let root = doc.get_map("state");
+        let profile = root.get_mergeable_map("profile").unwrap();
+        let text = profile
+            .insert_container("bio", TextHandler::new_detached())
+            .unwrap();
+        text.insert(0, "Ada", PosType::Unicode).unwrap();
+        doc.commit_then_renew();
+
+        let text_id: ContainerID = text.id();
+        let text_idx = doc.state.lock().arena.id_to_idx(&text_id).unwrap();
+
+        root.delete("profile").unwrap();
+        doc.commit_then_renew();
+        assert!(text.is_deleted());
+        assert_eq!(
+            doc.state.lock().dead_cache_entry(text_idx),
+            None,
+            "ordinary descendants behind a mergeable edge must not be cached as deleted"
+        );
+
+        root.get_mergeable_map("profile").unwrap();
+        doc.commit_then_renew();
+        assert!(!text.is_deleted());
+        assert_eq!(
+            doc.state.lock().dead_cache_entry(text_idx),
+            None,
+            "reactivated ordinary descendant must not leave a stale cache entry"
+        );
+    }
+
     /// The same stale-cache hazard exists when reactivation arrives from a *peer* via import,
-    /// not just from a local `get_mergeable_*` call. The update-import side-table rebuild
-    /// (`register_mergeable_children` -> `register_mergeable_edges_of_map`) re-registers the
-    /// active child, and must also clear the importing peer's poisoned deleted-cache entry.
+    /// not just from a local `get_mergeable_*` call. The importing peer must not cache the
+    /// mergeable-dependent deleted result before the reactivation update arrives.
     ///
     /// The scenario, with two peers A (author) and B (importer):
     /// 1. A creates the mergeable counter and deletes the key, then exports.
     /// 2. B imports A's updates so the child exists but is unreachable, and queries
-    ///    `is_deleted()` to poison B's `dead_containers_cache` with a `deleted` entry.
-    /// 3. A re-gets the counter (rewriting the discriminator, reactivating the child) and
+    ///    `is_deleted()`.
+    /// 3. A re-gets the counter (rewriting the marker, reactivating the child) and
     ///    exports just that new update.
-    /// 4. B imports the reactivation update; the import path re-registers the parent edge.
-    /// 5. Assert B's cache no longer holds a `deleted` entry for that idx.
+    /// 4. B imports the reactivation update.
+    /// 5. Assert B's cache never held a `deleted` entry for that idx.
     ///
     /// Like the local-reactivation test, this asserts cache contents directly rather than
     /// through `is_deleted()`, because `is_deleted()` only trusts the cache via a release-only
@@ -171,7 +210,7 @@ mod tests {
 
         let cid: ContainerID = counter_a.id();
 
-        // B imports A's history: the child exists but is unreachable (discriminator cleared).
+        // B imports A's history: the child exists but is unreachable (marker cleared).
         let doc_b = LoroDoc::new_auto_commit();
         doc_b.set_peer_id(2).unwrap();
         doc_b
@@ -179,12 +218,11 @@ mod tests {
             .unwrap();
 
         let idx = doc_b.state.lock().arena.id_to_idx(&cid).unwrap();
-        // Poison B's cache: querying the unreachable child records it as deleted.
         assert!(doc_b.state.lock().is_deleted(idx));
         assert_eq!(
             doc_b.state.lock().dead_cache_entry(idx),
-            Some(true),
-            "import of a deleted child must record it as deleted in the cache"
+            None,
+            "imported mergeable-dependent deletion must not be cached"
         );
 
         // A reactivates the child locally and exports just the new update.
@@ -193,8 +231,7 @@ mod tests {
         doc_a.commit_then_renew();
         let reactivation = doc_a.export(ExportMode::updates(&vv_before)).unwrap();
 
-        // B imports the reactivation: the import path re-registers the parent edge and must
-        // drop the stale deleted-cache entry.
+        // B imports the reactivation. There must be no stale deleted-cache entry left to mask it.
         doc_b.import(&reactivation).unwrap();
         assert_eq!(
             doc_b.state.lock().dead_cache_entry(idx),

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -145,6 +145,22 @@ impl Default for ChildContainers {
     }
 }
 
+enum ChildContainersIter<'a> {
+    Tiny(std::slice::Iter<'a, (ContainerID, InternalString)>),
+    Map(std::collections::hash_map::Iter<'a, ContainerID, InternalString>),
+}
+
+impl<'a> Iterator for ChildContainersIter<'a> {
+    type Item = (&'a ContainerID, &'a InternalString);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Tiny(iter) => iter.next().map(|(id, key)| (id, key)),
+            Self::Map(iter) => iter.next(),
+        }
+    }
+}
+
 impl ChildContainers {
     fn get(&self, id: &ContainerID) -> Option<&InternalString> {
         match self {
@@ -200,12 +216,28 @@ impl ChildContainers {
             }
         }
     }
+
+    fn iter(&self) -> ChildContainersIter<'_> {
+        match self {
+            Self::Tiny(entries) => ChildContainersIter::Tiny(entries.iter()),
+            Self::Map(map) => ChildContainersIter::Map(map.iter()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct MapState {
     idx: ContainerIdx,
     map: MapEntries,
+    /// Parent-edge index for regular child containers (`MapValue::Container`).
+    ///
+    /// Mergeable children's *reachability* is NOT tracked here: it is derived from the
+    /// `"🤝:<kind>"` discriminator stored in `map` (resolved at read time by
+    /// `DocState::mergeable_children_from_value`). The discriminator is the single source of truth,
+    /// exactly as a regular child's value-table entry is for regular children. The parent-edge
+    /// index entries this map DOES hold for mergeable cids only wire a cid back to its key for
+    /// [`Self::get_child_index`] and [`Self::contains_child`]; they are seeded from the
+    /// discriminators and kept in sync with them.
     child_containers: ChildContainers,
     size: usize,
 }
@@ -331,6 +363,14 @@ impl ContainerState for MapState {
                 ans.push(x.clone());
             }
         }
+        // Mergeable children are tracked in `child_containers` (registered when their
+        // discriminator op applies, removed when a delete clears it), so they appear here
+        // for reachability / parent-edge wiring just like regular children.
+        for (id, _) in self.child_containers.iter() {
+            if id.is_mergeable() {
+                ans.push(id.clone());
+            }
+        }
         ans
     }
 
@@ -421,6 +461,43 @@ impl MapState {
 
     pub fn get_last_edit_peer(&self, key: &str) -> Option<PeerID> {
         self.map.get(&key.into()).map(|v| v.peer)
+    }
+
+    /// Register a mergeable child container's parent edge in `child_containers`.
+    ///
+    /// Mergeable children have deterministic [`ContainerID::Root`] ids derived from
+    /// `(parent_id, key, kind)` (see [`ContainerID::new_mergeable`]). Their *visibility* is
+    /// driven by the `"🤝:<kind>"` discriminator stored in `self.map` (resolved by
+    /// `DocState::mergeable_children_from_value`); this side-table entry only wires up the parent
+    /// edge so path resolution and reachability (`get_child_index`, `contains_child`) resolve
+    /// the cid to its logical key. Registration is kept in sync with the discriminator by the
+    /// DocState op-apply hook and the import walk.
+    pub fn register_mergeable_child(&mut self, key: InternalString, id: ContainerID) {
+        debug_assert!(
+            id.is_mergeable(),
+            "register_mergeable_child must only be called with mergeable container ids"
+        );
+        self.child_containers.insert(id, key);
+    }
+
+    /// Iterate `(key, cid)` pairs for mergeable parent edges currently in the side table. Used
+    /// by the DocState op-apply hook to find a stale mergeable edge to evict when a key's
+    /// discriminator is cleared.
+    pub(crate) fn iter_mergeable_children(
+        &self,
+    ) -> impl Iterator<Item = (&InternalString, &ContainerID)> {
+        self.child_containers
+            .iter()
+            .filter(|(id, _)| id.is_mergeable())
+            .map(|(id, key)| (key, id))
+    }
+
+    /// Evict a specific mergeable parent edge from the side table. Returns true if the cid was
+    /// registered and removed; false if it wasn't present. Called by the DocState op-apply hook
+    /// when a key's discriminator is cleared (a delete or an overwrite to a non-discriminator
+    /// value).
+    pub fn evict_mergeable_child_cid(&mut self, cid: &ContainerID) -> bool {
+        self.child_containers.remove(cid).is_some()
     }
 }
 

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -145,22 +145,6 @@ impl Default for ChildContainers {
     }
 }
 
-enum ChildContainersIter<'a> {
-    Tiny(std::slice::Iter<'a, (ContainerID, InternalString)>),
-    Map(std::collections::hash_map::Iter<'a, ContainerID, InternalString>),
-}
-
-impl<'a> Iterator for ChildContainersIter<'a> {
-    type Item = (&'a ContainerID, &'a InternalString);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Tiny(iter) => iter.next().map(|(id, key)| (id, key)),
-            Self::Map(iter) => iter.next(),
-        }
-    }
-}
-
 impl ChildContainers {
     fn get(&self, id: &ContainerID) -> Option<&InternalString> {
         match self {
@@ -216,28 +200,15 @@ impl ChildContainers {
             }
         }
     }
-
-    fn iter(&self) -> ChildContainersIter<'_> {
-        match self {
-            Self::Tiny(entries) => ChildContainersIter::Tiny(entries.iter()),
-            Self::Map(map) => ChildContainersIter::Map(map.iter()),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
 pub struct MapState {
     idx: ContainerIdx,
     map: MapEntries,
-    /// Parent-edge index for regular child containers (`MapValue::Container`).
-    ///
-    /// Mergeable children's *reachability* is NOT tracked here: it is derived from the
-    /// `"🤝:<kind>"` discriminator stored in `map` (resolved at read time by
-    /// `DocState::mergeable_children_from_value`). The discriminator is the single source of truth,
-    /// exactly as a regular child's value-table entry is for regular children. The parent-edge
-    /// index entries this map DOES hold for mergeable cids only wire a cid back to its key for
-    /// [`Self::get_child_index`] and [`Self::contains_child`]; they are seeded from the
-    /// discriminators and kept in sync with them.
+    /// Parent-edge index for regular child containers (`MapValue::Container`). Mergeable child
+    /// edges are resolved by `DocState` from their deterministic cid and this map's marker
+    /// value, not stored here.
     child_containers: ChildContainers,
     size: usize,
 }
@@ -363,14 +334,6 @@ impl ContainerState for MapState {
                 ans.push(x.clone());
             }
         }
-        // Mergeable children are tracked in `child_containers` (registered when their
-        // discriminator op applies, removed when a delete clears it), so they appear here
-        // for reachability / parent-edge wiring just like regular children.
-        for (id, _) in self.child_containers.iter() {
-            if id.is_mergeable() {
-                ans.push(id.clone());
-            }
-        }
         ans
     }
 
@@ -461,43 +424,6 @@ impl MapState {
 
     pub fn get_last_edit_peer(&self, key: &str) -> Option<PeerID> {
         self.map.get(&key.into()).map(|v| v.peer)
-    }
-
-    /// Register a mergeable child container's parent edge in `child_containers`.
-    ///
-    /// Mergeable children have deterministic [`ContainerID::Root`] ids derived from
-    /// `(parent_id, key, kind)` (see [`ContainerID::new_mergeable`]). Their *visibility* is
-    /// driven by the `"🤝:<kind>"` discriminator stored in `self.map` (resolved by
-    /// `DocState::mergeable_children_from_value`); this side-table entry only wires up the parent
-    /// edge so path resolution and reachability (`get_child_index`, `contains_child`) resolve
-    /// the cid to its logical key. Registration is kept in sync with the discriminator by the
-    /// DocState op-apply hook and the import walk.
-    pub fn register_mergeable_child(&mut self, key: InternalString, id: ContainerID) {
-        debug_assert!(
-            id.is_mergeable(),
-            "register_mergeable_child must only be called with mergeable container ids"
-        );
-        self.child_containers.insert(id, key);
-    }
-
-    /// Iterate `(key, cid)` pairs for mergeable parent edges currently in the side table. Used
-    /// by the DocState op-apply hook to find a stale mergeable edge to evict when a key's
-    /// discriminator is cleared.
-    pub(crate) fn iter_mergeable_children(
-        &self,
-    ) -> impl Iterator<Item = (&InternalString, &ContainerID)> {
-        self.child_containers
-            .iter()
-            .filter(|(id, _)| id.is_mergeable())
-            .map(|(id, key)| (key, id))
-    }
-
-    /// Evict a specific mergeable parent edge from the side table. Returns true if the cid was
-    /// registered and removed; false if it wasn't present. Called by the DocState op-apply hook
-    /// when a key's discriminator is cleared (a delete or an overwrite to a non-discriminator
-    /// value).
-    pub fn evict_mergeable_child_cid(&mut self, cid: &ContainerID) -> bool {
-        self.child_containers.remove(cid).is_some()
     }
 }
 

--- a/crates/loro-internal/src/state/mergeable.rs
+++ b/crates/loro-internal/src/state/mergeable.rs
@@ -15,7 +15,7 @@
 //! [`MapState`]: super::map_state::MapState
 //! [`DocState::mergeable_children_from_value`]: super::DocState::mergeable_children_from_value
 
-use loro_common::{ContainerID, ContainerType, InternalString, LoroMapValue, LoroValue};
+use loro_common::{ContainerID, InternalString, LoroMapValue, LoroValue};
 use rustc_hash::FxHashSet;
 
 use crate::{
@@ -39,13 +39,28 @@ impl DocState {
     ///
     /// Called from [`Self::init_with_states_and_version`] right after a snapshot decode.
     pub(super) fn repopulate_mergeable_child_side_tables(&mut self, _oplog: &OpLog) {
-        let map_cids: Vec<ContainerID> = self
-            .store
-            .iter_all_container_ids()
-            .filter(|id| matches!(id.container_type(), ContainerType::Map))
-            .collect();
+        // Mergeable children that have state entries round-trip through the snapshot as their own
+        // KV entries, and their cid encodes `(parent, key, kind)`. Scan KV keys for those cids
+        // (no value decode, no `load_all`) instead of walking every Map and reading its value.
+        // Unmutated mergeable children have no state entry; they are reconstructed lazily by the
+        // read paths from the parent's discriminator, so they need no eager registration here.
+        let mergeable_cids = self.store.mergeable_container_ids();
 
-        for parent_id in map_cids {
+        // Group candidates by parent map so each parent's discriminators are read at most once.
+        // `register_mergeable_edges_of_map` re-derives the active children from the parent's value
+        // and only registers edges whose discriminator still matches, so a scanned cid whose slot
+        // was deleted or kind-changed is naturally dropped.
+        let mut parent_ids: Vec<ContainerID> = Vec::new();
+        let mut seen: FxHashSet<ContainerID> = FxHashSet::default();
+        for cid in mergeable_cids {
+            if let Some((parent_id, _key, _kind)) = cid.parse_mergeable() {
+                if seen.insert(parent_id.clone()) {
+                    parent_ids.push(parent_id);
+                }
+            }
+        }
+
+        for parent_id in parent_ids {
             self.register_mergeable_edges_of_map(&parent_id);
         }
     }

--- a/crates/loro-internal/src/state/mergeable.rs
+++ b/crates/loro-internal/src/state/mergeable.rs
@@ -1,11 +1,11 @@
 //! Mergeable-container edge resolution on `DocState`.
 //!
-//! Mergeable child containers (created via `MapHandler::get_mergeable_*`) use deterministic
+//! Mergeable child containers (created via `MapHandler::ensure_mergeable_*`) use deterministic
 //! `ContainerID::Root` ids in a reserved namespace. The cid encodes `(parent, key, kind)`, while
 //! the parent map's compact binary child ref is the single source of truth for whether that child
 //! is currently active.
 //!
-//! The ref is intentionally stored as binary user data rather than a reserved string. This keeps
+//! The ref is intentionally stored as a specially constructed binary marker value. This keeps
 //! user-editable strings from being reinterpreted as internal container topology, and lets the
 //! resolver fail closed unless the ref's digest matches the exact `(parent, key, kind)` being
 //! resolved.
@@ -29,7 +29,7 @@ impl DocState {
         child_id: &ContainerID,
     ) -> Option<Index> {
         if let Some((parent_id, key, kind)) = child_id.parse_mergeable() {
-            return self.get_mergeable_child_index(parent_idx, &parent_id, &key, kind);
+            return self.resolve_mergeable_child_index(parent_idx, &parent_id, &key, kind);
         }
 
         self.store
@@ -45,7 +45,7 @@ impl DocState {
         self.get_logical_child_index(parent_idx, child_id).is_some()
     }
 
-    fn get_mergeable_child_index(
+    fn resolve_mergeable_child_index(
         &mut self,
         parent_idx: ContainerIdx,
         encoded_parent_id: &ContainerID,

--- a/crates/loro-internal/src/state/mergeable.rs
+++ b/crates/loro-internal/src/state/mergeable.rs
@@ -1,186 +1,80 @@
-//! Mergeable-container bookkeeping on `DocState`.
+//! Mergeable-container edge resolution on `DocState`.
 //!
-//! Mergeable child containers (created via `MapHandler::get_mergeable_*`) live as deterministic
-//! `ContainerID::Root` ids in a reserved namespace. Their *visibility* is driven entirely by the
-//! `"🤝:<kind>"` discriminator string the parent map stores at the key (see loro-dev/loro#759 and
-//! [`DocState::mergeable_children_from_value`]): whichever discriminator the parent map's regular
-//! LWW resolves to picks the active kind, exactly as a regular child container's value-table entry
-//! picks the active child.
+//! Mergeable child containers (created via `MapHandler::get_mergeable_*`) use deterministic
+//! `ContainerID::Root` ids in a reserved namespace. The cid encodes `(parent, key, kind)`, while
+//! the parent map's compact binary child ref is the single source of truth for whether that child
+//! is currently active.
 //!
-//! The only out-of-band state is the parent-edge index (`child_containers` on [`MapState`]), which
-//! lets path resolution and reachability map a mergeable cid back to its key. This module keeps
-//! that index in sync with the discriminators: it is seeded on import (snapshot + update) and
-//! updated per-op as discriminators appear or are cleared.
-//!
-//! [`MapState`]: super::map_state::MapState
-//! [`DocState::mergeable_children_from_value`]: super::DocState::mergeable_children_from_value
+//! The ref is intentionally stored as binary user data rather than a reserved string. This keeps
+//! user-editable strings from being reinterpreted as internal container topology, and lets the
+//! resolver fail closed unless the ref's digest matches the exact `(parent, key, kind)` being
+//! resolved.
 
-use loro_common::{ContainerID, InternalString, LoroMapValue, LoroValue};
-use rustc_hash::FxHashSet;
+use loro_common::{ContainerID, ContainerType, InternalString, LoroMapValue};
 
-use crate::{
-    container::{idx::ContainerIdx, map::MapSet},
-    event::InternalContainerDiff,
-    op::{Op, RawOp, RawOpContent},
-    OpLog,
-};
+use crate::{container::idx::ContainerIdx, event::Index};
 
-use super::DocState;
+use super::{ContainerState, DocState};
 
 impl DocState {
-    /// Walk all map containers and rebuild the mergeable parent-edge index from the discriminators
-    /// stored in their value tables.
+    /// Resolve a child edge using the document-level logical edge model.
     ///
-    /// Discriminators ride through snapshots like any other map value, so no special recovery is
-    /// needed for the mergeable state itself; this walk only repopulates the in-memory
-    /// `child_containers` parent edges (which are not serialized) so that path resolution,
-    /// reachability, and child enumeration resolve imported mergeable cids without requiring the
-    /// caller to re-invoke `get_mergeable_*`.
-    ///
-    /// Called from [`Self::init_with_states_and_version`] right after a snapshot decode.
-    pub(super) fn repopulate_mergeable_child_side_tables(&mut self, _oplog: &OpLog) {
-        // Mergeable children that have state entries round-trip through the snapshot as their own
-        // KV entries, and their cid encodes `(parent, key, kind)`. Scan KV keys for those cids
-        // (no value decode, no `load_all`) instead of walking every Map and reading its value.
-        // Unmutated mergeable children have no state entry; they are reconstructed lazily by the
-        // read paths from the parent's discriminator, so they need no eager registration here.
-        let mergeable_cids = self.store.mergeable_container_ids();
-
-        // Group candidates by parent map so each parent's discriminators are read at most once.
-        // `register_mergeable_edges_of_map` re-derives the active children from the parent's value
-        // and only registers edges whose discriminator still matches, so a scanned cid whose slot
-        // was deleted or kind-changed is naturally dropped.
-        let mut parent_ids: Vec<ContainerID> = Vec::new();
-        let mut seen: FxHashSet<ContainerID> = FxHashSet::default();
-        for cid in mergeable_cids {
-            if let Some((parent_id, _key, _kind)) = cid.parse_mergeable() {
-                if seen.insert(parent_id.clone()) {
-                    parent_ids.push(parent_id);
-                }
-            }
-        }
-
-        for parent_id in parent_ids {
-            self.register_mergeable_edges_of_map(&parent_id);
-        }
-    }
-
-    /// Reconcile the mergeable parent edges for a single map container against its discriminators.
-    ///
-    /// Registers an edge for every key whose value is an active discriminator and evicts any
-    /// stale mergeable edge whose key no longer carries a matching discriminator (e.g. a key that
-    /// was deleted or whose kind changed). Idempotent.
-    fn register_mergeable_edges_of_map(&mut self, parent_id: &ContainerID) {
-        let Some(parent_idx) = self.arena.id_to_idx(parent_id) else {
-            return;
-        };
-        // Derive the active children from the map's value table through the lazy `get_value`
-        // path. Reading the decoded `MapState` here would force every map to decode its full
-        // state on import (including plain maps with no mergeable children), defeating the
-        // snapshot lazy-load and leaving roots with materialized state. Discriminators ride
-        // through the value table, so the value alone is sufficient (loro-dev/loro#759).
-        let active: Vec<(InternalString, ContainerID)> =
-            self.active_mergeable_children_lazy(parent_idx, parent_id);
-        let active_set: FxHashSet<ContainerID> =
-            active.iter().map(|(_, cid)| cid.clone()).collect();
-
-        // Evict edges that are no longer backed by a matching discriminator. The parent-edge
-        // index (`child_containers`) only exists on an already-decoded `MapState`; a map that is
-        // still lazy has no registered edges, so there is nothing to evict and we must not force a
-        // decode just to discover that. Only inspect the side table when the state is already
-        // decoded.
-        let stale: Vec<ContainerID> = if self.store.has_decoded_state(parent_idx) {
-            self.store
-                .get_container(parent_idx)
-                .and_then(|state| state.as_map_state())
-                .map(|map_state| {
-                    map_state
-                        .iter_mergeable_children()
-                        .filter(|(_, cid)| !active_set.contains(*cid))
-                        .map(|(_, cid)| cid.clone())
-                        .collect()
-                })
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-
-        if !stale.is_empty() {
-            if let Some(map) = self
-                .store
-                .get_container_mut(parent_idx)
-                .and_then(|state| state.as_map_state_mut())
-            {
-                for cid in &stale {
-                    map.evict_mergeable_child_cid(cid);
-                }
-            }
-            self.dead_containers_cache.clear_alive();
-        }
-
-        for (key, cid) in active {
-            // Wire the arena parent edge (idempotent) so the cid resolves in path / reachability
-            // walks, then record the parent-edge index entry on the MapState.
-            self.store.ensure_container(parent_id);
-            self.arena.register_container(parent_id);
-            let cid_idx = self.arena.register_container(&cid);
-            // The child is reachable again; drop any stale deleted-cache entry so release builds
-            // don't keep reporting it as deleted. This mirrors the local reactivation path in
-            // `sync_mergeable_side_table_for_op`, covering reactivation that arrives via import.
-            self.dead_containers_cache.remove(cid_idx);
-            if let Some(state) = self.store.get_container_mut(parent_idx) {
-                if let Some(map) = state.as_map_state_mut() {
-                    map.register_mergeable_child(key, cid);
-                }
-            }
-        }
-    }
-
-    /// Register mergeable parent edges for the maps touched by an update-import diff batch.
-    ///
-    /// The discriminator ops in the batch already updated each parent map's value table; this
-    /// walk reads those discriminators and registers the corresponding parent edges. Shared body
-    /// with the snapshot recovery walk, scoped to the batch's parent maps so update-import cost
-    /// stays proportional to the diff size.
-    pub(super) fn register_mergeable_children(
+    /// Ordinary child containers use the materialized child index stored in their parent state.
+    /// Mergeable children are resolved lazily from their deterministic cid plus the parent map's
+    /// current binary child ref, so snapshot/update import does not need any eager mergeable-edge
+    /// rebuild.
+    pub(super) fn get_logical_child_index(
         &mut self,
-        parent_map_ids: impl IntoIterator<Item = ContainerID>,
-    ) {
-        for parent_id in parent_map_ids {
-            self.register_mergeable_edges_of_map(&parent_id);
+        parent_idx: ContainerIdx,
+        child_id: &ContainerID,
+    ) -> Option<Index> {
+        if let Some((parent_id, key, kind)) = child_id.parse_mergeable() {
+            return self.get_mergeable_child_index(parent_idx, &parent_id, &key, kind);
+        }
+
+        self.store
+            .get_container_mut(parent_idx)
+            .and_then(|parent_state| parent_state.get_child_index(child_id))
+    }
+
+    pub(super) fn contains_logical_child(
+        &mut self,
+        parent_idx: ContainerIdx,
+        child_id: &ContainerID,
+    ) -> bool {
+        self.get_logical_child_index(parent_idx, child_id).is_some()
+    }
+
+    fn get_mergeable_child_index(
+        &mut self,
+        parent_idx: ContainerIdx,
+        encoded_parent_id: &ContainerID,
+        key: &str,
+        kind: ContainerType,
+    ) -> Option<Index> {
+        if parent_idx.get_type() != ContainerType::Map {
+            return None;
+        }
+
+        let actual_parent_id = self.arena.idx_to_id(parent_idx)?;
+        if &actual_parent_id != encoded_parent_id {
+            return None;
+        }
+
+        let value = self.store.map_get(parent_idx, key)?;
+        if loro_common::parse_mergeable_marker(&actual_parent_id, key, &value) == Some(kind) {
+            Some(Index::Key(key.into()))
+        } else {
+            None
         }
     }
 
     /// Derive `(key, cid)` pairs for the active mergeable children of a map directly from its
-    /// already-computed value table, without forcing the map's container state to decode.
+    /// current value table.
     ///
-    /// This is the read-time source of truth for mergeable resolution (loro-dev/loro#759),
-    /// exactly mirroring how a regular child container's reachability is the parent's value slot:
-    /// for each key whose value is a recognized `"🤝:<kind>"` discriminator, the active child is
-    /// the deterministic cid `ContainerID::new_mergeable(parent_id, key, kind)`. Whichever
-    /// discriminator the parent map's regular LWW resolved to picks the kind, so:
-    ///
-    /// - concurrent same-kind creation writes the identical discriminator (LWW no-op) and both
-    ///   peers' contributions land in the one deterministic cid;
-    /// - concurrent different-kind creation lets Map LWW deterministically pick one kind, while
-    ///   the loser's cid stays reachable only by an explicit `get_mergeable_<kind>` lookup (which
-    ///   rewrites the discriminator);
-    /// - `delete(key)` overwrites the discriminator with `None`, so the child becomes unreachable
-    ///   like any deleted container; a later `get_mergeable_<kind>(key)` rewrites the discriminator
-    ///   and brings it back, with Map LWW resolving any concurrent delete-vs-recreate race.
-    ///
-    /// Used by the deep-value walk (`get_container_deep_value` /
-    /// `get_container_deep_value_with_id`) to nest mergeable child values under their logical
-    /// parent key (overwriting the raw discriminator string the walk would otherwise emit), by
-    /// `get_alive_children_of`, and — via [`Self::active_mergeable_children_lazy`] — by the
-    /// import-time side-table walk.
-    ///
-    /// Deriving from the value rather than the decoded `MapState` is what keeps snapshot-backed
-    /// roots lazy: the value is obtained through the lazy `ContainerStore::get_value` path, so a
-    /// plain map with no discriminators is never forced to materialize its full state.
-    ///
-    /// `parent_id` is the cid of the map whose value is `map_value`; the caller supplies it
-    /// because `MapState` does not store its own id.
+    /// This is used by deep-value and alive-container walks. It mirrors regular map semantics:
+    /// the current value at a key determines which child is visible. For mergeable children, that
+    /// value is a compact binary child ref rather than `LoroValue::Container`.
     pub(super) fn mergeable_children_from_value(
         &self,
         parent_id: &ContainerID,
@@ -188,110 +82,12 @@ impl DocState {
     ) -> Vec<(InternalString, ContainerID)> {
         let mut ans = Vec::new();
         for (key, value) in map_value.iter() {
-            if let Some(kind) = loro_common::parse_mergeable_discriminator(value) {
+            if let Some(kind) = loro_common::parse_mergeable_marker(parent_id, key, value) {
                 let key_istr: InternalString = key.as_str().into();
                 let cid = ContainerID::new_mergeable(parent_id, key, kind);
                 ans.push((key_istr, cid));
             }
         }
         ans
-    }
-
-    /// Like [`Self::mergeable_children_from_value`], but fetches the map's value by container idx
-    /// through the lazy `ContainerStore::get_value` path so a snapshot-backed map is not forced to
-    /// decode its full state. Returns an empty Vec if the idx is not a map or its value is absent.
-    pub(super) fn active_mergeable_children_lazy(
-        &mut self,
-        parent_idx: ContainerIdx,
-        parent_id: &ContainerID,
-    ) -> Vec<(InternalString, ContainerID)> {
-        match self.store.get_value(parent_idx) {
-            Some(LoroValue::Map(map_value)) => {
-                self.mergeable_children_from_value(parent_id, &map_value)
-            }
-            _ => Vec::new(),
-        }
-    }
-
-    /// Capture the container idxs touched by a diff batch so the post-loop hook can register
-    /// mergeable parent edges for whichever of them turn out to be maps.
-    ///
-    /// We capture ALL touched idxs rather than filtering to maps here: a fresh receiver importing
-    /// the first discriminator op for a map that does not yet exist in the store would otherwise
-    /// be filtered out (the map state is only created when the diff applies). The post-loop hook
-    /// re-checks each idx against the now-populated store.
-    pub(super) fn capture_mergeable_diff_batch(
-        &mut self,
-        diffs: &[InternalContainerDiff],
-    ) -> FxHashSet<ContainerIdx> {
-        diffs.iter().map(|d| d.idx).collect()
-    }
-
-    /// Keep the mergeable parent-edge index in sync with a just-applied `MapSet` op on a parent
-    /// map.
-    ///
-    /// A `MapSet` writing a `"🤝:<kind>"` discriminator realizes (or re-realizes) a mergeable
-    /// child: register its deterministic cid's parent edge. Any other value at that key — `None`
-    /// (a delete) or a plain value that overwrote a discriminator — clears the child: evict the
-    /// stale mergeable edge so reachability and path walks no longer surface it.
-    ///
-    /// This is the per-op counterpart of [`Self::register_mergeable_children`]; together they keep
-    /// the in-memory index consistent with the discriminators that are the source of truth.
-    pub(super) fn sync_mergeable_side_table_for_op(&mut self, raw_op: &RawOp, op: &Op) {
-        let RawOpContent::Map(MapSet { key, value }) = &raw_op.content else {
-            return;
-        };
-        let Some(parent_id) = self.arena.idx_to_id(op.container) else {
-            return;
-        };
-        let key_istr: InternalString = key.clone();
-
-        let new_kind = value
-            .as_ref()
-            .and_then(loro_common::parse_mergeable_discriminator);
-
-        // Evict any stale mergeable edge under this key whose kind no longer matches what the
-        // discriminator (if any) now selects. This covers deletes (new_kind == None) and
-        // kind-change overwrites (different discriminator at the same key).
-        let stale: Vec<ContainerID> = self
-            .store
-            .get_container(op.container)
-            .and_then(|state| state.as_map_state())
-            .map(|map_state| {
-                map_state
-                    .iter_mergeable_children()
-                    .filter(|(k, cid)| **k == key_istr && Some(cid.container_type()) != new_kind)
-                    .map(|(_, cid)| cid.clone())
-                    .collect()
-            })
-            .unwrap_or_default();
-        if !stale.is_empty() {
-            if let Some(map) = self
-                .store
-                .get_container_mut(op.container)
-                .and_then(|state| state.as_map_state_mut())
-            {
-                for cid in &stale {
-                    map.evict_mergeable_child_cid(cid);
-                }
-            }
-            self.dead_containers_cache.clear_alive();
-        }
-
-        // Register the parent edge for the kind the discriminator now selects.
-        if let Some(kind) = new_kind {
-            let cid = ContainerID::new_mergeable(&parent_id, key, kind);
-            let cid_idx = self.arena.register_container(&cid);
-            // The child is reachable again; drop any stale deleted-cache entry from a
-            // prior delete so release builds don't keep reporting it as deleted.
-            self.dead_containers_cache.remove(cid_idx);
-            if let Some(map) = self
-                .store
-                .get_container_mut(op.container)
-                .and_then(|state| state.as_map_state_mut())
-            {
-                map.register_mergeable_child(key_istr, cid);
-            }
-        }
     }
 }

--- a/crates/loro-internal/src/state/mergeable.rs
+++ b/crates/loro-internal/src/state/mergeable.rs
@@ -123,7 +123,11 @@ impl DocState {
             // walks, then record the parent-edge index entry on the MapState.
             self.store.ensure_container(parent_id);
             self.arena.register_container(parent_id);
-            self.arena.register_container(&cid);
+            let cid_idx = self.arena.register_container(&cid);
+            // The child is reachable again; drop any stale deleted-cache entry so release builds
+            // don't keep reporting it as deleted. This mirrors the local reactivation path in
+            // `sync_mergeable_side_table_for_op`, covering reactivation that arrives via import.
+            self.dead_containers_cache.remove(cid_idx);
             if let Some(state) = self.store.get_container_mut(parent_idx) {
                 if let Some(map) = state.as_map_state_mut() {
                     map.register_mergeable_child(key, cid);

--- a/crates/loro-internal/src/state/mergeable.rs
+++ b/crates/loro-internal/src/state/mergeable.rs
@@ -262,7 +262,10 @@ impl DocState {
         // Register the parent edge for the kind the discriminator now selects.
         if let Some(kind) = new_kind {
             let cid = ContainerID::new_mergeable(&parent_id, key, kind);
-            self.arena.register_container(&cid);
+            let cid_idx = self.arena.register_container(&cid);
+            // The child is reachable again; drop any stale deleted-cache entry from a
+            // prior delete so release builds don't keep reporting it as deleted.
+            self.dead_containers_cache.remove(cid_idx);
             if let Some(map) = self
                 .store
                 .get_container_mut(op.container)

--- a/crates/loro-internal/src/state/mergeable.rs
+++ b/crates/loro-internal/src/state/mergeable.rs
@@ -1,0 +1,275 @@
+//! Mergeable-container bookkeeping on `DocState`.
+//!
+//! Mergeable child containers (created via `MapHandler::get_mergeable_*`) live as deterministic
+//! `ContainerID::Root` ids in a reserved namespace. Their *visibility* is driven entirely by the
+//! `"🤝:<kind>"` discriminator string the parent map stores at the key (see loro-dev/loro#759 and
+//! [`DocState::mergeable_children_from_value`]): whichever discriminator the parent map's regular
+//! LWW resolves to picks the active kind, exactly as a regular child container's value-table entry
+//! picks the active child.
+//!
+//! The only out-of-band state is the parent-edge index (`child_containers` on [`MapState`]), which
+//! lets path resolution and reachability map a mergeable cid back to its key. This module keeps
+//! that index in sync with the discriminators: it is seeded on import (snapshot + update) and
+//! updated per-op as discriminators appear or are cleared.
+//!
+//! [`MapState`]: super::map_state::MapState
+//! [`DocState::mergeable_children_from_value`]: super::DocState::mergeable_children_from_value
+
+use loro_common::{ContainerID, ContainerType, InternalString, LoroMapValue, LoroValue};
+use rustc_hash::FxHashSet;
+
+use crate::{
+    container::{idx::ContainerIdx, map::MapSet},
+    event::InternalContainerDiff,
+    op::{Op, RawOp, RawOpContent},
+    OpLog,
+};
+
+use super::DocState;
+
+impl DocState {
+    /// Walk all map containers and rebuild the mergeable parent-edge index from the discriminators
+    /// stored in their value tables.
+    ///
+    /// Discriminators ride through snapshots like any other map value, so no special recovery is
+    /// needed for the mergeable state itself; this walk only repopulates the in-memory
+    /// `child_containers` parent edges (which are not serialized) so that path resolution,
+    /// reachability, and child enumeration resolve imported mergeable cids without requiring the
+    /// caller to re-invoke `get_mergeable_*`.
+    ///
+    /// Called from [`Self::init_with_states_and_version`] right after a snapshot decode.
+    pub(super) fn repopulate_mergeable_child_side_tables(&mut self, _oplog: &OpLog) {
+        let map_cids: Vec<ContainerID> = self
+            .store
+            .iter_all_container_ids()
+            .filter(|id| matches!(id.container_type(), ContainerType::Map))
+            .collect();
+
+        for parent_id in map_cids {
+            self.register_mergeable_edges_of_map(&parent_id);
+        }
+    }
+
+    /// Reconcile the mergeable parent edges for a single map container against its discriminators.
+    ///
+    /// Registers an edge for every key whose value is an active discriminator and evicts any
+    /// stale mergeable edge whose key no longer carries a matching discriminator (e.g. a key that
+    /// was deleted or whose kind changed). Idempotent.
+    fn register_mergeable_edges_of_map(&mut self, parent_id: &ContainerID) {
+        let Some(parent_idx) = self.arena.id_to_idx(parent_id) else {
+            return;
+        };
+        // Derive the active children from the map's value table through the lazy `get_value`
+        // path. Reading the decoded `MapState` here would force every map to decode its full
+        // state on import (including plain maps with no mergeable children), defeating the
+        // snapshot lazy-load and leaving roots with materialized state. Discriminators ride
+        // through the value table, so the value alone is sufficient (loro-dev/loro#759).
+        let active: Vec<(InternalString, ContainerID)> =
+            self.active_mergeable_children_lazy(parent_idx, parent_id);
+        let active_set: FxHashSet<ContainerID> =
+            active.iter().map(|(_, cid)| cid.clone()).collect();
+
+        // Evict edges that are no longer backed by a matching discriminator. The parent-edge
+        // index (`child_containers`) only exists on an already-decoded `MapState`; a map that is
+        // still lazy has no registered edges, so there is nothing to evict and we must not force a
+        // decode just to discover that. Only inspect the side table when the state is already
+        // decoded.
+        let stale: Vec<ContainerID> = if self.store.has_decoded_state(parent_idx) {
+            self.store
+                .get_container(parent_idx)
+                .and_then(|state| state.as_map_state())
+                .map(|map_state| {
+                    map_state
+                        .iter_mergeable_children()
+                        .filter(|(_, cid)| !active_set.contains(*cid))
+                        .map(|(_, cid)| cid.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        if !stale.is_empty() {
+            if let Some(map) = self
+                .store
+                .get_container_mut(parent_idx)
+                .and_then(|state| state.as_map_state_mut())
+            {
+                for cid in &stale {
+                    map.evict_mergeable_child_cid(cid);
+                }
+            }
+            self.dead_containers_cache.clear_alive();
+        }
+
+        for (key, cid) in active {
+            // Wire the arena parent edge (idempotent) so the cid resolves in path / reachability
+            // walks, then record the parent-edge index entry on the MapState.
+            self.store.ensure_container(parent_id);
+            self.arena.register_container(parent_id);
+            self.arena.register_container(&cid);
+            if let Some(state) = self.store.get_container_mut(parent_idx) {
+                if let Some(map) = state.as_map_state_mut() {
+                    map.register_mergeable_child(key, cid);
+                }
+            }
+        }
+    }
+
+    /// Register mergeable parent edges for the maps touched by an update-import diff batch.
+    ///
+    /// The discriminator ops in the batch already updated each parent map's value table; this
+    /// walk reads those discriminators and registers the corresponding parent edges. Shared body
+    /// with the snapshot recovery walk, scoped to the batch's parent maps so update-import cost
+    /// stays proportional to the diff size.
+    pub(super) fn register_mergeable_children(
+        &mut self,
+        parent_map_ids: impl IntoIterator<Item = ContainerID>,
+    ) {
+        for parent_id in parent_map_ids {
+            self.register_mergeable_edges_of_map(&parent_id);
+        }
+    }
+
+    /// Derive `(key, cid)` pairs for the active mergeable children of a map directly from its
+    /// already-computed value table, without forcing the map's container state to decode.
+    ///
+    /// This is the read-time source of truth for mergeable resolution (loro-dev/loro#759),
+    /// exactly mirroring how a regular child container's reachability is the parent's value slot:
+    /// for each key whose value is a recognized `"🤝:<kind>"` discriminator, the active child is
+    /// the deterministic cid `ContainerID::new_mergeable(parent_id, key, kind)`. Whichever
+    /// discriminator the parent map's regular LWW resolved to picks the kind, so:
+    ///
+    /// - concurrent same-kind creation writes the identical discriminator (LWW no-op) and both
+    ///   peers' contributions land in the one deterministic cid;
+    /// - concurrent different-kind creation lets Map LWW deterministically pick one kind, while
+    ///   the loser's cid stays reachable only by an explicit `get_mergeable_<kind>` lookup (which
+    ///   rewrites the discriminator);
+    /// - `delete(key)` overwrites the discriminator with `None`, so the child becomes unreachable
+    ///   like any deleted container; a later `get_mergeable_<kind>(key)` rewrites the discriminator
+    ///   and brings it back, with Map LWW resolving any concurrent delete-vs-recreate race.
+    ///
+    /// Used by the deep-value walk (`get_container_deep_value` /
+    /// `get_container_deep_value_with_id`) to nest mergeable child values under their logical
+    /// parent key (overwriting the raw discriminator string the walk would otherwise emit), by
+    /// `get_alive_children_of`, and — via [`Self::active_mergeable_children_lazy`] — by the
+    /// import-time side-table walk.
+    ///
+    /// Deriving from the value rather than the decoded `MapState` is what keeps snapshot-backed
+    /// roots lazy: the value is obtained through the lazy `ContainerStore::get_value` path, so a
+    /// plain map with no discriminators is never forced to materialize its full state.
+    ///
+    /// `parent_id` is the cid of the map whose value is `map_value`; the caller supplies it
+    /// because `MapState` does not store its own id.
+    pub(super) fn mergeable_children_from_value(
+        &self,
+        parent_id: &ContainerID,
+        map_value: &LoroMapValue,
+    ) -> Vec<(InternalString, ContainerID)> {
+        let mut ans = Vec::new();
+        for (key, value) in map_value.iter() {
+            if let Some(kind) = loro_common::parse_mergeable_discriminator(value) {
+                let key_istr: InternalString = key.as_str().into();
+                let cid = ContainerID::new_mergeable(parent_id, key, kind);
+                ans.push((key_istr, cid));
+            }
+        }
+        ans
+    }
+
+    /// Like [`Self::mergeable_children_from_value`], but fetches the map's value by container idx
+    /// through the lazy `ContainerStore::get_value` path so a snapshot-backed map is not forced to
+    /// decode its full state. Returns an empty Vec if the idx is not a map or its value is absent.
+    pub(super) fn active_mergeable_children_lazy(
+        &mut self,
+        parent_idx: ContainerIdx,
+        parent_id: &ContainerID,
+    ) -> Vec<(InternalString, ContainerID)> {
+        match self.store.get_value(parent_idx) {
+            Some(LoroValue::Map(map_value)) => {
+                self.mergeable_children_from_value(parent_id, &map_value)
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Capture the container idxs touched by a diff batch so the post-loop hook can register
+    /// mergeable parent edges for whichever of them turn out to be maps.
+    ///
+    /// We capture ALL touched idxs rather than filtering to maps here: a fresh receiver importing
+    /// the first discriminator op for a map that does not yet exist in the store would otherwise
+    /// be filtered out (the map state is only created when the diff applies). The post-loop hook
+    /// re-checks each idx against the now-populated store.
+    pub(super) fn capture_mergeable_diff_batch(
+        &mut self,
+        diffs: &[InternalContainerDiff],
+    ) -> FxHashSet<ContainerIdx> {
+        diffs.iter().map(|d| d.idx).collect()
+    }
+
+    /// Keep the mergeable parent-edge index in sync with a just-applied `MapSet` op on a parent
+    /// map.
+    ///
+    /// A `MapSet` writing a `"🤝:<kind>"` discriminator realizes (or re-realizes) a mergeable
+    /// child: register its deterministic cid's parent edge. Any other value at that key — `None`
+    /// (a delete) or a plain value that overwrote a discriminator — clears the child: evict the
+    /// stale mergeable edge so reachability and path walks no longer surface it.
+    ///
+    /// This is the per-op counterpart of [`Self::register_mergeable_children`]; together they keep
+    /// the in-memory index consistent with the discriminators that are the source of truth.
+    pub(super) fn sync_mergeable_side_table_for_op(&mut self, raw_op: &RawOp, op: &Op) {
+        let RawOpContent::Map(MapSet { key, value }) = &raw_op.content else {
+            return;
+        };
+        let Some(parent_id) = self.arena.idx_to_id(op.container) else {
+            return;
+        };
+        let key_istr: InternalString = key.clone();
+
+        let new_kind = value
+            .as_ref()
+            .and_then(loro_common::parse_mergeable_discriminator);
+
+        // Evict any stale mergeable edge under this key whose kind no longer matches what the
+        // discriminator (if any) now selects. This covers deletes (new_kind == None) and
+        // kind-change overwrites (different discriminator at the same key).
+        let stale: Vec<ContainerID> = self
+            .store
+            .get_container(op.container)
+            .and_then(|state| state.as_map_state())
+            .map(|map_state| {
+                map_state
+                    .iter_mergeable_children()
+                    .filter(|(k, cid)| **k == key_istr && Some(cid.container_type()) != new_kind)
+                    .map(|(_, cid)| cid.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !stale.is_empty() {
+            if let Some(map) = self
+                .store
+                .get_container_mut(op.container)
+                .and_then(|state| state.as_map_state_mut())
+            {
+                for cid in &stale {
+                    map.evict_mergeable_child_cid(cid);
+                }
+            }
+            self.dead_containers_cache.clear_alive();
+        }
+
+        // Register the parent edge for the kind the discriminator now selects.
+        if let Some(kind) = new_kind {
+            let cid = ContainerID::new_mergeable(&parent_id, key, kind);
+            self.arena.register_container(&cid);
+            if let Some(map) = self
+                .store
+                .get_container_mut(op.container)
+                .and_then(|state| state.as_map_state_mut())
+            {
+                map.register_mergeable_child(key_istr, cid);
+            }
+        }
+    }
+}

--- a/crates/loro-internal/tests/mergeable_cid_encoding.rs
+++ b/crates/loro-internal/tests/mergeable_cid_encoding.rs
@@ -1,0 +1,186 @@
+//! Encoding and decoding of mergeable container ids.
+
+use loro_internal::ContainerType;
+
+#[test]
+#[cfg(feature = "counter")]
+fn mergeable_container_id_roundtrips_parent_key_and_type() {
+    let parent = loro_common::ContainerID::new_root("state", ContainerType::Map);
+    let key = "field\u{1}with/slash:and:semicolon";
+    let cid = loro_common::ContainerID::new_mergeable(&parent, key, ContainerType::Counter);
+
+    assert!(cid.is_mergeable());
+    let (decoded_parent, decoded_key, decoded_type) = cid.parse_mergeable().unwrap();
+    assert_eq!(decoded_parent, parent);
+    assert_eq!(decoded_key, key);
+    assert_eq!(decoded_type, ContainerType::Counter);
+}
+
+#[test]
+fn user_root_names_cannot_use_mergeable_namespace() {
+    assert!(!loro_common::check_root_container_name(
+        loro_common::MERGEABLE_NAMESPACE_PREFIX
+    ));
+}
+
+/// `parse_mergeable` is a pure decoder and must return `None` (not panic, not
+/// silently misinterpret) for every malformed payload. This guards against
+/// future drift in the encoder + decoder pair.
+#[test]
+#[cfg(feature = "counter")]
+fn parse_mergeable_rejects_malformed_payloads() {
+    use loro_common::{ContainerID, ContainerType};
+
+    // Non-mergeable root: returns None.
+    let plain_root = ContainerID::new_root("ordinary", ContainerType::Map);
+    assert!(plain_root.parse_mergeable().is_none());
+
+    // Mergeable prefix but invalid hex.
+    let bad_hex = ContainerID::Root {
+        name: "🤝:zzzz".into(),
+        container_type: ContainerType::Counter,
+    };
+    assert!(
+        bad_hex.parse_mergeable().is_none(),
+        "non-hex chars in payload must reject"
+    );
+
+    // Mergeable prefix, valid hex, but truncated (no segments).
+    let truncated = ContainerID::Root {
+        name: "🤝:".into(),
+        container_type: ContainerType::Counter,
+    };
+    assert!(
+        truncated.parse_mergeable().is_none(),
+        "empty payload must reject"
+    );
+
+    // Mergeable prefix, valid hex, but trailing garbage after the type byte.
+    let parent = ContainerID::new_root("state", ContainerType::Map);
+    let cid = ContainerID::new_mergeable(&parent, "k", ContainerType::Counter);
+    let mut name = match &cid {
+        ContainerID::Root { name, .. } => name.to_string(),
+        _ => panic!("expected Root"),
+    };
+    name.push_str("ff"); // append one extra byte's worth of hex
+    let with_garbage = ContainerID::Root {
+        name: name.into(),
+        container_type: ContainerType::Counter,
+    };
+    assert!(
+        with_garbage.parse_mergeable().is_none(),
+        "trailing bytes after type byte must reject"
+    );
+
+    // Mergeable prefix and a payload that decodes correctly, BUT the
+    // encoded type byte disagrees with the Root's container_type field.
+    let mismatched = ContainerID::Root {
+        name: match &cid {
+            ContainerID::Root { name, .. } => name.clone(),
+            _ => unreachable!(),
+        },
+        container_type: ContainerType::Map, // payload says Counter
+    };
+    assert!(
+        mismatched.parse_mergeable().is_none(),
+        "type-byte mismatch with Root.container_type must reject"
+    );
+}
+
+/// `LoroDoc::get_map` must reject names in the mergeable namespace at the
+/// call site, not just in `check_root_container_name`. Otherwise user code
+/// could fabricate a Root cid that masquerades as a mergeable child and
+/// confuse the parent-edge walks.
+///
+/// This test runs `check_root_container_name` directly on a variety of
+/// user-supplied strings; the runtime `get_map` / `get_text` / etc. calls
+/// route through this validator (see callers in `crates/loro-internal/src/`).
+/// If the validator is bypassed by a runtime path, that's a separate bug —
+/// but it's not something this test can prove without intentionally writing
+/// `🤝:` keys, which is what we're trying to prevent in the first place.
+#[test]
+fn root_name_validator_rejects_mergeable_namespace_inputs() {
+    use loro_common::{check_root_container_name, MERGEABLE_NAMESPACE_PREFIX};
+
+    // Bare prefix.
+    assert!(!check_root_container_name(MERGEABLE_NAMESPACE_PREFIX));
+    // Prefix + arbitrary payload.
+    assert!(!check_root_container_name("🤝:deadbeef"));
+    assert!(!check_root_container_name("🤝:"));
+    // Prefix-as-substring is OK (not a prefix), validator still allows it.
+    assert!(check_root_container_name("foo🤝:bar"));
+    // Prefix with a leading zero-width space is NOT a prefix match, allowed.
+    assert!(check_root_container_name("\u{200B}🤝:abc"));
+    // Sanity: ordinary user names still pass.
+    assert!(check_root_container_name("state"));
+    assert!(check_root_container_name("ordinary-name_with-symbols"));
+    // Empty is still rejected (pre-existing behavior).
+    assert!(!check_root_container_name(""));
+    // Slash and NUL still rejected (pre-existing behavior).
+    assert!(!check_root_container_name("a/b"));
+    assert!(!check_root_container_name("a\0b"));
+}
+
+/// For each supported container kind, `new_mergeable` produces a deterministic
+/// cid that decodes back to the same `(parent, key, kind)`. Counter is gated
+/// on the feature; the rest are unconditional.
+#[test]
+fn mergeable_cid_roundtrips_for_every_container_kind() {
+    use loro_common::{ContainerID, ContainerType};
+    let parent = ContainerID::new_root("state", ContainerType::Map);
+
+    let mut kinds: Vec<ContainerType> = vec![
+        ContainerType::Map,
+        ContainerType::List,
+        ContainerType::MovableList,
+        ContainerType::Text,
+        ContainerType::Tree,
+    ];
+    #[cfg(feature = "counter")]
+    kinds.push(ContainerType::Counter);
+
+    for kind in kinds {
+        let cid = ContainerID::new_mergeable(&parent, "field", kind);
+        assert!(cid.is_mergeable(), "kind {kind:?}: must be mergeable");
+        let again = ContainerID::new_mergeable(&parent, "field", kind);
+        assert_eq!(cid, again, "kind {kind:?}: cid must be deterministic");
+        let (decoded_parent, decoded_key, decoded_kind) = cid
+            .parse_mergeable()
+            .unwrap_or_else(|| panic!("kind {kind:?}: parse_mergeable returned None"));
+        assert_eq!(decoded_parent, parent, "kind {kind:?}: parent roundtrip");
+        assert_eq!(decoded_key, "field", "kind {kind:?}: key roundtrip");
+        assert_eq!(decoded_kind, kind, "kind {kind:?}: kind roundtrip");
+    }
+}
+
+/// Key encoding is len-prefixed binary, so it must round-trip cleanly for
+/// degenerate inputs: empty, long, embedded NUL, and embedded mergeable
+/// prefix substring. Catches off-by-one and ad-hoc string-split mistakes
+/// in any future decoder change.
+#[test]
+fn mergeable_cid_roundtrips_for_degenerate_keys() {
+    use loro_common::{ContainerID, ContainerType};
+    let parent = ContainerID::new_root("state", ContainerType::Map);
+
+    let long_key: String = std::iter::repeat('k').take(2048).collect();
+    let cases: Vec<&str> = vec![
+        "",
+        long_key.as_str(),
+        "with\0nul\0bytes",
+        "embedded 🤝: substring in the middle",
+        "starts_with_🤝:_prefix",
+        "trailing_emoji_🤝:",
+        "ascii/slash/looking",
+    ];
+
+    for key in cases {
+        let cid = ContainerID::new_mergeable(&parent, key, ContainerType::Map);
+        assert!(cid.is_mergeable(), "key {key:?}: must be mergeable");
+        let (decoded_parent, decoded_key, decoded_kind) = cid
+            .parse_mergeable()
+            .unwrap_or_else(|| panic!("key {key:?}: parse_mergeable returned None"));
+        assert_eq!(decoded_parent, parent);
+        assert_eq!(decoded_key, key, "key {key:?}: round-trip mismatch");
+        assert_eq!(decoded_kind, ContainerType::Map);
+    }
+}

--- a/crates/loro-internal/tests/mergeable_container.rs
+++ b/crates/loro-internal/tests/mergeable_container.rs
@@ -1,0 +1,15 @@
+//! Integration tests for mergeable container support. The actual tests live in focused files
+//! under `tests/mergeable_container/`; this harness aggregates them into a single test target.
+
+#[path = "mergeable_container/convergence.rs"]
+mod convergence;
+#[path = "mergeable_container/delete.rs"]
+mod delete;
+#[path = "mergeable_container/discriminator.rs"]
+mod discriminator;
+#[path = "mergeable_container/events_and_paths.rs"]
+mod events_and_paths;
+#[path = "mergeable_container/snapshot.rs"]
+mod snapshot;
+#[path = "mergeable_container/type_conflict.rs"]
+mod type_conflict;

--- a/crates/loro-internal/tests/mergeable_container/common.rs
+++ b/crates/loro-internal/tests/mergeable_container/common.rs
@@ -1,0 +1,25 @@
+//! Shared helpers for the mergeable-container integration tests.
+//!
+//! Each split test file uses `#[path = "mergeable_container/common.rs"] mod common;` from
+//! the harness in `tests/mergeable_container.rs`, so test fns can reach `common::doc` and
+//! `common::sync` regardless of which sub-file they live in.
+
+// Each split test file imports this module via `#[path = "common.rs"]`, so each helper appears
+// as a separate copy per file. Suppress the dead-code warning that fires when an individual file
+// only uses a subset of the helpers.
+#![allow(dead_code)]
+
+use loro_internal::{loro::ExportMode, LoroDoc};
+
+pub fn doc(peer: u64) -> LoroDoc {
+    let doc = LoroDoc::new_auto_commit();
+    doc.set_peer_id(peer).unwrap();
+    doc
+}
+
+pub fn sync(a: &LoroDoc, b: &LoroDoc) {
+    a.import(&b.export(ExportMode::updates(&a.oplog_vv())).unwrap())
+        .unwrap();
+    b.import(&a.export(ExportMode::updates(&b.oplog_vv())).unwrap())
+        .unwrap();
+}

--- a/crates/loro-internal/tests/mergeable_container/convergence.rs
+++ b/crates/loro-internal/tests/mergeable_container/convergence.rs
@@ -1,0 +1,287 @@
+//! Concurrent first-create convergence and basic merging.
+
+#[path = "common.rs"]
+mod common;
+use common::{doc, sync};
+
+use loro_internal::{cursor::PosType, event::Index, handler::ValueOrHandler, HandlerTrait, ToJson};
+use serde_json::json;
+
+#[test]
+#[cfg(feature = "counter")]
+fn concurrent_counter_increments_show_current_lost_update_bug() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_root = a.get_map("state");
+    let b_root = b.get_map("state");
+
+    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    let b_counter = b_root.get_mergeable_counter("revision").unwrap();
+
+    assert_eq!(
+        a_counter.id(),
+        b_counter.id(),
+        "both peers should produce the same deterministic cid"
+    );
+    assert!(
+        a_counter.id().is_mergeable(),
+        "counter cid should be in the mergeable namespace"
+    );
+
+    a_counter.increment(1.0).unwrap();
+    b_counter.increment(1.0).unwrap();
+
+    sync(&a, &b);
+
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 2.0 } }),
+        "both concurrent increments should survive on the merged counter",
+    );
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        a.get_deep_value().to_json_value()
+    );
+
+    let a_cid = match a_root.get_("revision") {
+        Some(ValueOrHandler::Handler(handler)) => Some(handler.id()),
+        _ => None,
+    };
+    let b_cid = match b_root.get_("revision") {
+        Some(ValueOrHandler::Handler(handler)) => Some(handler.id()),
+        _ => None,
+    };
+    assert_eq!(
+        a_cid, b_cid,
+        "both peers should resolve the same logical counter cid"
+    );
+}
+
+#[test]
+fn concurrent_text_updates_show_current_lost_update_bug() {
+    let a = doc(1);
+    let b = doc(2);
+    let a_text = a.get_map("state").get_mergeable_text("notes").unwrap();
+    let b_text = b.get_map("state").get_mergeable_text("notes").unwrap();
+
+    assert_eq!(
+        a_text.id(),
+        b_text.id(),
+        "both peers should produce the same deterministic cid"
+    );
+    assert!(
+        a_text.id().is_mergeable(),
+        "text cid should be in the mergeable namespace"
+    );
+
+    a_text.insert(0, "A", PosType::Unicode).unwrap();
+    b_text.insert(0, "B", PosType::Unicode).unwrap();
+    sync(&a, &b);
+
+    let value = a.get_deep_value().to_json_value();
+    assert!(
+        value == json!({ "state": { "notes": "AB" } })
+            || value == json!({ "state": { "notes": "BA" } }),
+        "both concurrent text edits should survive on the merged text; got {value}",
+    );
+}
+
+#[test]
+fn concurrent_list_inserts_show_current_lost_update_bug() {
+    let a = doc(1);
+    let b = doc(2);
+    let a_list = a.get_map("state").get_mergeable_list("items").unwrap();
+    let b_list = b.get_map("state").get_mergeable_list("items").unwrap();
+
+    assert_eq!(
+        a_list.id(),
+        b_list.id(),
+        "both peers should produce the same deterministic cid"
+    );
+    assert!(
+        a_list.id().is_mergeable(),
+        "list cid should be in the mergeable namespace"
+    );
+
+    a_list.insert(0, "A").unwrap();
+    b_list.insert(0, "B").unwrap();
+    sync(&a, &b);
+
+    let value = a.get_deep_value().to_json_value();
+    assert!(
+        value == json!({ "state": { "items": ["A", "B"] } })
+            || value == json!({ "state": { "items": ["B", "A"] } }),
+        "both concurrent list inserts should survive on the merged list; got {value}",
+    );
+}
+
+/// Two peers each obtain the "profile" Map via `get_mergeable_map` and write
+/// to *different* keys. With non-mergeable child Maps, each peer creates a
+/// distinct peer-specific cid, so LWW drops one peer's Map entirely even
+/// though the key sets are disjoint. Once child Maps are mergeable the merged
+/// value should contain both keys.
+#[test]
+fn concurrent_map_writes_show_current_lost_update_bug() {
+    let a = doc(1);
+    let b = doc(2);
+    let a_map = a.get_map("state").get_mergeable_map("profile").unwrap();
+    let b_map = b.get_map("state").get_mergeable_map("profile").unwrap();
+
+    assert_eq!(
+        a_map.id(),
+        b_map.id(),
+        "both peers should produce the same deterministic cid"
+    );
+    assert!(
+        a_map.id().is_mergeable(),
+        "map cid should be in the mergeable namespace"
+    );
+
+    a_map.insert("name", "Ada").unwrap();
+    b_map.insert("title", "Engineer").unwrap();
+    sync(&a, &b);
+
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({ "state": { "profile": { "name": "Ada", "title": "Engineer" } } })
+    );
+}
+
+/// Three peers each increment the same mergeable counter once. After a full
+/// round-robin sync, every peer must observe `3.0` and the same deterministic
+/// cid. Two-peer tests can't catch ordering or idempotency bugs that fire
+/// only when more than two histories overlap.
+#[test]
+#[cfg(feature = "counter")]
+fn three_peer_mergeable_counter_convergence() {
+    let a = doc(1);
+    let b = doc(2);
+    let c = doc(3);
+
+    let a_counter = a
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    let c_counter = c
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    assert_eq!(a_counter.id(), b_counter.id());
+    assert_eq!(b_counter.id(), c_counter.id());
+
+    a_counter.increment(1.0).unwrap();
+    b_counter.increment(1.0).unwrap();
+    c_counter.increment(1.0).unwrap();
+
+    // Full round-robin: every pair syncs.
+    sync(&a, &b);
+    sync(&b, &c);
+    sync(&a, &c);
+    sync(&a, &b);
+
+    let expected = json!({ "state": { "revision": 3.0 } });
+    assert_eq!(a.get_deep_value().to_json_value(), expected);
+    assert_eq!(b.get_deep_value().to_json_value(), expected);
+    assert_eq!(c.get_deep_value().to_json_value(), expected);
+}
+
+/// After A and B sync once, both peers concurrently mutate the same
+/// mergeable counter again, then sync. Convergence must hold on the second
+/// round — the deterministic cid plus CRDT merge must keep working after
+/// the side table has been populated and used.
+#[test]
+#[cfg(feature = "counter")]
+fn post_merge_concurrent_counter_increments_converge() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_counter = a
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    a_counter.increment(1.0).unwrap();
+    b_counter.increment(1.0).unwrap();
+    sync(&a, &b);
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 2.0 } })
+    );
+
+    // Round 2: concurrent edits on the already-merged child.
+    a_counter.increment(10.0).unwrap();
+    b_counter.increment(100.0).unwrap();
+    sync(&a, &b);
+
+    let expected = json!({ "state": { "revision": 112.0 } });
+    assert_eq!(a.get_deep_value().to_json_value(), expected);
+    assert_eq!(b.get_deep_value().to_json_value(), expected);
+}
+
+/// Two peers independently navigate `state → mergeable map "profile" →
+/// mergeable counter "revision"` and increment. The deterministic cid for
+/// "revision" is the same on both peers (it's a function of the "profile"
+/// cid, which is itself deterministic from "state"'s cid + "profile" + Map).
+/// After sync, both peers see the counter at 2.0 nested correctly.
+#[test]
+#[cfg(feature = "counter")]
+fn nested_mergeable_concurrent_counter_converges() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_profile = a.get_map("state").get_mergeable_map("profile").unwrap();
+    let b_profile = b.get_map("state").get_mergeable_map("profile").unwrap();
+    assert_eq!(a_profile.id(), b_profile.id());
+
+    let a_rev = a_profile.get_mergeable_counter("revision").unwrap();
+    let b_rev = b_profile.get_mergeable_counter("revision").unwrap();
+    assert_eq!(a_rev.id(), b_rev.id());
+
+    a_rev.increment(1.0).unwrap();
+    b_rev.increment(1.0).unwrap();
+    sync(&a, &b);
+
+    let expected = json!({ "state": { "profile": { "revision": 2.0 } } });
+    assert_eq!(a.get_deep_value().to_json_value(), expected);
+    assert_eq!(b.get_deep_value().to_json_value(), expected);
+
+    // Path resolution still walks both mergeable hops.
+    let path = a.get_path_to_container(&a_rev.id()).expect("path");
+    let indexes = path.iter().map(|(_, idx)| idx.clone()).collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![
+            Index::Key("state".into()),
+            Index::Key("profile".into()),
+            Index::Key("revision".into()),
+        ]
+    );
+}
+
+/// A detached map handler (built without a parent doc) supports
+/// `get_mergeable_*` by falling back to `get_or_create_container`. The
+/// fallback path doesn't compute deterministic cids — that's intentional;
+/// determinism is meaningless until the handler attaches to a doc — but it
+/// must still return a working child handler that callers can mutate.
+#[test]
+#[cfg(feature = "counter")]
+fn detached_map_get_mergeable_counter_falls_back_cleanly() {
+    use loro_internal::MapHandler;
+    let detached = MapHandler::new_detached();
+    let counter = detached
+        .get_mergeable_counter("revision")
+        .expect("detached fallback must succeed");
+    counter
+        .increment(7.0)
+        .expect("detached counter must be mutable");
+    // The detached handler still surfaces the value through its local state.
+    assert_eq!(counter.get_value().to_json_value(), json!(7.0));
+}

--- a/crates/loro-internal/tests/mergeable_container/convergence.rs
+++ b/crates/loro-internal/tests/mergeable_container/convergence.rs
@@ -193,7 +193,7 @@ fn three_peer_mergeable_counter_convergence() {
 /// After A and B sync once, both peers concurrently mutate the same
 /// mergeable counter again, then sync. Convergence must hold on the second
 /// round — the deterministic cid plus CRDT merge must keep working after
-/// the side table has been populated and used.
+/// the logical mergeable edge has already been resolved and used.
 #[test]
 #[cfg(feature = "counter")]
 fn post_merge_concurrent_counter_increments_converge() {

--- a/crates/loro-internal/tests/mergeable_container/convergence.rs
+++ b/crates/loro-internal/tests/mergeable_container/convergence.rs
@@ -16,8 +16,8 @@ fn concurrent_counter_increments_show_current_lost_update_bug() {
     let a_root = a.get_map("state");
     let b_root = b.get_map("state");
 
-    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
-    let b_counter = b_root.get_mergeable_counter("revision").unwrap();
+    let a_counter = a_root.ensure_mergeable_counter("revision").unwrap();
+    let b_counter = b_root.ensure_mergeable_counter("revision").unwrap();
 
     assert_eq!(
         a_counter.id(),
@@ -62,8 +62,8 @@ fn concurrent_counter_increments_show_current_lost_update_bug() {
 fn concurrent_text_updates_show_current_lost_update_bug() {
     let a = doc(1);
     let b = doc(2);
-    let a_text = a.get_map("state").get_mergeable_text("notes").unwrap();
-    let b_text = b.get_map("state").get_mergeable_text("notes").unwrap();
+    let a_text = a.get_map("state").ensure_mergeable_text("notes").unwrap();
+    let b_text = b.get_map("state").ensure_mergeable_text("notes").unwrap();
 
     assert_eq!(
         a_text.id(),
@@ -91,8 +91,8 @@ fn concurrent_text_updates_show_current_lost_update_bug() {
 fn concurrent_list_inserts_show_current_lost_update_bug() {
     let a = doc(1);
     let b = doc(2);
-    let a_list = a.get_map("state").get_mergeable_list("items").unwrap();
-    let b_list = b.get_map("state").get_mergeable_list("items").unwrap();
+    let a_list = a.get_map("state").ensure_mergeable_list("items").unwrap();
+    let b_list = b.get_map("state").ensure_mergeable_list("items").unwrap();
 
     assert_eq!(
         a_list.id(),
@@ -116,7 +116,7 @@ fn concurrent_list_inserts_show_current_lost_update_bug() {
     );
 }
 
-/// Two peers each obtain the "profile" Map via `get_mergeable_map` and write
+/// Two peers each obtain the "profile" Map via `ensure_mergeable_map` and write
 /// to *different* keys. With non-mergeable child Maps, each peer creates a
 /// distinct peer-specific cid, so LWW drops one peer's Map entirely even
 /// though the key sets are disjoint. Once child Maps are mergeable the merged
@@ -125,8 +125,8 @@ fn concurrent_list_inserts_show_current_lost_update_bug() {
 fn concurrent_map_writes_show_current_lost_update_bug() {
     let a = doc(1);
     let b = doc(2);
-    let a_map = a.get_map("state").get_mergeable_map("profile").unwrap();
-    let b_map = b.get_map("state").get_mergeable_map("profile").unwrap();
+    let a_map = a.get_map("state").ensure_mergeable_map("profile").unwrap();
+    let b_map = b.get_map("state").ensure_mergeable_map("profile").unwrap();
 
     assert_eq!(
         a_map.id(),
@@ -161,15 +161,15 @@ fn three_peer_mergeable_counter_convergence() {
 
     let a_counter = a
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     let c_counter = c
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     assert_eq!(a_counter.id(), b_counter.id());
     assert_eq!(b_counter.id(), c_counter.id());
@@ -202,11 +202,11 @@ fn post_merge_concurrent_counter_increments_converge() {
 
     let a_counter = a
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     a_counter.increment(1.0).unwrap();
     b_counter.increment(1.0).unwrap();
@@ -237,12 +237,12 @@ fn nested_mergeable_concurrent_counter_converges() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_profile = a.get_map("state").get_mergeable_map("profile").unwrap();
-    let b_profile = b.get_map("state").get_mergeable_map("profile").unwrap();
+    let a_profile = a.get_map("state").ensure_mergeable_map("profile").unwrap();
+    let b_profile = b.get_map("state").ensure_mergeable_map("profile").unwrap();
     assert_eq!(a_profile.id(), b_profile.id());
 
-    let a_rev = a_profile.get_mergeable_counter("revision").unwrap();
-    let b_rev = b_profile.get_mergeable_counter("revision").unwrap();
+    let a_rev = a_profile.ensure_mergeable_counter("revision").unwrap();
+    let b_rev = b_profile.ensure_mergeable_counter("revision").unwrap();
     assert_eq!(a_rev.id(), b_rev.id());
 
     a_rev.increment(1.0).unwrap();
@@ -267,17 +267,17 @@ fn nested_mergeable_concurrent_counter_converges() {
 }
 
 /// A detached map handler (built without a parent doc) supports
-/// `get_mergeable_*` by falling back to `get_or_create_container`. The
+/// `ensure_mergeable_*` by falling back to `get_or_create_container`. The
 /// fallback path doesn't compute deterministic cids — that's intentional;
 /// determinism is meaningless until the handler attaches to a doc — but it
 /// must still return a working child handler that callers can mutate.
 #[test]
 #[cfg(feature = "counter")]
-fn detached_map_get_mergeable_counter_falls_back_cleanly() {
+fn detached_map_ensure_mergeable_counter_falls_back_cleanly() {
     use loro_internal::MapHandler;
     let detached = MapHandler::new_detached();
     let counter = detached
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .expect("detached fallback must succeed");
     counter
         .increment(7.0)

--- a/crates/loro-internal/tests/mergeable_container/delete.rs
+++ b/crates/loro-internal/tests/mergeable_container/delete.rs
@@ -1,0 +1,339 @@
+//! Delete semantics for mergeable children.
+//!
+//! `delete(key)` overwrites the `"🤝:<kind>"` discriminator in the parent map's value slot with
+//! `None`, exactly as deleting a regular child container clears its value-table entry. The child
+//! becomes unreachable; its container state is preserved in history. Re-calling
+//! `get_mergeable_<kind>(key)` rewrites the discriminator and resurfaces the preserved state, and
+//! Map LWW resolves any concurrent delete-vs-recreate race — symmetric with normal Loro
+//! write/delete (loro-dev/loro#759).
+
+#[path = "common.rs"]
+mod common;
+use common::{doc, sync};
+
+use loro_internal::{loro::ExportMode, HandlerTrait, ToJson};
+use serde_json::json;
+
+/// `delete(key)` on a mergeable key clears the discriminator, so the child no longer appears in
+/// deep value. The child's container state is preserved: re-getting it resolves to the same
+/// deterministic cid and resurfaces the prior value (delete detaches, it does not reset).
+#[test]
+#[cfg(feature = "counter")]
+fn delete_clears_discriminator_and_recreate_resurfaces_state() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(3.0).unwrap();
+    doc.commit_then_renew();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 3.0 } })
+    );
+
+    root.delete("revision").unwrap();
+    doc.commit_then_renew();
+
+    // Cleared: not in deep value, exactly like any deleted container.
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": {} }),
+        "delete must clear the mergeable child from deep value"
+    );
+
+    // Re-get rewrites the discriminator. The child resurfaces with its PRESERVED value (3.0),
+    // not a reset to 0.0 — delete detaches, it does not destroy the container state.
+    let counter2 = root.get_mergeable_counter("revision").unwrap();
+    doc.commit_then_renew();
+    assert_eq!(counter2.id(), counter.id(), "deterministic cid is stable");
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 3.0 } }),
+        "re-get rewrites the discriminator and resurfaces the preserved state"
+    );
+}
+
+/// `delete(key)` records nothing special in side state — the slot value (`None`) is the whole
+/// story. After delete, the parent map simply has no value at the key.
+#[test]
+#[cfg(feature = "counter")]
+fn delete_leaves_no_value_at_key() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(1.0).unwrap();
+    doc.commit_then_renew();
+    assert!(root.get("revision").is_some(), "discriminator present");
+
+    root.delete("revision").unwrap();
+    doc.commit_then_renew();
+
+    assert_eq!(
+        root.get("revision"),
+        None,
+        "after delete the slot holds no value"
+    );
+}
+
+/// A local `delete` clears the child from deep value immediately, without waiting for any
+/// remote import cycle.
+#[test]
+#[cfg(feature = "counter")]
+fn local_delete_immediately_clears_mergeable_child() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(1.0).unwrap();
+    doc.commit_then_renew();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 1.0 } })
+    );
+
+    root.delete("revision").unwrap();
+    doc.commit_then_renew();
+
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": {} }),
+        "local delete must remove the mergeable child from deep value"
+    );
+}
+
+/// Recreate after seeing a delete wins: peer A deletes the key; peer B imports the delete (its
+/// slot is now cleared), then re-calls `get_mergeable_<kind>`, which re-emits a FRESH discriminator
+/// because the slot is empty. That discriminator's IdLp dominates the delete, so the child is
+/// visible again and its preserved state resurfaces — symmetric with re-`set_container` after a
+/// regular delete.
+///
+/// (Note the symmetry: if B re-calls `get_mergeable_<kind>` while still holding the OLD
+/// discriminator it imported earlier — i.e. before seeing the delete — the call is idempotent and
+/// emits no op, so the concurrent delete wins, exactly as a regular concurrent delete beats a
+/// stale local handle. That case is covered by `concurrent_delete_wins_against_earlier_increment`.)
+#[test]
+#[cfg(feature = "counter")]
+fn recreate_after_seen_delete_resurfaces_preserved_state() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_root = a.get_map("state");
+    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    a_counter.increment(1.0).unwrap();
+    a.commit_then_renew();
+    sync(&a, &b);
+
+    // A deletes; B imports the delete so B's slot is cleared.
+    a_root.delete("revision").unwrap();
+    a.commit_then_renew();
+    sync(&a, &b);
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": {} }),
+        "B sees the cleared slot after importing the delete"
+    );
+
+    // B re-creates: the slot is empty, so this re-emits a fresh discriminator dominating the
+    // delete. The preserved counter state (1.0) resurfaces, plus B's new increment.
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    b_counter.increment(100.0).unwrap();
+    b.commit_then_renew();
+
+    sync(&a, &b);
+
+    let va = a.get_deep_value().to_json_value();
+    let vb = b.get_deep_value().to_json_value();
+    assert_eq!(va, vb, "peers must converge");
+    assert_eq!(
+        va["state"]["revision"],
+        json!(101.0),
+        "recreate after seeing the delete resurfaces preserved state (1.0) + new increment (100.0)"
+    );
+}
+
+/// Concurrent delete-wins: peer A increments, peer B deletes with a higher IdLp and never
+/// recreates. The delete dominates the discriminator via Map LWW, so the child is gone on both
+/// peers — symmetric with a concurrent delete winning over a regular write.
+#[test]
+#[cfg(feature = "counter")]
+fn concurrent_delete_wins_against_earlier_increment() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_root = a.get_map("state");
+    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    a_counter.increment(1.0).unwrap();
+    a.commit_then_renew();
+    sync(&a, &b);
+
+    // B increments first (low IdLp).
+    let b_root = b.get_map("state");
+    let b_counter = b_root.get_mergeable_counter("revision").unwrap();
+    b_counter.increment(100.0).unwrap();
+    b.commit_then_renew();
+
+    // A advances its clock past B's increment, then deletes.
+    for i in 0..5 {
+        a_root.insert(&format!("noise_{i}"), i).unwrap();
+        a.commit_then_renew();
+    }
+    a_root.delete("revision").unwrap();
+    a.commit_then_renew();
+
+    sync(&a, &b);
+
+    let va = a.get_deep_value().to_json_value();
+    let vb = b.get_deep_value().to_json_value();
+    assert_eq!(va, vb);
+    assert!(
+        va["state"].get("revision").is_none(),
+        "delete with higher IdLp must dominate the discriminator; got {va}"
+    );
+}
+
+/// Remote delete clears the child on the receiver: peer B has a visible mergeable counter; peer A
+/// deletes the key with a higher IdLp. After sync, B's deep value drops the counter because A's
+/// delete wins the Map LWW for the discriminator slot.
+#[test]
+#[cfg(feature = "counter")]
+fn remote_delete_clears_mergeable_child_on_receiver() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let b_root = b.get_map("state");
+    let b_counter = b_root.get_mergeable_counter("revision").unwrap();
+    b_counter.increment(1.0).unwrap();
+    b.commit_then_renew();
+    sync(&a, &b);
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 1.0 } })
+    );
+
+    let a_root = a.get_map("state");
+    for i in 0..5 {
+        a_root.insert(&format!("noise_{i}"), i).unwrap();
+        a.commit_then_renew();
+    }
+    a_root.delete("revision").unwrap();
+    a.commit_then_renew();
+
+    sync(&a, &b);
+
+    let vb = b.get_deep_value().to_json_value();
+    assert!(
+        vb["state"].get("revision").is_none(),
+        "remote delete must clear B's mergeable child; got {vb}"
+    );
+}
+
+/// Three-peer convergence across a delete and a competing-kind recreate: B creates a counter, A
+/// deletes it with a higher IdLp, C recreates the key as a text. All peers converge on the text.
+#[test]
+#[cfg(feature = "counter")]
+fn three_peer_delete_then_recreate_converges() {
+    use loro_internal::cursor::PosType;
+
+    let a = doc(1);
+    let b = doc(2);
+    let c = doc(3);
+
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    b_counter.increment(1.0).unwrap();
+    b.commit_then_renew();
+
+    sync(&a, &b);
+    sync(&b, &c);
+
+    let a_root = a.get_map("state");
+    for i in 0..6 {
+        a_root.insert(&format!("noise_{i}"), i).unwrap();
+        a.commit_then_renew();
+    }
+    a_root.delete("revision").unwrap();
+    a.commit_then_renew();
+
+    sync(&a, &b);
+    sync(&a, &c);
+
+    // C recreates "revision" as a text with a post-delete IdLp.
+    let c_text = c.get_map("state").get_mergeable_text("revision").unwrap();
+    c_text.insert(0, "after-delete", PosType::Unicode).unwrap();
+    c.commit_then_renew();
+
+    sync(&b, &c);
+    sync(&a, &c);
+    sync(&a, &b);
+
+    let expected = json!({
+        "state": {
+            "noise_0": 0,
+            "noise_1": 1,
+            "noise_2": 2,
+            "noise_3": 3,
+            "noise_4": 4,
+            "noise_5": 5,
+            "revision": "after-delete",
+        }
+    });
+    assert_eq!(a.get_deep_value().to_json_value(), expected, "A converges");
+    assert_eq!(b.get_deep_value().to_json_value(), expected, "B converges");
+    assert_eq!(c.get_deep_value().to_json_value(), expected, "C converges");
+}
+
+/// Snapshot round-trip preserves the delete: a peer creates and deletes a mergeable counter, then
+/// exports a snapshot. The receiver sees no counter — the `None` slot rides through the snapshot
+/// as ordinary map state, so no special recovery is needed.
+#[test]
+#[cfg(feature = "counter")]
+fn snapshot_roundtrip_preserves_delete() {
+    let a = doc(1);
+    let a_root = a.get_map("state");
+    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    a_counter.increment(5.0).unwrap();
+    a_root.delete("revision").unwrap();
+    a.commit_then_renew();
+    assert_eq!(a.get_deep_value().to_json_value(), json!({ "state": {} }));
+
+    let snapshot = a.export(ExportMode::Snapshot).unwrap();
+    let b = doc(2);
+    b.import(&snapshot).unwrap();
+
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": {} }),
+        "snapshot import must preserve the cleared slot; no mergeable child appears"
+    );
+    assert_eq!(
+        b.get_map("state").get("revision"),
+        None,
+        "the cleared slot has no value after snapshot import"
+    );
+}
+
+/// `delete` on a mergeable key emits exactly one op — a regular `MapSet { value: None }` — by the
+/// local peer. No new op types are introduced; older peers apply it as an ordinary map-key clear.
+#[test]
+#[cfg(feature = "counter")]
+fn delete_on_mergeable_key_emits_only_existing_op_types() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(1.0).unwrap();
+    doc.commit_then_renew();
+    let counter_before = doc.oplog_vv().get(&1).copied().unwrap_or(0);
+
+    root.delete("revision").unwrap();
+    doc.commit_then_renew();
+    let counter_after = doc.oplog_vv().get(&1).copied().unwrap_or(0);
+
+    let new_ops = counter_after - counter_before;
+    assert_eq!(
+        new_ops, 1,
+        "delete must emit exactly one op (the MapSet clearing the slot); got {new_ops}"
+    );
+}

--- a/crates/loro-internal/tests/mergeable_container/delete.rs
+++ b/crates/loro-internal/tests/mergeable_container/delete.rs
@@ -1,9 +1,9 @@
 //! Delete semantics for mergeable children.
 //!
-//! `delete(key)` overwrites the `"🤝:<kind>"` discriminator in the parent map's value slot with
-//! `None`, exactly as deleting a regular child container clears its value-table entry. The child
+//! `delete(key)` overwrites the binary marker in the parent map's value slot with `None`, exactly
+//! as deleting a regular child container clears its value-table entry. The child
 //! becomes unreachable; its container state is preserved in history. Re-calling
-//! `get_mergeable_<kind>(key)` rewrites the discriminator and resurfaces the preserved state, and
+//! `get_mergeable_<kind>(key)` rewrites the marker and resurfaces the preserved state, and
 //! Map LWW resolves any concurrent delete-vs-recreate race — symmetric with normal Loro
 //! write/delete (loro-dev/loro#759).
 
@@ -14,12 +14,12 @@ use common::{doc, sync};
 use loro_internal::{loro::ExportMode, HandlerTrait, ToJson};
 use serde_json::json;
 
-/// `delete(key)` on a mergeable key clears the discriminator, so the child no longer appears in
+/// `delete(key)` on a mergeable key clears the marker, so the child no longer appears in
 /// deep value. The child's container state is preserved: re-getting it resolves to the same
 /// deterministic cid and resurfaces the prior value (delete detaches, it does not reset).
 #[test]
 #[cfg(feature = "counter")]
-fn delete_clears_discriminator_and_recreate_resurfaces_state() {
+fn delete_clears_marker_and_recreate_resurfaces_state() {
     let doc = doc(1);
     let root = doc.get_map("state");
     let counter = root.get_mergeable_counter("revision").unwrap();
@@ -40,7 +40,7 @@ fn delete_clears_discriminator_and_recreate_resurfaces_state() {
         "delete must clear the mergeable child from deep value"
     );
 
-    // Re-get rewrites the discriminator. The child resurfaces with its PRESERVED value (3.0),
+    // Re-get rewrites the marker. The child resurfaces with its PRESERVED value (3.0),
     // not a reset to 0.0 — delete detaches, it does not destroy the container state.
     let counter2 = root.get_mergeable_counter("revision").unwrap();
     doc.commit_then_renew();
@@ -48,7 +48,7 @@ fn delete_clears_discriminator_and_recreate_resurfaces_state() {
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({ "state": { "revision": 3.0 } }),
-        "re-get rewrites the discriminator and resurfaces the preserved state"
+        "re-get rewrites the marker and resurfaces the preserved state"
     );
 }
 
@@ -62,7 +62,7 @@ fn delete_leaves_no_value_at_key() {
     let counter = root.get_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     doc.commit_then_renew();
-    assert!(root.get("revision").is_some(), "discriminator present");
+    assert!(root.get("revision").is_some(), "marker present");
 
     root.delete("revision").unwrap();
     doc.commit_then_renew();
@@ -100,13 +100,13 @@ fn local_delete_immediately_clears_mergeable_child() {
 }
 
 /// Recreate after seeing a delete wins: peer A deletes the key; peer B imports the delete (its
-/// slot is now cleared), then re-calls `get_mergeable_<kind>`, which re-emits a FRESH discriminator
-/// because the slot is empty. That discriminator's IdLp dominates the delete, so the child is
+/// slot is now cleared), then re-calls `get_mergeable_<kind>`, which re-emits a FRESH marker
+/// because the slot is empty. That marker's IdLp dominates the delete, so the child is
 /// visible again and its preserved state resurfaces — symmetric with re-`set_container` after a
 /// regular delete.
 ///
 /// (Note the symmetry: if B re-calls `get_mergeable_<kind>` while still holding the OLD
-/// discriminator it imported earlier — i.e. before seeing the delete — the call is idempotent and
+/// marker it imported earlier — i.e. before seeing the delete — the call is idempotent and
 /// emits no op, so the concurrent delete wins, exactly as a regular concurrent delete beats a
 /// stale local handle. That case is covered by `concurrent_delete_wins_against_earlier_increment`.)
 #[test]
@@ -131,7 +131,7 @@ fn recreate_after_seen_delete_resurfaces_preserved_state() {
         "B sees the cleared slot after importing the delete"
     );
 
-    // B re-creates: the slot is empty, so this re-emits a fresh discriminator dominating the
+    // B re-creates: the slot is empty, so this re-emits a fresh marker dominating the
     // delete. The preserved counter state (1.0) resurfaces, plus B's new increment.
     let b_counter = b
         .get_map("state")
@@ -153,7 +153,7 @@ fn recreate_after_seen_delete_resurfaces_preserved_state() {
 }
 
 /// Concurrent delete-wins: peer A increments, peer B deletes with a higher IdLp and never
-/// recreates. The delete dominates the discriminator via Map LWW, so the child is gone on both
+/// recreates. The delete dominates the marker via Map LWW, so the child is gone on both
 /// peers — symmetric with a concurrent delete winning over a regular write.
 #[test]
 #[cfg(feature = "counter")]
@@ -188,13 +188,13 @@ fn concurrent_delete_wins_against_earlier_increment() {
     assert_eq!(va, vb);
     assert!(
         va["state"].get("revision").is_none(),
-        "delete with higher IdLp must dominate the discriminator; got {va}"
+        "delete with higher IdLp must dominate the marker; got {va}"
     );
 }
 
 /// Remote delete clears the child on the receiver: peer B has a visible mergeable counter; peer A
 /// deletes the key with a higher IdLp. After sync, B's deep value drops the counter because A's
-/// delete wins the Map LWW for the discriminator slot.
+/// delete wins the Map LWW for the marker slot.
 #[test]
 #[cfg(feature = "counter")]
 fn remote_delete_clears_mergeable_child_on_receiver() {

--- a/crates/loro-internal/tests/mergeable_container/delete.rs
+++ b/crates/loro-internal/tests/mergeable_container/delete.rs
@@ -3,7 +3,7 @@
 //! `delete(key)` overwrites the binary marker in the parent map's value slot with `None`, exactly
 //! as deleting a regular child container clears its value-table entry. The child
 //! becomes unreachable; its container state is preserved in history. Re-calling
-//! `get_mergeable_<kind>(key)` rewrites the marker and resurfaces the preserved state, and
+//! `ensure_mergeable_<kind>(key)` rewrites the marker and resurfaces the preserved state, and
 //! Map LWW resolves any concurrent delete-vs-recreate race — symmetric with normal Loro
 //! write/delete (loro-dev/loro#759).
 
@@ -22,7 +22,7 @@ use serde_json::json;
 fn delete_clears_marker_and_recreate_resurfaces_state() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(3.0).unwrap();
     doc.commit_then_renew();
     assert_eq!(
@@ -42,7 +42,7 @@ fn delete_clears_marker_and_recreate_resurfaces_state() {
 
     // Re-get rewrites the marker. The child resurfaces with its PRESERVED value (3.0),
     // not a reset to 0.0 — delete detaches, it does not destroy the container state.
-    let counter2 = root.get_mergeable_counter("revision").unwrap();
+    let counter2 = root.ensure_mergeable_counter("revision").unwrap();
     doc.commit_then_renew();
     assert_eq!(counter2.id(), counter.id(), "deterministic cid is stable");
     assert_eq!(
@@ -59,7 +59,7 @@ fn delete_clears_marker_and_recreate_resurfaces_state() {
 fn delete_leaves_no_value_at_key() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     doc.commit_then_renew();
     assert!(root.get("revision").is_some(), "marker present");
@@ -81,7 +81,7 @@ fn delete_leaves_no_value_at_key() {
 fn local_delete_immediately_clears_mergeable_child() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     doc.commit_then_renew();
     assert_eq!(
@@ -100,12 +100,12 @@ fn local_delete_immediately_clears_mergeable_child() {
 }
 
 /// Recreate after seeing a delete wins: peer A deletes the key; peer B imports the delete (its
-/// slot is now cleared), then re-calls `get_mergeable_<kind>`, which re-emits a FRESH marker
+/// slot is now cleared), then re-calls `ensure_mergeable_<kind>`, which re-emits a FRESH marker
 /// because the slot is empty. That marker's IdLp dominates the delete, so the child is
 /// visible again and its preserved state resurfaces — symmetric with re-`set_container` after a
 /// regular delete.
 ///
-/// (Note the symmetry: if B re-calls `get_mergeable_<kind>` while still holding the OLD
+/// (Note the symmetry: if B re-calls `ensure_mergeable_<kind>` while still holding the OLD
 /// marker it imported earlier — i.e. before seeing the delete — the call is idempotent and
 /// emits no op, so the concurrent delete wins, exactly as a regular concurrent delete beats a
 /// stale local handle. That case is covered by `concurrent_delete_wins_against_earlier_increment`.)
@@ -116,7 +116,7 @@ fn recreate_after_seen_delete_resurfaces_preserved_state() {
     let b = doc(2);
 
     let a_root = a.get_map("state");
-    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    let a_counter = a_root.ensure_mergeable_counter("revision").unwrap();
     a_counter.increment(1.0).unwrap();
     a.commit_then_renew();
     sync(&a, &b);
@@ -135,7 +135,7 @@ fn recreate_after_seen_delete_resurfaces_preserved_state() {
     // delete. The preserved counter state (1.0) resurfaces, plus B's new increment.
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     b_counter.increment(100.0).unwrap();
     b.commit_then_renew();
@@ -162,14 +162,14 @@ fn concurrent_delete_wins_against_earlier_increment() {
     let b = doc(2);
 
     let a_root = a.get_map("state");
-    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    let a_counter = a_root.ensure_mergeable_counter("revision").unwrap();
     a_counter.increment(1.0).unwrap();
     a.commit_then_renew();
     sync(&a, &b);
 
     // B increments first (low IdLp).
     let b_root = b.get_map("state");
-    let b_counter = b_root.get_mergeable_counter("revision").unwrap();
+    let b_counter = b_root.ensure_mergeable_counter("revision").unwrap();
     b_counter.increment(100.0).unwrap();
     b.commit_then_renew();
 
@@ -202,7 +202,7 @@ fn remote_delete_clears_mergeable_child_on_receiver() {
     let b = doc(2);
 
     let b_root = b.get_map("state");
-    let b_counter = b_root.get_mergeable_counter("revision").unwrap();
+    let b_counter = b_root.ensure_mergeable_counter("revision").unwrap();
     b_counter.increment(1.0).unwrap();
     b.commit_then_renew();
     sync(&a, &b);
@@ -241,7 +241,7 @@ fn three_peer_delete_then_recreate_converges() {
 
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     b_counter.increment(1.0).unwrap();
     b.commit_then_renew();
@@ -261,7 +261,7 @@ fn three_peer_delete_then_recreate_converges() {
     sync(&a, &c);
 
     // C recreates "revision" as a text with a post-delete IdLp.
-    let c_text = c.get_map("state").get_mergeable_text("revision").unwrap();
+    let c_text = c.get_map("state").ensure_mergeable_text("revision").unwrap();
     c_text.insert(0, "after-delete", PosType::Unicode).unwrap();
     c.commit_then_renew();
 
@@ -293,7 +293,7 @@ fn three_peer_delete_then_recreate_converges() {
 fn snapshot_roundtrip_preserves_delete() {
     let a = doc(1);
     let a_root = a.get_map("state");
-    let a_counter = a_root.get_mergeable_counter("revision").unwrap();
+    let a_counter = a_root.ensure_mergeable_counter("revision").unwrap();
     a_counter.increment(5.0).unwrap();
     a_root.delete("revision").unwrap();
     a.commit_then_renew();
@@ -322,7 +322,7 @@ fn snapshot_roundtrip_preserves_delete() {
 fn delete_on_mergeable_key_emits_only_existing_op_types() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     doc.commit_then_renew();
     let counter_before = doc.oplog_vv().get(&1).copied().unwrap_or(0);

--- a/crates/loro-internal/tests/mergeable_container/discriminator.rs
+++ b/crates/loro-internal/tests/mergeable_container/discriminator.rs
@@ -1,6 +1,6 @@
 //! Marker-based mergeable type-conflict resolution.
 //!
-//! `get_mergeable_<kind>(key)` records which container kind is active at
+//! `ensure_mergeable_<kind>(key)` records which container kind is active at
 //! `(parent, key)` by writing a compact binary marker op against the parent map.
 //! The active mergeable child is whichever marker the parent map's regular LWW
 //! resolves to. See loro-dev/loro#759.
@@ -13,36 +13,36 @@ use loro_common::{mergeable_marker, ContainerType, LoroError, LoroValue, MERGEAB
 use loro_internal::{HandlerTrait, ToJson};
 use serde_json::json;
 
-/// `get_mergeable_map(key)` writes the marker into the parent map's slot at
+/// `ensure_mergeable_map(key)` writes the marker into the parent map's slot at
 /// `key`, so a plain `map.get(key)` reads back that binary value.
 #[test]
-fn get_mergeable_writes_marker_into_parent_slot() {
+fn ensure_mergeable_writes_marker_into_parent_slot() {
     let d = doc(1);
     let root = d.get_map("state");
 
     assert_eq!(root.get("tags"), None, "key starts empty");
 
-    let _list = root.get_mergeable_list("tags").unwrap();
+    let _list = root.ensure_mergeable_list("tags").unwrap();
 
     assert_eq!(
         root.get("tags"),
         Some(mergeable_marker(&root.id(), "tags", ContainerType::List)),
-        "get_mergeable_list must write the List marker into the parent slot"
+        "ensure_mergeable_list must write the List marker into the parent slot"
     );
 }
 
-/// `get_mergeable_<kind>(key)` must not silently clobber an existing non-mergeable value at the
+/// `ensure_mergeable_<kind>(key)` must not silently clobber an existing non-mergeable value at the
 /// key. A plain scalar or a regular child container occupying the slot makes the call an error,
 /// so the marker overwrite is never a hidden side effect of a `get_`-named API.
 #[test]
-fn get_mergeable_rejects_overwriting_a_scalar_value() {
+fn ensure_mergeable_rejects_overwriting_a_scalar_value() {
     let d = doc(1);
     let root = d.get_map("state");
     root.insert("field", 5).unwrap();
 
     let err = root
-        .get_mergeable_list("field")
-        .expect_err("get_mergeable over a scalar must error");
+        .ensure_mergeable_list("field")
+        .expect_err("ensure_mergeable over a scalar must error");
     assert!(
         matches!(err, LoroError::ArgErr(_)),
         "expected ArgErr, got {err:?}"
@@ -57,15 +57,15 @@ fn get_mergeable_rejects_overwriting_a_scalar_value() {
 /// The same guard applies when the slot holds a regular child container: requesting a mergeable
 /// child there is an error and must not overwrite the container reference.
 #[test]
-fn get_mergeable_rejects_overwriting_a_regular_child_container() {
+fn ensure_mergeable_rejects_overwriting_a_regular_child_container() {
     let d = doc(1);
     let root = d.get_map("state");
     root.insert_container("field", loro_internal::handler::MapHandler::new_detached())
         .unwrap();
 
     let err = root
-        .get_mergeable_list("field")
-        .expect_err("get_mergeable over a regular child container must error");
+        .ensure_mergeable_list("field")
+        .expect_err("ensure_mergeable over a regular child container must error");
     assert!(
         matches!(err, LoroError::ArgErr(_)),
         "expected ArgErr, got {err:?}"
@@ -73,36 +73,36 @@ fn get_mergeable_rejects_overwriting_a_regular_child_container() {
 }
 
 /// An empty slot, or a slot already holding a mergeable marker, is fair game:
-/// `get_mergeable_<kind>` creates on empty and is idempotent / kind-changes over an existing
+/// `ensure_mergeable_<kind>` creates on empty and is idempotent / kind-changes over an existing
 /// marker. Only non-mergeable occupants are rejected.
 #[test]
-fn get_mergeable_allows_empty_slot_and_existing_marker() {
+fn ensure_mergeable_allows_empty_slot_and_existing_marker() {
     let d = doc(1);
     let root = d.get_map("state");
 
     // Empty slot: creates.
-    let _list = root.get_mergeable_list("a").unwrap();
+    let _list = root.ensure_mergeable_list("a").unwrap();
     // Same kind again: idempotent, still Ok.
-    let _list2 = root.get_mergeable_list("a").unwrap();
+    let _list2 = root.ensure_mergeable_list("a").unwrap();
     // Different kind over an existing marker: kind change, still Ok.
-    let _map = root.get_mergeable_map("a").unwrap();
+    let _map = root.ensure_mergeable_map("a").unwrap();
 }
 
-/// A user string that happens to look like the old textual sentinel must stay a plain scalar.
+/// A user string must stay a plain scalar and block mergeable child creation.
 #[test]
-fn user_string_that_looks_like_old_marker_is_not_mergeable() {
+fn user_string_is_not_mergeable() {
     let d = doc(1);
     let root = d.get_map("state");
 
-    root.insert("field", "🤝:Map").unwrap();
+    root.insert("field", "not-a-marker").unwrap();
     d.commit_then_renew();
 
     assert_eq!(
         d.get_deep_value().to_json_value(),
-        json!({ "state": { "field": "🤝:Map" } })
+        json!({ "state": { "field": "not-a-marker" } })
     );
     let err = root
-        .get_mergeable_map("field")
+        .ensure_mergeable_map("field")
         .expect_err("user string must not be treated as a mergeable marker");
     assert!(
         matches!(err, LoroError::ArgErr(_)),
@@ -123,7 +123,7 @@ fn marker_for_another_key_is_not_mergeable() {
 
     assert_eq!(root.get("field"), Some(marker_for_other));
     let err = root
-        .get_mergeable_map("field")
+        .ensure_mergeable_map("field")
         .expect_err("marker digest for another key must not activate this key");
     assert!(
         matches!(err, LoroError::ArgErr(_)),
@@ -131,24 +131,24 @@ fn marker_for_another_key_is_not_mergeable() {
     );
 }
 
-/// A second `get_mergeable_<kind>(key)` with the SAME kind is idempotent: it
+/// A second `ensure_mergeable_<kind>(key)` with the SAME kind is idempotent: it
 /// does not emit another op (the parent slot already holds the matching marker).
 #[test]
-fn repeated_get_mergeable_same_kind_is_idempotent() {
+fn repeated_ensure_mergeable_same_kind_is_idempotent() {
     let d = doc(1);
     let root = d.get_map("state");
 
-    let _first = root.get_mergeable_map("profile").unwrap();
+    let _first = root.ensure_mergeable_map("profile").unwrap();
     d.commit_then_renew();
     let ops_after_first = d.len_ops();
 
-    let _second = root.get_mergeable_map("profile").unwrap();
+    let _second = root.ensure_mergeable_map("profile").unwrap();
     d.commit_then_renew();
     let ops_after_second = d.len_ops();
 
     assert_eq!(
         ops_after_second, ops_after_first,
-        "a second same-kind get_mergeable must not emit another op"
+        "a second same-kind ensure_mergeable must not emit another op"
     );
 }
 
@@ -158,7 +158,7 @@ fn repeated_get_mergeable_same_kind_is_idempotent() {
 fn marker_resolves_to_child_in_deep_value() {
     let d = doc(1);
     let root = d.get_map("state");
-    let _list = root.get_mergeable_list("tags").unwrap();
+    let _list = root.ensure_mergeable_list("tags").unwrap();
     d.commit_then_renew();
 
     assert_eq!(
@@ -168,7 +168,7 @@ fn marker_resolves_to_child_in_deep_value() {
     );
 
     // Now add an item; the resolved child must reflect it.
-    let list = root.get_mergeable_list("tags").unwrap();
+    let list = root.ensure_mergeable_list("tags").unwrap();
     list.insert(0, "hello").unwrap();
     d.commit_then_renew();
     assert_eq!(
@@ -184,8 +184,8 @@ fn marker_resolves_to_child_in_deep_value() {
 #[cfg(feature = "counter")]
 fn nested_mergeable_chain_resolves_at_every_hop() {
     let d = doc(1);
-    let profile = d.get_map("state").get_mergeable_map("profile").unwrap();
-    let rev = profile.get_mergeable_counter("revision").unwrap();
+    let profile = d.get_map("state").ensure_mergeable_map("profile").unwrap();
+    let rev = profile.ensure_mergeable_counter("revision").unwrap();
     rev.increment(5.0).unwrap();
     d.commit_then_renew();
 
@@ -204,11 +204,11 @@ fn concurrent_same_kind_creation_merges_via_identical_marker() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_list = a.get_map("state").get_mergeable_list("tags").unwrap();
+    let a_list = a.get_map("state").ensure_mergeable_list("tags").unwrap();
     a_list.insert(0, "from_a").unwrap();
     a.commit_then_renew();
 
-    let b_list = b.get_map("state").get_mergeable_list("tags").unwrap();
+    let b_list = b.get_map("state").ensure_mergeable_list("tags").unwrap();
     b_list.insert(0, "from_b").unwrap();
     b.commit_then_renew();
 
@@ -232,7 +232,7 @@ fn concurrent_same_kind_creation_merges_via_identical_marker() {
     );
 }
 
-/// Kind-change cycle: a key cycles List -> Map -> List. Each `get_mergeable_<kind>` rewrites the
+/// Kind-change cycle: a key cycles List -> Map -> List. Each `ensure_mergeable_<kind>` rewrites the
 /// marker. When the marker returns to List, the ORIGINAL List's contents resurface (its container
 /// state was preserved by name across the cycle), proving the cycle is non-lossy.
 #[test]
@@ -241,7 +241,7 @@ fn kind_change_cycle_resurfaces_original_list_contents() {
     let root = d.get_map("state");
 
     // v1: List with an item.
-    let list = root.get_mergeable_list("field").unwrap();
+    let list = root.ensure_mergeable_list("field").unwrap();
     list.insert(0, "original").unwrap();
     d.commit_then_renew();
     assert_eq!(
@@ -250,7 +250,7 @@ fn kind_change_cycle_resurfaces_original_list_contents() {
     );
 
     // v2: Map (kind change). The List is now hidden, but its state is preserved by name.
-    let map = root.get_mergeable_map("field").unwrap();
+    let map = root.ensure_mergeable_map("field").unwrap();
     map.insert("k", 1).unwrap();
     d.commit_then_renew();
     assert_eq!(
@@ -260,7 +260,7 @@ fn kind_change_cycle_resurfaces_original_list_contents() {
     );
 
     // v3: back to List. The marker returns to List and the ORIGINAL contents resurface.
-    let list_again = root.get_mergeable_list("field").unwrap();
+    let list_again = root.ensure_mergeable_list("field").unwrap();
     d.commit_then_renew();
     assert_eq!(
         list_again.id(),
@@ -281,7 +281,7 @@ fn kind_change_cycle_resurfaces_original_list_contents() {
 fn marker_is_observable_as_raw_binary_for_old_clients() {
     let d = doc(1);
     let root = d.get_map("state");
-    let _list = root.get_mergeable_list("tags").unwrap();
+    let _list = root.ensure_mergeable_list("tags").unwrap();
     d.commit_then_renew();
 
     // The raw slot value is the compact binary marker.

--- a/crates/loro-internal/tests/mergeable_container/discriminator.rs
+++ b/crates/loro-internal/tests/mergeable_container/discriminator.rs
@@ -1,23 +1,22 @@
-//! Discriminator-based mergeable type-conflict resolution.
+//! Marker-based mergeable type-conflict resolution.
 //!
 //! `get_mergeable_<kind>(key)` records which container kind is active at
-//! `(parent, key)` by writing a `MapSet { key, value: String("🤝:<kind>") }`
-//! op against the parent map. The active mergeable child is whichever
-//! discriminator the parent map's regular LWW resolves to. See
-//! loro-dev/loro#759.
+//! `(parent, key)` by writing a compact binary marker op against the parent map.
+//! The active mergeable child is whichever marker the parent map's regular LWW
+//! resolves to. See loro-dev/loro#759.
 
 #[path = "common.rs"]
 mod common;
 use common::{doc, sync};
 
-use loro_common::{mergeable_discriminator, ContainerType, LoroError};
+use loro_common::{mergeable_marker, ContainerType, LoroError, LoroValue, MERGEABLE_MARKER_MAGIC};
 use loro_internal::{HandlerTrait, ToJson};
 use serde_json::json;
 
-/// `get_mergeable_map(key)` writes the discriminator string into the parent
-/// map's slot at `key`, so a plain `map.get(key)` reads back `"🤝:Map"`.
+/// `get_mergeable_map(key)` writes the marker into the parent map's slot at
+/// `key`, so a plain `map.get(key)` reads back that binary value.
 #[test]
-fn get_mergeable_writes_discriminator_into_parent_slot() {
+fn get_mergeable_writes_marker_into_parent_slot() {
     let d = doc(1);
     let root = d.get_map("state");
 
@@ -27,14 +26,14 @@ fn get_mergeable_writes_discriminator_into_parent_slot() {
 
     assert_eq!(
         root.get("tags"),
-        Some(mergeable_discriminator(ContainerType::List)),
-        "get_mergeable_list must write the List discriminator into the parent slot"
+        Some(mergeable_marker(&root.id(), "tags", ContainerType::List)),
+        "get_mergeable_list must write the List marker into the parent slot"
     );
 }
 
 /// `get_mergeable_<kind>(key)` must not silently clobber an existing non-mergeable value at the
 /// key. A plain scalar or a regular child container occupying the slot makes the call an error,
-/// so the discriminator-overwrite is never a hidden side effect of a `get_`-named API.
+/// so the marker overwrite is never a hidden side effect of a `get_`-named API.
 #[test]
 fn get_mergeable_rejects_overwriting_a_scalar_value() {
     let d = doc(1);
@@ -73,11 +72,11 @@ fn get_mergeable_rejects_overwriting_a_regular_child_container() {
     );
 }
 
-/// An empty slot, or a slot already holding a mergeable discriminator, is fair game:
+/// An empty slot, or a slot already holding a mergeable marker, is fair game:
 /// `get_mergeable_<kind>` creates on empty and is idempotent / kind-changes over an existing
-/// discriminator. Only non-mergeable occupants are rejected.
+/// marker. Only non-mergeable occupants are rejected.
 #[test]
-fn get_mergeable_allows_empty_slot_and_existing_discriminator() {
+fn get_mergeable_allows_empty_slot_and_existing_marker() {
     let d = doc(1);
     let root = d.get_map("state");
 
@@ -85,13 +84,55 @@ fn get_mergeable_allows_empty_slot_and_existing_discriminator() {
     let _list = root.get_mergeable_list("a").unwrap();
     // Same kind again: idempotent, still Ok.
     let _list2 = root.get_mergeable_list("a").unwrap();
-    // Different kind over an existing discriminator: kind change, still Ok.
+    // Different kind over an existing marker: kind change, still Ok.
     let _map = root.get_mergeable_map("a").unwrap();
 }
 
+/// A user string that happens to look like the old textual sentinel must stay a plain scalar.
+#[test]
+fn user_string_that_looks_like_old_marker_is_not_mergeable() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    root.insert("field", "🤝:Map").unwrap();
+    d.commit_then_renew();
+
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "field": "🤝:Map" } })
+    );
+    let err = root
+        .get_mergeable_map("field")
+        .expect_err("user string must not be treated as a mergeable marker");
+    assert!(
+        matches!(err, LoroError::ArgErr(_)),
+        "expected ArgErr, got {err:?}"
+    );
+}
+
+/// A marker is bound to its exact `(parent, key, kind)` by the digest. Copying
+/// the binary payload to another key leaves it as an inert user binary value.
+#[test]
+fn marker_for_another_key_is_not_mergeable() {
+    let d = doc(1);
+    let root = d.get_map("state");
+    let marker_for_other = mergeable_marker(&root.id(), "other", ContainerType::Map);
+
+    root.insert("field", marker_for_other.clone()).unwrap();
+    d.commit_then_renew();
+
+    assert_eq!(root.get("field"), Some(marker_for_other));
+    let err = root
+        .get_mergeable_map("field")
+        .expect_err("marker digest for another key must not activate this key");
+    assert!(
+        matches!(err, LoroError::ArgErr(_)),
+        "expected ArgErr, got {err:?}"
+    );
+}
+
 /// A second `get_mergeable_<kind>(key)` with the SAME kind is idempotent: it
-/// does not emit another op (the parent slot already holds the matching
-/// discriminator).
+/// does not emit another op (the parent slot already holds the matching marker).
 #[test]
 fn repeated_get_mergeable_same_kind_is_idempotent() {
     let d = doc(1);
@@ -111,11 +152,10 @@ fn repeated_get_mergeable_same_kind_is_idempotent() {
     );
 }
 
-/// The resolver substitutes the resolved child for the discriminator string
-/// in deep value: the (empty) child is visible immediately as its default,
-/// and the raw `"🤝:List"` string never leaks into the read view.
+/// The resolver substitutes the resolved child for the binary marker in deep value: the (empty)
+/// child is visible immediately as its default, and the raw marker never leaks into the read view.
 #[test]
-fn discriminator_resolves_to_child_in_deep_value() {
+fn marker_resolves_to_child_in_deep_value() {
     let d = doc(1);
     let root = d.get_map("state");
     let _list = root.get_mergeable_list("tags").unwrap();
@@ -124,7 +164,7 @@ fn discriminator_resolves_to_child_in_deep_value() {
     assert_eq!(
         d.get_deep_value().to_json_value(),
         json!({ "state": { "tags": [] } }),
-        "the discriminator must resolve to the child's value, not leak as a string"
+        "the marker must resolve to the child's value, not leak as a binary value"
     );
 
     // Now add an item; the resolved child must reflect it.
@@ -137,10 +177,9 @@ fn discriminator_resolves_to_child_in_deep_value() {
     );
 }
 
-/// A nested chain of mergeable children resolves at every hop: the
-/// intermediate mergeable map is visible (it has a discriminator on its
-/// parent) even though it never receives a direct content op — only its
-/// nested child does. This is the case the old `has_ops` gate broke.
+/// A nested chain of mergeable children resolves at every hop: the intermediate mergeable map is
+/// visible (it has a marker on its parent) even though it never receives a direct content op, only
+/// its nested child does. This is the case the old `has_ops` gate broke.
 #[test]
 #[cfg(feature = "counter")]
 fn nested_mergeable_chain_resolves_at_every_hop() {
@@ -153,15 +192,15 @@ fn nested_mergeable_chain_resolves_at_every_hop() {
     assert_eq!(
         d.get_deep_value().to_json_value(),
         json!({ "state": { "profile": { "revision": 5.0 } } }),
-        "intermediate mergeable map must be visible via its discriminator"
+        "intermediate mergeable map must be visible via its marker"
     );
 }
 
-/// Two peers concurrently create the SAME kind under the same key. Both write
-/// the identical discriminator string, so the Map LWW merge is a no-op and
-/// both peers' contributions land in the one deterministic cid.
+/// Two peers concurrently create the SAME kind under the same key. Both write the identical
+/// marker, so the Map LWW merge is a no-op and both peers' contributions land in the one
+/// deterministic cid.
 #[test]
-fn concurrent_same_kind_creation_merges_via_identical_discriminator() {
+fn concurrent_same_kind_creation_merges_via_identical_marker() {
     let a = doc(1);
     let b = doc(2);
 
@@ -194,8 +233,8 @@ fn concurrent_same_kind_creation_merges_via_identical_discriminator() {
 }
 
 /// Kind-change cycle: a key cycles List -> Map -> List. Each `get_mergeable_<kind>` rewrites the
-/// discriminator. When the discriminator returns to List, the ORIGINAL List's contents resurface
-/// (its container state was preserved by name across the cycle), proving the cycle is non-lossy.
+/// marker. When the marker returns to List, the ORIGINAL List's contents resurface (its container
+/// state was preserved by name across the cycle), proving the cycle is non-lossy.
 #[test]
 fn kind_change_cycle_resurfaces_original_list_contents() {
     let d = doc(1);
@@ -217,10 +256,10 @@ fn kind_change_cycle_resurfaces_original_list_contents() {
     assert_eq!(
         d.get_deep_value().to_json_value(),
         json!({ "state": { "field": { "k": 1 } } }),
-        "Map discriminator active; List hidden"
+        "Map marker active; List hidden"
     );
 
-    // v3: back to List. The discriminator returns to List and the ORIGINAL contents resurface.
+    // v3: back to List. The marker returns to List and the ORIGINAL contents resurface.
     let list_again = root.get_mergeable_list("field").unwrap();
     d.commit_then_renew();
     assert_eq!(
@@ -235,28 +274,25 @@ fn kind_change_cycle_resurfaces_original_list_contents() {
     );
 }
 
-/// Forward-compatibility envelope (issue #759 §5): the discriminator is a real Map value, so an
-/// older client that doesn't understand mergeable containers sees it as a plain string in toJSON
-/// output (a sentinel in the reserved namespace), rather than a plausible user value. We assert
-/// the discriminator string is observable as a raw value via `MapHandler::get` (the surface an
-/// older client's value-table read would hit).
+/// Forward-compatibility envelope: the marker is a real Map value, so an older client that doesn't
+/// understand mergeable containers sees it as an inert binary scalar. It does not look like a
+/// plausible user string and does not introduce a fake container edge.
 #[test]
-fn discriminator_is_observable_as_raw_string_for_old_clients() {
-    use loro_common::MERGEABLE_NAMESPACE_PREFIX;
-
+fn marker_is_observable_as_raw_binary_for_old_clients() {
     let d = doc(1);
     let root = d.get_map("state");
     let _list = root.get_mergeable_list("tags").unwrap();
     d.commit_then_renew();
 
-    // The raw slot value is the discriminator string in the reserved namespace.
+    // The raw slot value is the compact binary marker.
     let raw = root.get("tags").expect("slot has a value");
-    let loro_common::LoroValue::String(s) = &raw else {
-        panic!("discriminator must be a string value; got {raw:?}");
+    let LoroValue::Binary(bytes) = &raw else {
+        panic!("marker must be a binary value; got {raw:?}");
     };
-    assert!(
-        s.starts_with(MERGEABLE_NAMESPACE_PREFIX),
-        "old clients see the discriminator as a reserved-namespace sentinel string; got {s:?}"
+    assert_eq!(bytes.len(), 8);
+    assert!(bytes.starts_with(&MERGEABLE_MARKER_MAGIC));
+    assert_eq!(
+        bytes[MERGEABLE_MARKER_MAGIC.len()],
+        ContainerType::List.to_u8()
     );
-    assert_eq!(s.as_str(), "🤝:List");
 }

--- a/crates/loro-internal/tests/mergeable_container/discriminator.rs
+++ b/crates/loro-internal/tests/mergeable_container/discriminator.rs
@@ -10,7 +10,7 @@
 mod common;
 use common::{doc, sync};
 
-use loro_common::{mergeable_discriminator, ContainerType};
+use loro_common::{mergeable_discriminator, ContainerType, LoroError};
 use loro_internal::{HandlerTrait, ToJson};
 use serde_json::json;
 
@@ -30,6 +30,63 @@ fn get_mergeable_writes_discriminator_into_parent_slot() {
         Some(mergeable_discriminator(ContainerType::List)),
         "get_mergeable_list must write the List discriminator into the parent slot"
     );
+}
+
+/// `get_mergeable_<kind>(key)` must not silently clobber an existing non-mergeable value at the
+/// key. A plain scalar or a regular child container occupying the slot makes the call an error,
+/// so the discriminator-overwrite is never a hidden side effect of a `get_`-named API.
+#[test]
+fn get_mergeable_rejects_overwriting_a_scalar_value() {
+    let d = doc(1);
+    let root = d.get_map("state");
+    root.insert("field", 5).unwrap();
+
+    let err = root
+        .get_mergeable_list("field")
+        .expect_err("get_mergeable over a scalar must error");
+    assert!(
+        matches!(err, LoroError::ArgErr(_)),
+        "expected ArgErr, got {err:?}"
+    );
+    assert_eq!(
+        root.get("field"),
+        Some(5.into()),
+        "the existing scalar value must be left untouched"
+    );
+}
+
+/// The same guard applies when the slot holds a regular child container: requesting a mergeable
+/// child there is an error and must not overwrite the container reference.
+#[test]
+fn get_mergeable_rejects_overwriting_a_regular_child_container() {
+    let d = doc(1);
+    let root = d.get_map("state");
+    root.insert_container("field", loro_internal::handler::MapHandler::new_detached())
+        .unwrap();
+
+    let err = root
+        .get_mergeable_list("field")
+        .expect_err("get_mergeable over a regular child container must error");
+    assert!(
+        matches!(err, LoroError::ArgErr(_)),
+        "expected ArgErr, got {err:?}"
+    );
+}
+
+/// An empty slot, or a slot already holding a mergeable discriminator, is fair game:
+/// `get_mergeable_<kind>` creates on empty and is idempotent / kind-changes over an existing
+/// discriminator. Only non-mergeable occupants are rejected.
+#[test]
+fn get_mergeable_allows_empty_slot_and_existing_discriminator() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    // Empty slot: creates.
+    let _list = root.get_mergeable_list("a").unwrap();
+    // Same kind again: idempotent, still Ok.
+    let _list2 = root.get_mergeable_list("a").unwrap();
+    // Different kind over an existing discriminator: kind change, still Ok.
+    let _map = root.get_mergeable_map("a").unwrap();
 }
 
 /// A second `get_mergeable_<kind>(key)` with the SAME kind is idempotent: it

--- a/crates/loro-internal/tests/mergeable_container/discriminator.rs
+++ b/crates/loro-internal/tests/mergeable_container/discriminator.rs
@@ -1,0 +1,205 @@
+//! Discriminator-based mergeable type-conflict resolution.
+//!
+//! `get_mergeable_<kind>(key)` records which container kind is active at
+//! `(parent, key)` by writing a `MapSet { key, value: String("🤝:<kind>") }`
+//! op against the parent map. The active mergeable child is whichever
+//! discriminator the parent map's regular LWW resolves to. See
+//! loro-dev/loro#759.
+
+#[path = "common.rs"]
+mod common;
+use common::{doc, sync};
+
+use loro_common::{mergeable_discriminator, ContainerType};
+use loro_internal::{HandlerTrait, ToJson};
+use serde_json::json;
+
+/// `get_mergeable_map(key)` writes the discriminator string into the parent
+/// map's slot at `key`, so a plain `map.get(key)` reads back `"🤝:Map"`.
+#[test]
+fn get_mergeable_writes_discriminator_into_parent_slot() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    assert_eq!(root.get("tags"), None, "key starts empty");
+
+    let _list = root.get_mergeable_list("tags").unwrap();
+
+    assert_eq!(
+        root.get("tags"),
+        Some(mergeable_discriminator(ContainerType::List)),
+        "get_mergeable_list must write the List discriminator into the parent slot"
+    );
+}
+
+/// A second `get_mergeable_<kind>(key)` with the SAME kind is idempotent: it
+/// does not emit another op (the parent slot already holds the matching
+/// discriminator).
+#[test]
+fn repeated_get_mergeable_same_kind_is_idempotent() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    let _first = root.get_mergeable_map("profile").unwrap();
+    d.commit_then_renew();
+    let ops_after_first = d.len_ops();
+
+    let _second = root.get_mergeable_map("profile").unwrap();
+    d.commit_then_renew();
+    let ops_after_second = d.len_ops();
+
+    assert_eq!(
+        ops_after_second, ops_after_first,
+        "a second same-kind get_mergeable must not emit another op"
+    );
+}
+
+/// The resolver substitutes the resolved child for the discriminator string
+/// in deep value: the (empty) child is visible immediately as its default,
+/// and the raw `"🤝:List"` string never leaks into the read view.
+#[test]
+fn discriminator_resolves_to_child_in_deep_value() {
+    let d = doc(1);
+    let root = d.get_map("state");
+    let _list = root.get_mergeable_list("tags").unwrap();
+    d.commit_then_renew();
+
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "tags": [] } }),
+        "the discriminator must resolve to the child's value, not leak as a string"
+    );
+
+    // Now add an item; the resolved child must reflect it.
+    let list = root.get_mergeable_list("tags").unwrap();
+    list.insert(0, "hello").unwrap();
+    d.commit_then_renew();
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "tags": ["hello"] } })
+    );
+}
+
+/// A nested chain of mergeable children resolves at every hop: the
+/// intermediate mergeable map is visible (it has a discriminator on its
+/// parent) even though it never receives a direct content op — only its
+/// nested child does. This is the case the old `has_ops` gate broke.
+#[test]
+#[cfg(feature = "counter")]
+fn nested_mergeable_chain_resolves_at_every_hop() {
+    let d = doc(1);
+    let profile = d.get_map("state").get_mergeable_map("profile").unwrap();
+    let rev = profile.get_mergeable_counter("revision").unwrap();
+    rev.increment(5.0).unwrap();
+    d.commit_then_renew();
+
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "profile": { "revision": 5.0 } } }),
+        "intermediate mergeable map must be visible via its discriminator"
+    );
+}
+
+/// Two peers concurrently create the SAME kind under the same key. Both write
+/// the identical discriminator string, so the Map LWW merge is a no-op and
+/// both peers' contributions land in the one deterministic cid.
+#[test]
+fn concurrent_same_kind_creation_merges_via_identical_discriminator() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_list = a.get_map("state").get_mergeable_list("tags").unwrap();
+    a_list.insert(0, "from_a").unwrap();
+    a.commit_then_renew();
+
+    let b_list = b.get_map("state").get_mergeable_list("tags").unwrap();
+    b_list.insert(0, "from_b").unwrap();
+    b.commit_then_renew();
+
+    sync(&a, &b);
+
+    let va = a.get_deep_value().to_json_value();
+    let vb = b.get_deep_value().to_json_value();
+    assert_eq!(va, vb, "same-kind concurrent creation must converge");
+
+    let tags = &va["state"]["tags"];
+    assert!(tags.is_array(), "tags must be a list, got {tags:?}");
+    let items: Vec<&str> = tags
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        items.contains(&"from_a") && items.contains(&"from_b"),
+        "both peers' items must be preserved in the merged list; got {items:?}"
+    );
+}
+
+/// Kind-change cycle: a key cycles List -> Map -> List. Each `get_mergeable_<kind>` rewrites the
+/// discriminator. When the discriminator returns to List, the ORIGINAL List's contents resurface
+/// (its container state was preserved by name across the cycle), proving the cycle is non-lossy.
+#[test]
+fn kind_change_cycle_resurfaces_original_list_contents() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    // v1: List with an item.
+    let list = root.get_mergeable_list("field").unwrap();
+    list.insert(0, "original").unwrap();
+    d.commit_then_renew();
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "field": ["original"] } })
+    );
+
+    // v2: Map (kind change). The List is now hidden, but its state is preserved by name.
+    let map = root.get_mergeable_map("field").unwrap();
+    map.insert("k", 1).unwrap();
+    d.commit_then_renew();
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "field": { "k": 1 } } }),
+        "Map discriminator active; List hidden"
+    );
+
+    // v3: back to List. The discriminator returns to List and the ORIGINAL contents resurface.
+    let list_again = root.get_mergeable_list("field").unwrap();
+    d.commit_then_renew();
+    assert_eq!(
+        list_again.id(),
+        list.id(),
+        "List cid is deterministic across the cycle"
+    );
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "field": ["original"] } }),
+        "original List contents resurface after the List -> Map -> List cycle"
+    );
+}
+
+/// Forward-compatibility envelope (issue #759 §5): the discriminator is a real Map value, so an
+/// older client that doesn't understand mergeable containers sees it as a plain string in toJSON
+/// output (a sentinel in the reserved namespace), rather than a plausible user value. We assert
+/// the discriminator string is observable as a raw value via `MapHandler::get` (the surface an
+/// older client's value-table read would hit).
+#[test]
+fn discriminator_is_observable_as_raw_string_for_old_clients() {
+    use loro_common::MERGEABLE_NAMESPACE_PREFIX;
+
+    let d = doc(1);
+    let root = d.get_map("state");
+    let _list = root.get_mergeable_list("tags").unwrap();
+    d.commit_then_renew();
+
+    // The raw slot value is the discriminator string in the reserved namespace.
+    let raw = root.get("tags").expect("slot has a value");
+    let loro_common::LoroValue::String(s) = &raw else {
+        panic!("discriminator must be a string value; got {raw:?}");
+    };
+    assert!(
+        s.starts_with(MERGEABLE_NAMESPACE_PREFIX),
+        "old clients see the discriminator as a reserved-namespace sentinel string; got {s:?}"
+    );
+    assert_eq!(s.as_str(), "🤝:List");
+}

--- a/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
+++ b/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 fn get_path_returns_logical_parent_path_for_mergeable_child() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     // Exercise the cid path directly; child-side wiring needed to keep
     // mutating ops alive arrives in a later commit.
     let _ = counter.increment(1.0);
@@ -38,7 +38,7 @@ fn get_path_returns_logical_parent_path_for_mergeable_child() {
 fn deep_value_nests_mergeable_child_under_parent_and_hides_synthetic_root() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(2.0).unwrap();
 
     assert_eq!(
@@ -47,7 +47,7 @@ fn deep_value_nests_mergeable_child_under_parent_and_hides_synthetic_root() {
     );
 }
 
-/// `get_mergeable_*` writes a marker op into the parent map, which
+/// `ensure_mergeable_*` writes a marker op into the parent map, which
 /// realizes the child immediately (loro-dev/loro#759). So an unmutated
 /// mergeable child IS visible in deep value, rendered as its empty default.
 /// Because the marker is a real op, every peer that imports it agrees
@@ -55,7 +55,7 @@ fn deep_value_nests_mergeable_child_under_parent_and_hides_synthetic_root() {
 #[test]
 fn deep_value_shows_unmutated_mergeable_child_as_empty() {
     let a = doc(1);
-    let _child = a.get_map("state").get_mergeable_map("nested").unwrap();
+    let _child = a.get_map("state").ensure_mergeable_map("nested").unwrap();
     a.commit_then_renew();
 
     assert_eq!(
@@ -74,7 +74,7 @@ fn deep_value_shows_unmutated_mergeable_child_as_empty() {
 fn parent_map_subscription_receives_mergeable_child_events() {
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
 
     let received: Arc<Mutex<Vec<Vec<Index>>>> = Arc::new(Mutex::new(Vec::new()));
     let received_clone = received.clone();
@@ -114,7 +114,7 @@ fn mergeable_child_subscription_receives_own_events() {
     let doc = doc(1);
     let counter = doc
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
 
     let count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
@@ -149,7 +149,7 @@ fn undo_manager_reverts_mergeable_counter_mutation() {
     let doc = doc(1);
     let counter = doc
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     let undo = UndoManager::new(&doc);
 
@@ -186,7 +186,7 @@ fn top_level_root_enumeration_skips_mergeable_roots() {
 
     let doc = doc(1);
     let root = doc.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     doc.commit_then_renew();
 
@@ -242,7 +242,7 @@ fn has_container_reports_false_for_unwritten_mergeable_child() {
     let root = doc.get_map("state");
 
     // Build the deterministic mergeable cid by hand, WITHOUT calling
-    // get_mergeable_counter (which would write the marker).
+    // ensure_mergeable_counter (which would write the marker).
     let parent_id = root.id();
     let unwritten_cid = ContainerID::new_mergeable(&parent_id, "revision", ContainerType::Counter);
     assert!(unwritten_cid.is_mergeable());
@@ -252,7 +252,7 @@ fn has_container_reports_false_for_unwritten_mergeable_child() {
     );
 
     // Now actually create and mutate the child. has_container must flip to true.
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     assert_eq!(counter.id(), unwritten_cid, "cid is deterministic");
     assert!(

--- a/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
+++ b/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
@@ -1,0 +1,266 @@
+//! Path resolution, deep value, subscriptions, undo, and has_container.
+
+#[path = "common.rs"]
+mod common;
+use common::doc;
+
+use std::sync::{Arc, Mutex};
+
+use loro_internal::{event::Index, HandlerTrait, ToJson};
+use serde_json::json;
+
+#[test]
+#[cfg(feature = "counter")]
+fn get_path_returns_logical_parent_path_for_mergeable_child() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    // Exercise the cid path directly; child-side wiring needed to keep
+    // mutating ops alive arrives in a later commit.
+    let _ = counter.increment(1.0);
+
+    let path = doc
+        .get_path_to_container(&counter.id())
+        .expect("mergeable counter should have a logical path");
+    let indexes = path
+        .iter()
+        .map(|(_, index)| index.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![Index::Key("state".into()), Index::Key("revision".into()),],
+        "mergeable child path should walk logical parent edges, not the synthetic Root name",
+    );
+}
+
+#[test]
+#[cfg(feature = "counter")]
+fn deep_value_nests_mergeable_child_under_parent_and_hides_synthetic_root() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(2.0).unwrap();
+
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 2.0 } })
+    );
+}
+
+/// `get_mergeable_*` writes a discriminator op into the parent map, which
+/// realizes the child immediately (loro-dev/loro#759). So an unmutated
+/// mergeable child IS visible in deep value, rendered as its empty default.
+/// Because the discriminator is a real op, every peer that imports it agrees
+/// on this view — there is no originating-peer divergence.
+#[test]
+fn deep_value_shows_unmutated_mergeable_child_as_empty() {
+    let a = doc(1);
+    let _child = a.get_map("state").get_mergeable_map("nested").unwrap();
+    a.commit_then_renew();
+
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({ "state": { "nested": {} } }),
+        "the discriminator realizes the child; it shows as its empty default",
+    );
+}
+
+/// Subscribing to the *parent* map must receive events when one of its
+/// mergeable children is mutated: subscriptions on ancestor containers should
+/// observe deltas from mergeable descendants, not only subscriptions on the
+/// mergeable child itself.
+#[test]
+#[cfg(feature = "counter")]
+fn parent_map_subscription_receives_mergeable_child_events() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+
+    let received: Arc<Mutex<Vec<Vec<Index>>>> = Arc::new(Mutex::new(Vec::new()));
+    let received_clone = received.clone();
+    let _sub = doc.subscribe(
+        &root.id(),
+        Arc::new(move |event| {
+            let mut g = received_clone.lock().unwrap();
+            for container_diff in event.events.iter() {
+                g.push(
+                    container_diff
+                        .path
+                        .iter()
+                        .map(|(_, idx)| idx.clone())
+                        .collect::<Vec<_>>(),
+                );
+            }
+        }),
+    );
+
+    counter.increment(1.0).unwrap();
+    doc.commit_then_renew();
+
+    let captured = received.lock().unwrap();
+    assert!(
+        captured.iter().any(|path| path
+            .iter()
+            .any(|idx| matches!(idx, Index::Key(k) if &**k == "revision"))),
+        "parent map subscriber should see an event whose path includes the mergeable child's key 'revision'; got {captured:?}",
+    );
+}
+
+/// A subscription on the mergeable child's cid must receive events when the
+/// child is mutated, symmetric to the existing parent-map subscription test.
+#[test]
+#[cfg(feature = "counter")]
+fn mergeable_child_subscription_receives_own_events() {
+    let doc = doc(1);
+    let counter = doc
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+
+    let count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let count_clone = count.clone();
+    let _sub = doc.subscribe(
+        &counter.id(),
+        Arc::new(move |_event| {
+            *count_clone.lock().unwrap() += 1;
+        }),
+    );
+
+    counter.increment(1.0).unwrap();
+    doc.commit_then_renew();
+    counter.increment(2.0).unwrap();
+    doc.commit_then_renew();
+
+    let observed = *count.lock().unwrap();
+    assert!(
+        observed >= 2,
+        "mergeable-child subscription must fire at least once per commit; got {observed} events"
+    );
+}
+
+/// Mutations on a mergeable child must be undoable. Undoing reverts the
+/// child's value; the side-table registration persists (because it isn't
+/// itself an op).
+#[test]
+#[cfg(feature = "counter")]
+fn undo_manager_reverts_mergeable_counter_mutation() {
+    use loro_internal::UndoManager;
+
+    let doc = doc(1);
+    let counter = doc
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    let undo = UndoManager::new(&doc);
+
+    counter.increment(5.0).unwrap();
+    doc.commit_then_renew();
+    assert_eq!(counter.get_value().to_json_value(), json!(5.0));
+
+    let did_undo = undo.undo().expect("undo must succeed");
+    assert!(did_undo, "undo must report it did something");
+
+    // The mergeable child still exists (registration is not an op), but its
+    // value is back to zero.
+    assert_eq!(
+        counter.get_value().to_json_value(),
+        json!(0.0),
+        "undo must revert the increment"
+    );
+}
+
+/// Mergeable Roots have a deterministic `ContainerID::Root` in a reserved namespace,
+/// but they are conceptually parented to a regular Map. The top-level root enumeration
+/// (driven by `DocState::preferred_root_containers`, surfaced through
+/// `LoroDoc::get_value`) must NOT include the synthetic mergeable Root — otherwise
+/// the doc would expose a top-level key with a `🤝:...` hex name alongside the real
+/// roots.
+///
+/// This guards the `id.is_mergeable()` skip in `preferred_root_containers` against
+/// accidental removal: without it, peers would see two top-level entries (the actual
+/// parent map plus the synthetic mergeable root) instead of one.
+#[test]
+#[cfg(feature = "counter")]
+fn top_level_root_enumeration_skips_mergeable_roots() {
+    use loro_common::MERGEABLE_NAMESPACE_PREFIX;
+
+    let doc = doc(1);
+    let root = doc.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(1.0).unwrap();
+    doc.commit_then_renew();
+
+    // Sanity: the mergeable cid carries the synthetic namespace prefix.
+    let mergeable_cid = counter.id();
+    assert!(mergeable_cid.is_mergeable());
+
+    // `get_value()` returns a Map keyed by top-level root names. The mergeable cid's
+    // synthetic Root name (🤝:<hex>) must NOT appear here.
+    let top_level = doc.get_value().to_json_value();
+    let map = top_level
+        .as_object()
+        .expect("top-level doc value must be a JSON object");
+    let keys: Vec<&str> = map.keys().map(|s| s.as_str()).collect();
+    assert!(
+        keys.iter().any(|k| *k == "state"),
+        "real parent root 'state' must appear in top-level enumeration; got {keys:?}"
+    );
+    assert!(
+        keys.iter()
+            .all(|k| !k.starts_with(MERGEABLE_NAMESPACE_PREFIX)),
+        "no mergeable-namespace Root name must appear at the top level; got {keys:?}"
+    );
+    // Even more strictly: the synthetic root's exact name must not be a top-level key.
+    let synthetic_name = match &mergeable_cid {
+        loro_common::ContainerID::Root { name, .. } => name.to_string(),
+        _ => unreachable!("mergeable cid is always a Root"),
+    };
+    assert!(
+        !keys.iter().any(|k| *k == synthetic_name),
+        "synthetic mergeable root name {synthetic_name:?} must not be in top-level keys {keys:?}"
+    );
+
+    // Deep value must show the mergeable child nested under its logical parent, not as a
+    // sibling top-level entry.
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 1.0 } }),
+        "mergeable child must be nested under its logical parent, not surfaced at the top level"
+    );
+}
+
+/// `LoroDoc::has_container(cid)` must return `false` for a mergeable cid
+/// that has never been written to, and `true` after the child has been
+/// mutated. Mergeable existence depends on state, not on the name shape, so
+/// the short-circuit for plain `Root` ids must skip mergeable namespace cids.
+#[test]
+#[cfg(feature = "counter")]
+fn has_container_reports_false_for_unwritten_mergeable_child() {
+    use loro_common::{ContainerID, ContainerType};
+
+    let doc = doc(1);
+    let root = doc.get_map("state");
+
+    // Build the deterministic mergeable cid by hand, WITHOUT calling
+    // get_mergeable_counter (which would register the side-table entry).
+    let parent_id = root.id();
+    let unwritten_cid = ContainerID::new_mergeable(&parent_id, "revision", ContainerType::Counter);
+    assert!(unwritten_cid.is_mergeable());
+    assert!(
+        !doc.has_container(&unwritten_cid),
+        "has_container must report false for an unwritten mergeable cid"
+    );
+
+    // Now actually create and mutate the child. has_container must flip to true.
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(1.0).unwrap();
+    assert_eq!(counter.id(), unwritten_cid, "cid is deterministic");
+    assert!(
+        doc.has_container(&unwritten_cid),
+        "has_container must report true after the mergeable child has state"
+    );
+
+    // Regular root containers still report true as before (regression guard).
+    let regular_root = ContainerID::new_root("state", ContainerType::Map);
+    assert!(doc.has_container(&regular_root));
+}

--- a/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
+++ b/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
@@ -47,10 +47,10 @@ fn deep_value_nests_mergeable_child_under_parent_and_hides_synthetic_root() {
     );
 }
 
-/// `get_mergeable_*` writes a discriminator op into the parent map, which
+/// `get_mergeable_*` writes a marker op into the parent map, which
 /// realizes the child immediately (loro-dev/loro#759). So an unmutated
 /// mergeable child IS visible in deep value, rendered as its empty default.
-/// Because the discriminator is a real op, every peer that imports it agrees
+/// Because the marker is a real op, every peer that imports it agrees
 /// on this view — there is no originating-peer divergence.
 #[test]
 fn deep_value_shows_unmutated_mergeable_child_as_empty() {
@@ -61,7 +61,7 @@ fn deep_value_shows_unmutated_mergeable_child_as_empty() {
     assert_eq!(
         a.get_deep_value().to_json_value(),
         json!({ "state": { "nested": {} } }),
-        "the discriminator realizes the child; it shows as its empty default",
+        "the marker realizes the child; it shows as its empty default",
     );
 }
 
@@ -139,8 +139,8 @@ fn mergeable_child_subscription_receives_own_events() {
 }
 
 /// Mutations on a mergeable child must be undoable. Undoing reverts the
-/// child's value; the side-table registration persists (because it isn't
-/// itself an op).
+/// child's value; the parent marker persists (because it isn't the
+/// increment op being undone).
 #[test]
 #[cfg(feature = "counter")]
 fn undo_manager_reverts_mergeable_counter_mutation() {
@@ -242,7 +242,7 @@ fn has_container_reports_false_for_unwritten_mergeable_child() {
     let root = doc.get_map("state");
 
     // Build the deterministic mergeable cid by hand, WITHOUT calling
-    // get_mergeable_counter (which would register the side-table entry).
+    // get_mergeable_counter (which would write the marker).
     let parent_id = root.id();
     let unwritten_cid = ContainerID::new_mergeable(&parent_id, "revision", ContainerType::Counter);
     assert!(unwritten_cid.is_mergeable());

--- a/crates/loro-internal/tests/mergeable_container/snapshot.rs
+++ b/crates/loro-internal/tests/mergeable_container/snapshot.rs
@@ -1,0 +1,283 @@
+//! Snapshot and update-import round-trips, including LWW recovery.
+
+#[path = "common.rs"]
+mod common;
+use common::{doc, sync};
+
+use loro_internal::{cursor::PosType, event::Index, loro::ExportMode, HandlerTrait, ToJson};
+use serde_json::json;
+
+/// Snapshot round-trip must preserve the parent edges (logical path) and
+/// state values for mergeable child containers nested inside other mergeable
+/// child containers.
+///
+/// Source peer creates `state` → mergeable map `profile` → mergeable counter
+/// `revision`, mutates each, then exports a snapshot. Importing into a fresh
+/// peer must reproduce the same deep value and the same logical path for
+/// the counter.
+#[test]
+#[cfg(feature = "counter")]
+fn snapshot_roundtrip_preserves_mergeable_parent_edges_and_values() {
+    let source = doc(1);
+    let root = source.get_map("state");
+    let nested = root.get_mergeable_map("profile").unwrap();
+    nested.insert("name", "Ada").unwrap();
+    let counter = nested.get_mergeable_counter("revision").unwrap();
+    counter.increment(3.0).unwrap();
+
+    let snapshot = source.export(ExportMode::Snapshot).unwrap();
+    let imported = doc(2);
+    imported.import(&snapshot).unwrap();
+
+    assert_eq!(
+        imported.get_deep_value().to_json_value(),
+        source.get_deep_value().to_json_value(),
+        "deep value of the imported doc must match the source after snapshot round-trip"
+    );
+
+    let imported_counter = imported
+        .get_map("state")
+        .get_mergeable_map("profile")
+        .unwrap()
+        .get_mergeable_counter("revision")
+        .unwrap();
+    let path = imported
+        .get_path_to_container(&imported_counter.id())
+        .expect("mergeable counter must have a logical path after snapshot import");
+    let indexes = path
+        .iter()
+        .map(|(_, index)| index.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![
+            Index::Key("state".into()),
+            Index::Key("profile".into()),
+            Index::Key("revision".into()),
+        ],
+        "imported counter should walk logical parent edges across two mergeable hops"
+    );
+}
+
+/// Peer B imports updates that originated from peer A's `get_mergeable_counter`
+/// + `increment` calls, but peer B never locally called `get_mergeable_*`.
+/// After import, peer B's deep value, container enumeration, and path
+/// resolution for the mergeable child must all reflect the imported state.
+#[test]
+#[cfg(feature = "counter")]
+fn update_import_populates_mergeable_side_table_on_receiver() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_counter = a
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    a_counter.increment(5.0).unwrap();
+    a.commit_then_renew();
+
+    // Peer B imports A's updates WITHOUT first calling get_mergeable_counter.
+    let updates = a.export(ExportMode::updates(&b.oplog_vv())).unwrap();
+    b.import(&updates).unwrap();
+
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 5.0 } }),
+        "after update import, peer B's deep value must include the mergeable child"
+    );
+
+    // Peer B then locally resolves the mergeable handler — this must return
+    // the same cid as the one peer A wrote, and the existing value.
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    assert_eq!(b_counter.id(), a_counter.id());
+    assert_eq!(b_counter.get_value().to_json_value(), json!(5.0));
+
+    // Path resolution from peer B's side must walk through the parent map.
+    let path = b.get_path_to_container(&b_counter.id()).expect("path");
+    let indexes = path.iter().map(|(_, idx)| idx.clone()).collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![Index::Key("state".into()), Index::Key("revision".into())]
+    );
+}
+
+/// Create a mergeable counter but never mutate it, then export a snapshot.
+/// `get_mergeable_*` writes a discriminator into the parent map's value table,
+/// which is ordinary map state and rides through the snapshot like any other
+/// value (loro-dev/loro#759). So the receiving peer resolves the discriminator
+/// to the same deterministic cid and sees the child as its empty default — no
+/// special recovery is needed.
+#[test]
+#[cfg(feature = "counter")]
+fn unmutated_mergeable_child_survives_snapshot_via_discriminator() {
+    let a = doc(1);
+    let _counter = a
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    // Deliberately no increment. Commit anyway so any pending state is flushed.
+    a.commit_then_renew();
+
+    let snapshot = a.export(ExportMode::Snapshot).unwrap();
+    let b = doc(2);
+    b.import(&snapshot).unwrap();
+
+    // The discriminator string rides through the snapshot as a normal map value, so B
+    // resolves the same deterministic cid and renders it as an empty counter.
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 0.0 } }),
+        "discriminator survives snapshot round-trip; child resolves to its empty default",
+    );
+
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    assert_eq!(b_counter.id(), _counter.id(), "cid still deterministic");
+    assert_eq!(b_counter.get_value().to_json_value(), json!(0.0));
+}
+
+/// Snapshot import where both peers registered the same `(key, kind)`:
+/// deterministic cids match, recovery walk converges, content from peer A
+/// wins through normal CRDT merge.
+#[test]
+fn snapshot_import_same_type_collision_converges() {
+    let a = doc(1);
+    let a_text = a.get_map("state").get_mergeable_text("notes").unwrap();
+    a_text.insert(0, "A", PosType::Unicode).unwrap();
+    a.commit_then_renew();
+    let snapshot = a.export(ExportMode::Snapshot).unwrap();
+
+    let b = doc(2);
+    let b_text = b.get_map("state").get_mergeable_text("notes").unwrap();
+    b_text.insert(0, "B", PosType::Unicode).unwrap();
+    b.commit_then_renew();
+    assert_eq!(a_text.id(), b_text.id(), "cids must match before import");
+
+    b.import(&snapshot).unwrap();
+
+    // Sync back so A sees both.
+    sync(&a, &b);
+    let value = a.get_deep_value().to_json_value();
+    assert!(
+        value == json!({ "state": { "notes": "AB" } })
+            || value == json!({ "state": { "notes": "BA" } }),
+        "both edits must survive on same-type collision; got {value}"
+    );
+    assert_eq!(b.get_deep_value().to_json_value(), value);
+}
+
+/// Snapshot import where the LOCAL peer registered a different kind for the same key than the
+/// SNAPSHOT peer. The two discriminators ("🤝:Text" vs "🤝:Map") compete in the parent map's slot
+/// for "k"; the parent map's regular LWW deterministically resolves to one, so exactly one kind
+/// is visible. Both containers' states are preserved; the loser is reachable by explicit lookup.
+#[test]
+fn snapshot_import_different_type_collision_resolves_by_lww() {
+    let a = doc(1);
+    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    a_text.insert(0, "hello", PosType::Unicode).unwrap();
+    a.commit_then_renew();
+    let snapshot = a.export(ExportMode::Snapshot).unwrap();
+
+    let b = doc(2);
+    let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
+    b_map.insert("flag", true).unwrap();
+    b.commit_then_renew();
+    assert_ne!(
+        a_text.id(),
+        b_map.id(),
+        "different kinds under the same key MUST produce different cids"
+    );
+
+    b.import(&snapshot).expect("import must not fail");
+
+    // Exactly one kind is visible in deep value (whichever discriminator won the Map LWW).
+    let value = b.get_deep_value().to_json_value();
+    let k = &value["state"]["k"];
+    let visible_kinds = [k.is_string(), k.is_object()];
+    assert_eq!(
+        visible_kinds.iter().filter(|x| **x).count(),
+        1,
+        "exactly one kind must be visible after LWW; got {k:?}"
+    );
+
+    // Both getters still succeed (each rewrites the discriminator to its kind). Neither errors —
+    // requesting a kind is a kind change, not a conflict.
+    let _ = b.get_map("state").get_mergeable_text("k").unwrap();
+    let _ = b.get_map("state").get_mergeable_map("k").unwrap();
+}
+
+/// After snapshot import resolves `"k"` to a Text discriminator on the receiver, a local
+/// `get_mergeable_map("k")` does NOT error — it rewrites the discriminator to Map (a deliberate
+/// kind change). The Text container stays reachable by name; requesting it again rewrites the
+/// discriminator back to Text and resurfaces its preserved contents.
+#[test]
+fn different_kind_request_after_snapshot_is_a_kind_change() {
+    let a = doc(1);
+    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    a_text.insert(0, "x", PosType::Unicode).unwrap();
+    a.commit_then_renew();
+    let snapshot = a.export(ExportMode::Snapshot).unwrap();
+
+    let b = doc(2);
+    b.import(&snapshot).unwrap();
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "k": "x" } }),
+        "imported Text discriminator resolves to its content"
+    );
+
+    // Requesting a Map rewrites the discriminator to Map; no error.
+    let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
+    b_map.insert("flag", true).unwrap();
+    b.commit_then_renew();
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "k": { "flag": true } } }),
+        "different-kind request is a kind change, not an error"
+    );
+
+    // The Text is still reachable; requesting it again resurfaces its preserved content.
+    let b_text = b.get_map("state").get_mergeable_text("k").unwrap();
+    assert_eq!(b_text.id(), a_text.id());
+    b.commit_then_renew();
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "k": "x" } }),
+        "re-requesting Text rewrites the discriminator back and resurfaces preserved content"
+    );
+}
+
+/// Shallow snapshot export should preserve mergeable child state and parent
+/// edges on the receiver, the same as a full snapshot.
+#[test]
+#[cfg(feature = "counter")]
+fn shallow_snapshot_roundtrip_preserves_mergeable_child() {
+    let a = doc(1);
+    let counter = a
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    counter.increment(4.0).unwrap();
+    a.commit_then_renew();
+
+    // ShallowSnapshot at current frontiers.
+    let frontiers = a.state_frontiers();
+    let snapshot = a
+        .export(ExportMode::ShallowSnapshot(std::borrow::Cow::Owned(
+            frontiers,
+        )))
+        .unwrap();
+
+    let b = doc(2);
+    b.import(&snapshot).unwrap();
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 4.0 } }),
+        "shallow snapshot must carry mergeable child state and side-table reconstruction"
+    );
+}

--- a/crates/loro-internal/tests/mergeable_container/snapshot.rs
+++ b/crates/loro-internal/tests/mergeable_container/snapshot.rs
@@ -24,25 +24,14 @@ fn snapshot_roundtrip_preserves_mergeable_parent_edges_and_values() {
     nested.insert("name", "Ada").unwrap();
     let counter = nested.get_mergeable_counter("revision").unwrap();
     counter.increment(3.0).unwrap();
+    let counter_id = counter.id();
 
     let snapshot = source.export(ExportMode::Snapshot).unwrap();
     let imported = doc(2);
     imported.import(&snapshot).unwrap();
 
-    assert_eq!(
-        imported.get_deep_value().to_json_value(),
-        source.get_deep_value().to_json_value(),
-        "deep value of the imported doc must match the source after snapshot round-trip"
-    );
-
-    let imported_counter = imported
-        .get_map("state")
-        .get_mergeable_map("profile")
-        .unwrap()
-        .get_mergeable_counter("revision")
-        .unwrap();
     let path = imported
-        .get_path_to_container(&imported_counter.id())
+        .get_path_to_container(&counter_id)
         .expect("mergeable counter must have a logical path after snapshot import");
     let indexes = path
         .iter()
@@ -57,6 +46,20 @@ fn snapshot_roundtrip_preserves_mergeable_parent_edges_and_values() {
         ],
         "imported counter should walk logical parent edges across two mergeable hops"
     );
+
+    assert_eq!(
+        imported.get_deep_value().to_json_value(),
+        source.get_deep_value().to_json_value(),
+        "deep value of the imported doc must match the source after snapshot round-trip"
+    );
+
+    let imported_counter = imported
+        .get_map("state")
+        .get_mergeable_map("profile")
+        .unwrap()
+        .get_mergeable_counter("revision")
+        .unwrap();
+    assert_eq!(imported_counter.id(), counter_id);
 }
 
 /// Peer B imports updates that originated from peer A's `get_mergeable_counter`
@@ -65,7 +68,7 @@ fn snapshot_roundtrip_preserves_mergeable_parent_edges_and_values() {
 /// resolution for the mergeable child must all reflect the imported state.
 #[test]
 #[cfg(feature = "counter")]
-fn update_import_populates_mergeable_side_table_on_receiver() {
+fn update_import_resolves_mergeable_logical_edge_on_receiver() {
     let a = doc(1);
     let b = doc(2);
 
@@ -74,11 +77,21 @@ fn update_import_populates_mergeable_side_table_on_receiver() {
         .get_mergeable_counter("revision")
         .unwrap();
     a_counter.increment(5.0).unwrap();
+    let a_counter_id = a_counter.id();
     a.commit_then_renew();
 
     // Peer B imports A's updates WITHOUT first calling get_mergeable_counter.
     let updates = a.export(ExportMode::updates(&b.oplog_vv())).unwrap();
     b.import(&updates).unwrap();
+
+    // Path resolution must work directly from the deterministic cid. Calling the getter first
+    // would rewrite the marker and could hide resolver bugs after import.
+    let path = b.get_path_to_container(&a_counter_id).expect("path");
+    let indexes = path.iter().map(|(_, idx)| idx.clone()).collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![Index::Key("state".into()), Index::Key("revision".into())]
+    );
 
     assert_eq!(
         b.get_deep_value().to_json_value(),
@@ -92,32 +105,25 @@ fn update_import_populates_mergeable_side_table_on_receiver() {
         .get_map("state")
         .get_mergeable_counter("revision")
         .unwrap();
-    assert_eq!(b_counter.id(), a_counter.id());
+    assert_eq!(b_counter.id(), a_counter_id);
     assert_eq!(b_counter.get_value().to_json_value(), json!(5.0));
-
-    // Path resolution from peer B's side must walk through the parent map.
-    let path = b.get_path_to_container(&b_counter.id()).expect("path");
-    let indexes = path.iter().map(|(_, idx)| idx.clone()).collect::<Vec<_>>();
-    assert_eq!(
-        indexes,
-        vec![Index::Key("state".into()), Index::Key("revision".into())]
-    );
 }
 
 /// Create a mergeable counter but never mutate it, then export a snapshot.
-/// `get_mergeable_*` writes a discriminator into the parent map's value table,
+/// `get_mergeable_*` writes a marker into the parent map's value table,
 /// which is ordinary map state and rides through the snapshot like any other
-/// value (loro-dev/loro#759). So the receiving peer resolves the discriminator
+/// value (loro-dev/loro#759). So the receiving peer resolves the marker
 /// to the same deterministic cid and sees the child as its empty default — no
 /// special recovery is needed.
 #[test]
 #[cfg(feature = "counter")]
-fn unmutated_mergeable_child_survives_snapshot_via_discriminator() {
+fn unmutated_mergeable_child_survives_snapshot_via_marker() {
     let a = doc(1);
-    let _counter = a
+    let counter = a
         .get_map("state")
         .get_mergeable_counter("revision")
         .unwrap();
+    let counter_id = counter.id();
     // Deliberately no increment. Commit anyway so any pending state is flushed.
     a.commit_then_renew();
 
@@ -125,19 +131,34 @@ fn unmutated_mergeable_child_survives_snapshot_via_discriminator() {
     let b = doc(2);
     b.import(&snapshot).unwrap();
 
-    // The discriminator string rides through the snapshot as a normal map value, so B
+    let has_container_before_path = b.has_container(&counter_id);
+    let path = b
+        .get_path_to_container(&counter_id)
+        .expect("unmutated mergeable child must resolve from marker");
+    let indexes = path.iter().map(|(_, idx)| idx.clone()).collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![Index::Key("state".into()), Index::Key("revision".into())]
+    );
+    assert_eq!(
+        b.has_container(&counter_id),
+        has_container_before_path,
+        "path lookup must not change has_container semantics for mergeable cids"
+    );
+
+    // The binary marker rides through the snapshot as a normal map value, so B
     // resolves the same deterministic cid and renders it as an empty counter.
     assert_eq!(
         b.get_deep_value().to_json_value(),
         json!({ "state": { "revision": 0.0 } }),
-        "discriminator survives snapshot round-trip; child resolves to its empty default",
+        "marker survives snapshot round-trip; child resolves to its empty default",
     );
 
     let b_counter = b
         .get_map("state")
         .get_mergeable_counter("revision")
         .unwrap();
-    assert_eq!(b_counter.id(), _counter.id(), "cid still deterministic");
+    assert_eq!(b_counter.id(), counter_id, "cid still deterministic");
     assert_eq!(b_counter.get_value().to_json_value(), json!(0.0));
 }
 
@@ -172,9 +193,9 @@ fn snapshot_import_same_type_collision_converges() {
 }
 
 /// Snapshot import where the LOCAL peer registered a different kind for the same key than the
-/// SNAPSHOT peer. The two discriminators ("🤝:Text" vs "🤝:Map") compete in the parent map's slot
-/// for "k"; the parent map's regular LWW deterministically resolves to one, so exactly one kind
-/// is visible. Both containers' states are preserved; the loser is reachable by explicit lookup.
+/// SNAPSHOT peer. The two binary markers compete in the parent map's slot for "k"; the parent
+/// map's regular LWW deterministically resolves to one, so exactly one kind is visible. Both
+/// containers' states are preserved; the loser is reachable by explicit lookup.
 #[test]
 fn snapshot_import_different_type_collision_resolves_by_lww() {
     let a = doc(1);
@@ -195,7 +216,7 @@ fn snapshot_import_different_type_collision_resolves_by_lww() {
 
     b.import(&snapshot).expect("import must not fail");
 
-    // Exactly one kind is visible in deep value (whichever discriminator won the Map LWW).
+    // Exactly one kind is visible in deep value (whichever marker won the Map LWW).
     let value = b.get_deep_value().to_json_value();
     let k = &value["state"]["k"];
     let visible_kinds = [k.is_string(), k.is_object()];
@@ -205,16 +226,16 @@ fn snapshot_import_different_type_collision_resolves_by_lww() {
         "exactly one kind must be visible after LWW; got {k:?}"
     );
 
-    // Both getters still succeed (each rewrites the discriminator to its kind). Neither errors —
+    // Both getters still succeed (each rewrites the marker to its kind). Neither errors —
     // requesting a kind is a kind change, not a conflict.
     let _ = b.get_map("state").get_mergeable_text("k").unwrap();
     let _ = b.get_map("state").get_mergeable_map("k").unwrap();
 }
 
-/// After snapshot import resolves `"k"` to a Text discriminator on the receiver, a local
-/// `get_mergeable_map("k")` does NOT error — it rewrites the discriminator to Map (a deliberate
+/// After snapshot import resolves `"k"` to a Text marker on the receiver, a local
+/// `get_mergeable_map("k")` does NOT error — it rewrites the marker to Map (a deliberate
 /// kind change). The Text container stays reachable by name; requesting it again rewrites the
-/// discriminator back to Text and resurfaces its preserved contents.
+/// marker back to Text and resurfaces its preserved contents.
 #[test]
 fn different_kind_request_after_snapshot_is_a_kind_change() {
     let a = doc(1);
@@ -228,10 +249,10 @@ fn different_kind_request_after_snapshot_is_a_kind_change() {
     assert_eq!(
         b.get_deep_value().to_json_value(),
         json!({ "state": { "k": "x" } }),
-        "imported Text discriminator resolves to its content"
+        "imported Text marker resolves to its content"
     );
 
-    // Requesting a Map rewrites the discriminator to Map; no error.
+    // Requesting a Map rewrites the marker to Map; no error.
     let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
     b_map.insert("flag", true).unwrap();
     b.commit_then_renew();
@@ -248,7 +269,7 @@ fn different_kind_request_after_snapshot_is_a_kind_change() {
     assert_eq!(
         b.get_deep_value().to_json_value(),
         json!({ "state": { "k": "x" } }),
-        "re-requesting Text rewrites the discriminator back and resurfaces preserved content"
+        "re-requesting Text rewrites the marker back and resurfaces preserved content"
     );
 }
 
@@ -278,6 +299,6 @@ fn shallow_snapshot_roundtrip_preserves_mergeable_child() {
     assert_eq!(
         b.get_deep_value().to_json_value(),
         json!({ "state": { "revision": 4.0 } }),
-        "shallow snapshot must carry mergeable child state and side-table reconstruction"
+        "shallow snapshot must carry mergeable child state and logical edge resolution"
     );
 }

--- a/crates/loro-internal/tests/mergeable_container/snapshot.rs
+++ b/crates/loro-internal/tests/mergeable_container/snapshot.rs
@@ -20,9 +20,9 @@ use serde_json::json;
 fn snapshot_roundtrip_preserves_mergeable_parent_edges_and_values() {
     let source = doc(1);
     let root = source.get_map("state");
-    let nested = root.get_mergeable_map("profile").unwrap();
+    let nested = root.ensure_mergeable_map("profile").unwrap();
     nested.insert("name", "Ada").unwrap();
-    let counter = nested.get_mergeable_counter("revision").unwrap();
+    let counter = nested.ensure_mergeable_counter("revision").unwrap();
     counter.increment(3.0).unwrap();
     let counter_id = counter.id();
 
@@ -55,15 +55,15 @@ fn snapshot_roundtrip_preserves_mergeable_parent_edges_and_values() {
 
     let imported_counter = imported
         .get_map("state")
-        .get_mergeable_map("profile")
+        .ensure_mergeable_map("profile")
         .unwrap()
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     assert_eq!(imported_counter.id(), counter_id);
 }
 
-/// Peer B imports updates that originated from peer A's `get_mergeable_counter`
-/// + `increment` calls, but peer B never locally called `get_mergeable_*`.
+/// Peer B imports updates that originated from peer A's `ensure_mergeable_counter`
+/// + `increment` calls, but peer B never locally called `ensure_mergeable_*`.
 /// After import, peer B's deep value, container enumeration, and path
 /// resolution for the mergeable child must all reflect the imported state.
 #[test]
@@ -74,13 +74,13 @@ fn update_import_resolves_mergeable_logical_edge_on_receiver() {
 
     let a_counter = a
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     a_counter.increment(5.0).unwrap();
     let a_counter_id = a_counter.id();
     a.commit_then_renew();
 
-    // Peer B imports A's updates WITHOUT first calling get_mergeable_counter.
+    // Peer B imports A's updates WITHOUT first calling ensure_mergeable_counter.
     let updates = a.export(ExportMode::updates(&b.oplog_vv())).unwrap();
     b.import(&updates).unwrap();
 
@@ -103,14 +103,14 @@ fn update_import_resolves_mergeable_logical_edge_on_receiver() {
     // the same cid as the one peer A wrote, and the existing value.
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     assert_eq!(b_counter.id(), a_counter_id);
     assert_eq!(b_counter.get_value().to_json_value(), json!(5.0));
 }
 
 /// Create a mergeable counter but never mutate it, then export a snapshot.
-/// `get_mergeable_*` writes a marker into the parent map's value table,
+/// `ensure_mergeable_*` writes a marker into the parent map's value table,
 /// which is ordinary map state and rides through the snapshot like any other
 /// value (loro-dev/loro#759). So the receiving peer resolves the marker
 /// to the same deterministic cid and sees the child as its empty default — no
@@ -121,7 +121,7 @@ fn unmutated_mergeable_child_survives_snapshot_via_marker() {
     let a = doc(1);
     let counter = a
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     let counter_id = counter.id();
     // Deliberately no increment. Commit anyway so any pending state is flushed.
@@ -156,7 +156,7 @@ fn unmutated_mergeable_child_survives_snapshot_via_marker() {
 
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     assert_eq!(b_counter.id(), counter_id, "cid still deterministic");
     assert_eq!(b_counter.get_value().to_json_value(), json!(0.0));
@@ -168,13 +168,13 @@ fn unmutated_mergeable_child_survives_snapshot_via_marker() {
 #[test]
 fn snapshot_import_same_type_collision_converges() {
     let a = doc(1);
-    let a_text = a.get_map("state").get_mergeable_text("notes").unwrap();
+    let a_text = a.get_map("state").ensure_mergeable_text("notes").unwrap();
     a_text.insert(0, "A", PosType::Unicode).unwrap();
     a.commit_then_renew();
     let snapshot = a.export(ExportMode::Snapshot).unwrap();
 
     let b = doc(2);
-    let b_text = b.get_map("state").get_mergeable_text("notes").unwrap();
+    let b_text = b.get_map("state").ensure_mergeable_text("notes").unwrap();
     b_text.insert(0, "B", PosType::Unicode).unwrap();
     b.commit_then_renew();
     assert_eq!(a_text.id(), b_text.id(), "cids must match before import");
@@ -199,13 +199,13 @@ fn snapshot_import_same_type_collision_converges() {
 #[test]
 fn snapshot_import_different_type_collision_resolves_by_lww() {
     let a = doc(1);
-    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    let a_text = a.get_map("state").ensure_mergeable_text("k").unwrap();
     a_text.insert(0, "hello", PosType::Unicode).unwrap();
     a.commit_then_renew();
     let snapshot = a.export(ExportMode::Snapshot).unwrap();
 
     let b = doc(2);
-    let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
+    let b_map = b.get_map("state").ensure_mergeable_map("k").unwrap();
     b_map.insert("flag", true).unwrap();
     b.commit_then_renew();
     assert_ne!(
@@ -228,18 +228,18 @@ fn snapshot_import_different_type_collision_resolves_by_lww() {
 
     // Both getters still succeed (each rewrites the marker to its kind). Neither errors —
     // requesting a kind is a kind change, not a conflict.
-    let _ = b.get_map("state").get_mergeable_text("k").unwrap();
-    let _ = b.get_map("state").get_mergeable_map("k").unwrap();
+    let _ = b.get_map("state").ensure_mergeable_text("k").unwrap();
+    let _ = b.get_map("state").ensure_mergeable_map("k").unwrap();
 }
 
 /// After snapshot import resolves `"k"` to a Text marker on the receiver, a local
-/// `get_mergeable_map("k")` does NOT error — it rewrites the marker to Map (a deliberate
+/// `ensure_mergeable_map("k")` does NOT error — it rewrites the marker to Map (a deliberate
 /// kind change). The Text container stays reachable by name; requesting it again rewrites the
 /// marker back to Text and resurfaces its preserved contents.
 #[test]
 fn different_kind_request_after_snapshot_is_a_kind_change() {
     let a = doc(1);
-    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    let a_text = a.get_map("state").ensure_mergeable_text("k").unwrap();
     a_text.insert(0, "x", PosType::Unicode).unwrap();
     a.commit_then_renew();
     let snapshot = a.export(ExportMode::Snapshot).unwrap();
@@ -253,7 +253,7 @@ fn different_kind_request_after_snapshot_is_a_kind_change() {
     );
 
     // Requesting a Map rewrites the marker to Map; no error.
-    let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
+    let b_map = b.get_map("state").ensure_mergeable_map("k").unwrap();
     b_map.insert("flag", true).unwrap();
     b.commit_then_renew();
     assert_eq!(
@@ -263,7 +263,7 @@ fn different_kind_request_after_snapshot_is_a_kind_change() {
     );
 
     // The Text is still reachable; requesting it again resurfaces its preserved content.
-    let b_text = b.get_map("state").get_mergeable_text("k").unwrap();
+    let b_text = b.get_map("state").ensure_mergeable_text("k").unwrap();
     assert_eq!(b_text.id(), a_text.id());
     b.commit_then_renew();
     assert_eq!(
@@ -281,7 +281,7 @@ fn shallow_snapshot_roundtrip_preserves_mergeable_child() {
     let a = doc(1);
     let counter = a
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     counter.increment(4.0).unwrap();
     a.commit_then_renew();

--- a/crates/loro-internal/tests/mergeable_container/type_conflict.rs
+++ b/crates/loro-internal/tests/mergeable_container/type_conflict.rs
@@ -3,7 +3,7 @@
 //! When two peers create different kinds under the same key, each writes a different binary marker
 //! into the parent map's slot. The parent map's regular LWW deterministically resolves to one
 //! marker, so every peer surfaces the same kind; the loser's container stays reachable only by an
-//! explicit `get_mergeable_<kind>` lookup (which rewrites the marker).
+//! explicit `ensure_mergeable_<kind>` lookup (which rewrites the marker).
 //! See loro-dev/loro#759.
 
 #[path = "common.rs"]
@@ -21,7 +21,7 @@ fn local_different_kind_request_rewrites_the_marker() {
     let doc = doc(1);
     let root = doc.get_map("state");
 
-    let text = root.get_mergeable_text("field").unwrap();
+    let text = root.ensure_mergeable_text("field").unwrap();
     text.insert(0, "hello", PosType::Unicode).unwrap();
     doc.commit_then_renew();
     assert_eq!(
@@ -30,7 +30,7 @@ fn local_different_kind_request_rewrites_the_marker() {
     );
 
     // Switch the kind: this rewrites the marker to Map.
-    let map = root.get_mergeable_map("field").unwrap();
+    let map = root.ensure_mergeable_map("field").unwrap();
     map.insert("k", 1).unwrap();
     doc.commit_then_renew();
     assert_eq!(
@@ -48,7 +48,7 @@ fn local_different_kind_request_rewrites_the_marker() {
 fn different_kind_collision_resolves_by_map_lww_at_import() {
     // Peer A: text under "k", low lamport.
     let a = doc(1);
-    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    let a_text = a.get_map("state").ensure_mergeable_text("k").unwrap();
     a_text.insert(0, "from_a", PosType::Unicode).unwrap();
     let a_text_id = a_text.id();
     a.commit_then_renew();
@@ -60,7 +60,7 @@ fn different_kind_collision_resolves_by_map_lww_at_import() {
         b_state.insert(&format!("filler_{i}"), i).unwrap();
         b.commit_then_renew();
     }
-    let b_map = b_state.get_mergeable_map("k").unwrap();
+    let b_map = b_state.ensure_mergeable_map("k").unwrap();
     b_map.insert("from_b", true).unwrap();
     let b_map_id = b_map.id();
     b.commit_then_renew();
@@ -96,9 +96,9 @@ fn different_kind_collision_resolves_by_map_lww_at_import() {
     );
     assert_eq!(k_value["from_b"], json!(true));
 
-    // The loser's Text container is still reachable by an explicit get_mergeable_text — which
+    // The loser's Text container is still reachable by an explicit ensure_mergeable_text — which
     // rewrites the marker back to Text (a local kind change), so it now resurfaces.
-    let b_text = b.get_map("state").get_mergeable_text("k").unwrap();
+    let b_text = b.get_map("state").ensure_mergeable_text("k").unwrap();
     assert_eq!(b_text.id(), a_text_id);
     assert_eq!(
         b_text.get_value().to_json_value(),
@@ -117,15 +117,15 @@ fn three_peer_different_kind_conflict_converges() {
     let b = doc(2);
     let c = doc(3);
 
-    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    let a_text = a.get_map("state").ensure_mergeable_text("k").unwrap();
     a_text.insert(0, "from_a", PosType::Unicode).unwrap();
     a.commit_then_renew();
 
-    let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
+    let b_map = b.get_map("state").ensure_mergeable_map("k").unwrap();
     b_map.insert("from_b", true).unwrap();
     b.commit_then_renew();
 
-    let c_list = c.get_map("state").get_mergeable_list("k").unwrap();
+    let c_list = c.get_map("state").ensure_mergeable_list("k").unwrap();
     c_list.insert(0, "from_c").unwrap();
     c.commit_then_renew();
 
@@ -157,11 +157,11 @@ fn concurrent_same_kind_creation_converges() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_list = a.get_map("state").get_mergeable_list("k").unwrap();
+    let a_list = a.get_map("state").ensure_mergeable_list("k").unwrap();
     a_list.insert(0, "from_a").unwrap();
     a.commit_then_renew();
 
-    let b_list = b.get_map("state").get_mergeable_list("k").unwrap();
+    let b_list = b.get_map("state").ensure_mergeable_list("k").unwrap();
     b_list.insert(0, "from_b").unwrap();
     b.commit_then_renew();
 

--- a/crates/loro-internal/tests/mergeable_container/type_conflict.rs
+++ b/crates/loro-internal/tests/mergeable_container/type_conflict.rs
@@ -1,0 +1,161 @@
+//! Concurrent different-kind creation, resolved by the parent map's discriminator LWW.
+//!
+//! When two peers create different kinds under the same key, each writes a different `"🤝:<kind>"`
+//! discriminator string into the parent map's slot. The parent map's regular LWW deterministically
+//! resolves to one discriminator, so every peer surfaces the same kind; the loser's container stays
+//! reachable only by an explicit `get_mergeable_<kind>` lookup (which rewrites the discriminator).
+//! See loro-dev/loro#759.
+
+#[path = "common.rs"]
+mod common;
+use common::{doc, sync};
+
+use loro_internal::{cursor::PosType, loro::ExportMode, HandlerTrait, ToJson};
+use serde_json::json;
+
+/// Requesting a different kind under a key that already holds another kind's discriminator is a
+/// deliberate, local kind change: it rewrites the discriminator. The new kind becomes active and
+/// the new handler is usable. (This is the building block of the List -> Map -> List cycle.)
+#[test]
+fn local_different_kind_request_rewrites_the_discriminator() {
+    let doc = doc(1);
+    let root = doc.get_map("state");
+
+    let text = root.get_mergeable_text("field").unwrap();
+    text.insert(0, "hello", PosType::Unicode).unwrap();
+    doc.commit_then_renew();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "field": "hello" } })
+    );
+
+    // Switch the kind: this rewrites the discriminator to Map.
+    let map = root.get_mergeable_map("field").unwrap();
+    map.insert("k", 1).unwrap();
+    doc.commit_then_renew();
+    assert_eq!(
+        doc.get_deep_value().to_json_value(),
+        json!({ "state": { "field": { "k": 1 } } }),
+        "requesting a different kind rewrites the discriminator to that kind"
+    );
+}
+
+/// When two competing-kind discriminators land in the same parent's slot under the same key during
+/// import, the parent map's regular LWW deterministically picks one. The visible kind is the same
+/// on every peer; the loser's container is still reachable by name but not surfaced by default.
+#[test]
+#[cfg(feature = "counter")]
+fn different_kind_collision_resolves_by_map_lww_at_import() {
+    // Peer A: text under "k", low lamport.
+    let a = doc(1);
+    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    a_text.insert(0, "from_a", PosType::Unicode).unwrap();
+    a.commit_then_renew();
+
+    // Peer B: map under "k", with a later lamport (advance B's clock first).
+    let b = doc(2);
+    let b_state = b.get_map("state");
+    for i in 0..5 {
+        b_state.insert(&format!("filler_{i}"), i).unwrap();
+        b.commit_then_renew();
+    }
+    let b_map = b_state.get_mergeable_map("k").unwrap();
+    b_map.insert("from_b", true).unwrap();
+    b.commit_then_renew();
+
+    // B imports A's snapshot. The two discriminators ("🤝:Text" vs "🤝:Map") compete in B's map
+    // slot for "k"; B's Map discriminator has the higher lamport, so Map wins.
+    let snapshot = a.export(ExportMode::Snapshot).unwrap();
+    b.import(&snapshot).unwrap();
+
+    let value = b.get_deep_value().to_json_value();
+    let k_value = &value["state"]["k"];
+    assert!(
+        k_value.is_object(),
+        "Map discriminator won the LWW; got {k_value:?}"
+    );
+    assert_eq!(k_value["from_b"], json!(true));
+
+    // The loser's Text container is still reachable by an explicit get_mergeable_text — which
+    // rewrites the discriminator back to Text (a local kind change), so it now resurfaces.
+    let b_text = b.get_map("state").get_mergeable_text("k").unwrap();
+    assert_eq!(
+        b_text.get_value().to_json_value(),
+        json!("from_a"),
+        "loser's container is preserved and reachable by name"
+    );
+}
+
+/// Three peers each create a different kind under the same key and mutate it once. After a full
+/// round-robin sync, every peer's parent-map LWW resolves to the same discriminator, so all agree
+/// on exactly one visible kind.
+#[test]
+#[cfg(feature = "counter")]
+fn three_peer_different_kind_conflict_converges() {
+    let a = doc(1);
+    let b = doc(2);
+    let c = doc(3);
+
+    let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
+    a_text.insert(0, "from_a", PosType::Unicode).unwrap();
+    a.commit_then_renew();
+
+    let b_map = b.get_map("state").get_mergeable_map("k").unwrap();
+    b_map.insert("from_b", true).unwrap();
+    b.commit_then_renew();
+
+    let c_list = c.get_map("state").get_mergeable_list("k").unwrap();
+    c_list.insert(0, "from_c").unwrap();
+    c.commit_then_renew();
+
+    sync(&a, &b);
+    sync(&b, &c);
+    sync(&a, &c);
+    sync(&a, &b);
+
+    let va = a.get_deep_value().to_json_value();
+    let vb = b.get_deep_value().to_json_value();
+    let vc = c.get_deep_value().to_json_value();
+    assert_eq!(va, vb, "A and B must agree");
+    assert_eq!(vb, vc, "B and C must agree");
+
+    // Exactly one kind is visible under "k": Text -> string, Map -> object, List -> array.
+    let k = &va["state"]["k"];
+    let survivors = [k.is_string(), k.is_object(), k.is_array()];
+    let count: usize = survivors.iter().filter(|x| **x).count();
+    assert_eq!(
+        count, 1,
+        "exactly one kind must be visible; got {survivors:?} for value {k:?}"
+    );
+}
+
+/// Concurrent SAME-kind creation: both peers write the identical discriminator, so the Map LWW
+/// merge is a no-op and both contributions land in the one deterministic cid.
+#[test]
+fn concurrent_same_kind_creation_converges() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_list = a.get_map("state").get_mergeable_list("k").unwrap();
+    a_list.insert(0, "from_a").unwrap();
+    a.commit_then_renew();
+
+    let b_list = b.get_map("state").get_mergeable_list("k").unwrap();
+    b_list.insert(0, "from_b").unwrap();
+    b.commit_then_renew();
+
+    sync(&a, &b);
+
+    let va = a.get_deep_value().to_json_value();
+    assert_eq!(va, b.get_deep_value().to_json_value(), "peers converge");
+    let items: Vec<&str> = va["state"]["k"]
+        .as_array()
+        .expect("k is a list")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        items.contains(&"from_a") && items.contains(&"from_b"),
+        "both contributions preserved; got {items:?}"
+    );
+}

--- a/crates/loro-internal/tests/mergeable_container/type_conflict.rs
+++ b/crates/loro-internal/tests/mergeable_container/type_conflict.rs
@@ -1,23 +1,23 @@
-//! Concurrent different-kind creation, resolved by the parent map's discriminator LWW.
+//! Concurrent different-kind creation, resolved by the parent map's marker LWW.
 //!
-//! When two peers create different kinds under the same key, each writes a different `"🤝:<kind>"`
-//! discriminator string into the parent map's slot. The parent map's regular LWW deterministically
-//! resolves to one discriminator, so every peer surfaces the same kind; the loser's container stays
-//! reachable only by an explicit `get_mergeable_<kind>` lookup (which rewrites the discriminator).
+//! When two peers create different kinds under the same key, each writes a different binary marker
+//! into the parent map's slot. The parent map's regular LWW deterministically resolves to one
+//! marker, so every peer surfaces the same kind; the loser's container stays reachable only by an
+//! explicit `get_mergeable_<kind>` lookup (which rewrites the marker).
 //! See loro-dev/loro#759.
 
 #[path = "common.rs"]
 mod common;
 use common::{doc, sync};
 
-use loro_internal::{cursor::PosType, loro::ExportMode, HandlerTrait, ToJson};
+use loro_internal::{cursor::PosType, event::Index, loro::ExportMode, HandlerTrait, ToJson};
 use serde_json::json;
 
-/// Requesting a different kind under a key that already holds another kind's discriminator is a
-/// deliberate, local kind change: it rewrites the discriminator. The new kind becomes active and
+/// Requesting a different kind under a key that already holds another kind's marker is a
+/// deliberate, local kind change: it rewrites the marker. The new kind becomes active and
 /// the new handler is usable. (This is the building block of the List -> Map -> List cycle.)
 #[test]
-fn local_different_kind_request_rewrites_the_discriminator() {
+fn local_different_kind_request_rewrites_the_marker() {
     let doc = doc(1);
     let root = doc.get_map("state");
 
@@ -29,18 +29,18 @@ fn local_different_kind_request_rewrites_the_discriminator() {
         json!({ "state": { "field": "hello" } })
     );
 
-    // Switch the kind: this rewrites the discriminator to Map.
+    // Switch the kind: this rewrites the marker to Map.
     let map = root.get_mergeable_map("field").unwrap();
     map.insert("k", 1).unwrap();
     doc.commit_then_renew();
     assert_eq!(
         doc.get_deep_value().to_json_value(),
         json!({ "state": { "field": { "k": 1 } } }),
-        "requesting a different kind rewrites the discriminator to that kind"
+        "requesting a different kind rewrites the marker to that kind"
     );
 }
 
-/// When two competing-kind discriminators land in the same parent's slot under the same key during
+/// When two competing-kind markers land in the same parent's slot under the same key during
 /// import, the parent map's regular LWW deterministically picks one. The visible kind is the same
 /// on every peer; the loser's container is still reachable by name but not surfaced by default.
 #[test]
@@ -50,6 +50,7 @@ fn different_kind_collision_resolves_by_map_lww_at_import() {
     let a = doc(1);
     let a_text = a.get_map("state").get_mergeable_text("k").unwrap();
     a_text.insert(0, "from_a", PosType::Unicode).unwrap();
+    let a_text_id = a_text.id();
     a.commit_then_renew();
 
     // Peer B: map under "k", with a later lamport (advance B's clock first).
@@ -61,24 +62,44 @@ fn different_kind_collision_resolves_by_map_lww_at_import() {
     }
     let b_map = b_state.get_mergeable_map("k").unwrap();
     b_map.insert("from_b", true).unwrap();
+    let b_map_id = b_map.id();
     b.commit_then_renew();
 
-    // B imports A's snapshot. The two discriminators ("🤝:Text" vs "🤝:Map") compete in B's map
-    // slot for "k"; B's Map discriminator has the higher lamport, so Map wins.
+    // B imports A's snapshot. The Text and Map markers compete in B's map slot for "k"; B's Map
+    // marker has the higher lamport, so Map wins.
     let snapshot = a.export(ExportMode::Snapshot).unwrap();
     b.import(&snapshot).unwrap();
+
+    // Check the direct cids before calling any getter. The losing Text cid must not have a logical
+    // path while the Map marker wins; the winning Map cid resolves from the marker.
+    assert!(
+        b.get_path_to_container(&a_text_id).is_none(),
+        "old Text cid must be inactive while the Map marker wins"
+    );
+    let map_path = b
+        .get_path_to_container(&b_map_id)
+        .expect("winning Map cid must resolve from the parent marker");
+    let indexes = map_path
+        .iter()
+        .map(|(_, index)| index.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![Index::Key("state".into()), Index::Key("k".into())]
+    );
 
     let value = b.get_deep_value().to_json_value();
     let k_value = &value["state"]["k"];
     assert!(
         k_value.is_object(),
-        "Map discriminator won the LWW; got {k_value:?}"
+        "Map marker won the LWW; got {k_value:?}"
     );
     assert_eq!(k_value["from_b"], json!(true));
 
     // The loser's Text container is still reachable by an explicit get_mergeable_text — which
-    // rewrites the discriminator back to Text (a local kind change), so it now resurfaces.
+    // rewrites the marker back to Text (a local kind change), so it now resurfaces.
     let b_text = b.get_map("state").get_mergeable_text("k").unwrap();
+    assert_eq!(b_text.id(), a_text_id);
     assert_eq!(
         b_text.get_value().to_json_value(),
         json!("from_a"),
@@ -87,7 +108,7 @@ fn different_kind_collision_resolves_by_map_lww_at_import() {
 }
 
 /// Three peers each create a different kind under the same key and mutate it once. After a full
-/// round-robin sync, every peer's parent-map LWW resolves to the same discriminator, so all agree
+/// round-robin sync, every peer's parent-map LWW resolves to the same marker, so all agree
 /// on exactly one visible kind.
 #[test]
 #[cfg(feature = "counter")]
@@ -129,7 +150,7 @@ fn three_peer_different_kind_conflict_converges() {
     );
 }
 
-/// Concurrent SAME-kind creation: both peers write the identical discriminator, so the Map LWW
+/// Concurrent SAME-kind creation: both peers write the identical marker, so the Map LWW
 /// merge is a no-op and both contributions land in the one deterministic cid.
 #[test]
 fn concurrent_same_kind_creation_converges() {

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3056,27 +3056,18 @@ impl Default for LoroText {
 ///
 /// ## Mergeable child containers
 ///
-/// `getMergeable*` methods create deterministic child containers under a map
+/// `ensureMergeable*` methods create deterministic child containers under a map
 /// key. If two peers independently call the same method with the same parent
 /// map, key, and container type, they get the same child container id and their
 /// subsequent edits merge in that child.
 ///
-/// Loro stores the activation value in the parent map slot as a compact binary
-/// mergeable-child ref, not as a reserved string. This avoids reserving
-/// user-visible strings such as `"🤝:Map"`: applications often let users edit
-/// titles, custom properties, metadata, or imported JSON fields directly, and a
-/// user-created string should not accidentally become an internal container
-/// edge. The binary ref includes a small digest of `(parent_id, key, kind)`, so
-/// copied or malformed binary values do not activate a mergeable child in the
-/// wrong map slot.
-///
-/// The ref is not an anti-forgery mechanism. It is a compact marker that makes
-/// accidental or UI-level construction of an internal mergeable edge negligible
-/// while keeping the map slot small. Existing non-mergeable values at the key
-/// are rejected and left untouched by `getMergeable*`.
+/// Loro activates a mergeable child by writing a specially constructed binary
+/// marker value into the parent map slot. String values do not activate
+/// mergeable children. If the key already holds a non-mergeable value,
+/// `ensureMergeable*` returns an error and leaves the value unchanged.
 ///
 /// Deleting the map key clears the ref and hides the mergeable child, but the
-/// child's state is preserved. Calling the same `getMergeable*` method again
+/// child's state is preserved. Calling the same `ensureMergeable*` method again
 /// writes the ref back and resurfaces the preserved state.
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -3299,70 +3290,72 @@ impl LoroMap {
         Ok(handler_to_js_value(c, false).into())
     }
 
-    /// Get or create a mergeable Counter under the given key.
+    /// Ensure a mergeable Counter exists under the given key and return it.
     ///
-    /// See the `LoroMap` class documentation, section "Mergeable child containers",
-    /// for the storage format and conflict semantics.
-    ///
-    /// Throws if the key already holds a non-mergeable value (a plain scalar or a regular child
-    /// container); the existing value is left untouched.
+    /// If the key already holds a non-mergeable value, this throws and leaves
+    /// the value unchanged.
     ///
     /// @example
     /// ```ts
     /// import { LoroDoc } from "loro-crdt";
     ///
     /// const doc = new LoroDoc();
-    /// const counter = doc.getMap("state").getMergeableCounter("revision");
+    /// const counter = doc.getMap("state").ensureMergeableCounter("revision");
     /// counter.increment(1);
     /// ```
-    #[wasm_bindgen(js_name = "getMergeableCounter")]
-    pub fn get_mergeable_counter(&self, key: &str) -> JsResult<LoroCounter> {
-        let handler = self.handler.get_mergeable_counter(key)?;
+    #[wasm_bindgen(js_name = "ensureMergeableCounter")]
+    pub fn ensure_mergeable_counter(&self, key: &str) -> JsResult<LoroCounter> {
+        let handler = self.handler.ensure_mergeable_counter(key)?;
         Ok(LoroCounter { handler })
     }
 
-    /// Get or create a mergeable Map under the given key.
-    /// See the `LoroMap` class documentation, section "Mergeable child containers",
-    /// for the storage format and conflict semantics.
-    #[wasm_bindgen(js_name = "getMergeableMap")]
-    pub fn get_mergeable_map(&self, key: &str) -> JsResult<LoroMap> {
-        let handler = self.handler.get_mergeable_map(key)?;
+    /// Ensure a mergeable Map exists under the given key and return it.
+    ///
+    /// If the key already holds a non-mergeable value, this throws and leaves
+    /// the value unchanged.
+    #[wasm_bindgen(js_name = "ensureMergeableMap")]
+    pub fn ensure_mergeable_map(&self, key: &str) -> JsResult<LoroMap> {
+        let handler = self.handler.ensure_mergeable_map(key)?;
         Ok(LoroMap { handler })
     }
 
-    /// Get or create a mergeable List under the given key.
-    /// See the `LoroMap` class documentation, section "Mergeable child containers",
-    /// for the storage format and conflict semantics.
-    #[wasm_bindgen(js_name = "getMergeableList")]
-    pub fn get_mergeable_list(&self, key: &str) -> JsResult<LoroList> {
-        let handler = self.handler.get_mergeable_list(key)?;
+    /// Ensure a mergeable List exists under the given key and return it.
+    ///
+    /// If the key already holds a non-mergeable value, this throws and leaves
+    /// the value unchanged.
+    #[wasm_bindgen(js_name = "ensureMergeableList")]
+    pub fn ensure_mergeable_list(&self, key: &str) -> JsResult<LoroList> {
+        let handler = self.handler.ensure_mergeable_list(key)?;
         Ok(LoroList { handler })
     }
 
-    /// Get or create a mergeable MovableList under the given key.
-    /// See the `LoroMap` class documentation, section "Mergeable child containers",
-    /// for the storage format and conflict semantics.
-    #[wasm_bindgen(js_name = "getMergeableMovableList")]
-    pub fn get_mergeable_movable_list(&self, key: &str) -> JsResult<LoroMovableList> {
-        let handler = self.handler.get_mergeable_movable_list(key)?;
+    /// Ensure a mergeable MovableList exists under the given key and return it.
+    ///
+    /// If the key already holds a non-mergeable value, this throws and leaves
+    /// the value unchanged.
+    #[wasm_bindgen(js_name = "ensureMergeableMovableList")]
+    pub fn ensure_mergeable_movable_list(&self, key: &str) -> JsResult<LoroMovableList> {
+        let handler = self.handler.ensure_mergeable_movable_list(key)?;
         Ok(LoroMovableList { handler })
     }
 
-    /// Get or create a mergeable Text under the given key.
-    /// See the `LoroMap` class documentation, section "Mergeable child containers",
-    /// for the storage format and conflict semantics.
-    #[wasm_bindgen(js_name = "getMergeableText")]
-    pub fn get_mergeable_text(&self, key: &str) -> JsResult<LoroText> {
-        let handler = self.handler.get_mergeable_text(key)?;
+    /// Ensure a mergeable Text exists under the given key and return it.
+    ///
+    /// If the key already holds a non-mergeable value, this throws and leaves
+    /// the value unchanged.
+    #[wasm_bindgen(js_name = "ensureMergeableText")]
+    pub fn ensure_mergeable_text(&self, key: &str) -> JsResult<LoroText> {
+        let handler = self.handler.ensure_mergeable_text(key)?;
         Ok(LoroText { handler })
     }
 
-    /// Get or create a mergeable Tree under the given key.
-    /// See the `LoroMap` class documentation, section "Mergeable child containers",
-    /// for the storage format and conflict semantics.
-    #[wasm_bindgen(js_name = "getMergeableTree")]
-    pub fn get_mergeable_tree(&self, key: &str) -> JsResult<LoroTree> {
-        let handler = self.handler.get_mergeable_tree(key)?;
+    /// Ensure a mergeable Tree exists under the given key and return it.
+    ///
+    /// If the key already holds a non-mergeable value, this throws and leaves
+    /// the value unchanged.
+    #[wasm_bindgen(js_name = "ensureMergeableTree")]
+    pub fn ensure_mergeable_tree(&self, key: &str) -> JsResult<LoroTree> {
+        let handler = self.handler.ensure_mergeable_tree(key)?;
         Ok(LoroTree { handler })
     }
 
@@ -6967,24 +6960,18 @@ interface LoroMovableList<T = unknown> {
  *
  * ## Mergeable child containers
  *
- * `getMergeable*` methods create deterministic child containers under a map key.
+ * `ensureMergeable*` methods create deterministic child containers under a map key.
  * If two peers independently call the same method with the same parent map, key,
  * and container type, they get the same child container id and their subsequent
  * edits merge in that child.
  *
- * Loro stores the activation value in the parent map slot as a compact binary
- * mergeable-child ref, not as a reserved string. This avoids reserving
- * user-visible strings such as `"🤝:Map"`: users may edit titles, custom
- * properties, metadata, or imported JSON fields directly, and a user-created
- * string should not accidentally become an internal container edge.
- *
- * The binary ref includes a small digest of `(parent_id, key, kind)`. It is not
- * an anti-forgery mechanism; it makes accidental or UI-level construction of an
- * internal mergeable edge negligible and makes copied or malformed binary values
- * fail closed unless they are in the exact map slot they were created for.
+ * Loro activates a mergeable child by writing a specially constructed binary
+ * marker value into the parent map slot. String values do not activate
+ * mergeable children. If the key already holds a non-mergeable value,
+ * `ensureMergeable*` returns an error and leaves the value unchanged.
  *
  * Deleting the map key clears the ref and hides the mergeable child, but the
- * child's state is preserved. Calling the same `getMergeable*` method again
+ * child's state is preserved. Calling the same `ensureMergeable*` method again
  * writes the ref back and resurfaces the preserved state.
  */
 interface LoroMap<T extends Record<string, unknown> = Record<string, unknown>> {
@@ -7022,59 +7009,47 @@ interface LoroMap<T extends Record<string, unknown> = Record<string, unknown>> {
      */
     setContainer<C extends Container, Key extends keyof T>(key: Key, child: C): NonNullableType<T[Key]> extends C ? NonNullableType<T[Key]> : C;
     /**
-     * Get or create a mergeable Counter under the given key.
+     * Ensure a mergeable Counter exists under the given key and return it.
      *
-     * See the `LoroMap` documentation, section "Mergeable child containers",
-     * for the storage format and conflict semantics.
-     *
-     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     * If the key already holds a non-mergeable value, this throws and leaves
+     * the value unchanged.
      */
-    getMergeableCounter(key: string): LoroCounter;
+    ensureMergeableCounter(key: string): LoroCounter;
     /**
-     * Get or create a mergeable Map under the given key.
+     * Ensure a mergeable Map exists under the given key and return it.
      *
-     * See the `LoroMap` documentation, section "Mergeable child containers",
-     * for the storage format and conflict semantics.
-     *
-     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     * If the key already holds a non-mergeable value, this throws and leaves
+     * the value unchanged.
      */
-    getMergeableMap(key: string): LoroMap;
+    ensureMergeableMap(key: string): LoroMap;
     /**
-     * Get or create a mergeable List under the given key.
+     * Ensure a mergeable List exists under the given key and return it.
      *
-     * See the `LoroMap` documentation, section "Mergeable child containers",
-     * for the storage format and conflict semantics.
-     *
-     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     * If the key already holds a non-mergeable value, this throws and leaves
+     * the value unchanged.
      */
-    getMergeableList(key: string): LoroList;
+    ensureMergeableList(key: string): LoroList;
     /**
-     * Get or create a mergeable MovableList under the given key.
+     * Ensure a mergeable MovableList exists under the given key and return it.
      *
-     * See the `LoroMap` documentation, section "Mergeable child containers",
-     * for the storage format and conflict semantics.
-     *
-     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     * If the key already holds a non-mergeable value, this throws and leaves
+     * the value unchanged.
      */
-    getMergeableMovableList(key: string): LoroMovableList;
+    ensureMergeableMovableList(key: string): LoroMovableList;
     /**
-     * Get or create a mergeable Text under the given key.
+     * Ensure a mergeable Text exists under the given key and return it.
      *
-     * See the `LoroMap` documentation, section "Mergeable child containers",
-     * for the storage format and conflict semantics.
-     *
-     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     * If the key already holds a non-mergeable value, this throws and leaves
+     * the value unchanged.
      */
-    getMergeableText(key: string): LoroText;
+    ensureMergeableText(key: string): LoroText;
     /**
-     * Get or create a mergeable Tree under the given key.
+     * Ensure a mergeable Tree exists under the given key and return it.
      *
-     * See the `LoroMap` documentation, section "Mergeable child containers",
-     * for the storage format and conflict semantics.
-     *
-     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     * If the key already holds a non-mergeable value, this throws and leaves
+     * the value unchanged.
      */
-    getMergeableTree(key: string): LoroTree;
+    ensureMergeableTree(key: string): LoroTree;
     /**
      *  Get the value of the key. If the value is a child container, the corresponding
      *  `Container` will be returned.

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3274,6 +3274,68 @@ impl LoroMap {
         Ok(handler_to_js_value(c, false).into())
     }
 
+    /// Get or create a mergeable Counter under the given key.
+    ///
+    /// Mergeable child containers converge on concurrent first-write across peers: independently
+    /// created children under the same key resolve to one container that merges. Visibility is
+    /// driven by the `"🤝:<kind>"` discriminator the parent map stores at the key, so `delete`
+    /// clears that slot like any regular map key; re-calling `getMergeable*` rewrites the
+    /// discriminator and resurfaces the preserved child state.
+    ///
+    /// @example
+    /// ```ts
+    /// import { LoroDoc } from "loro-crdt";
+    ///
+    /// const doc = new LoroDoc();
+    /// const counter = doc.getMap("state").getMergeableCounter("revision");
+    /// counter.increment(1);
+    /// ```
+    #[wasm_bindgen(js_name = "getMergeableCounter")]
+    pub fn get_mergeable_counter(&self, key: &str) -> JsResult<LoroCounter> {
+        let handler = self.handler.get_mergeable_counter(key)?;
+        Ok(LoroCounter { handler })
+    }
+
+    /// Get or create a mergeable Map under the given key.
+    /// See `getMergeableCounter` for semantics.
+    #[wasm_bindgen(js_name = "getMergeableMap")]
+    pub fn get_mergeable_map(&self, key: &str) -> JsResult<LoroMap> {
+        let handler = self.handler.get_mergeable_map(key)?;
+        Ok(LoroMap { handler })
+    }
+
+    /// Get or create a mergeable List under the given key.
+    /// See `getMergeableCounter` for semantics.
+    #[wasm_bindgen(js_name = "getMergeableList")]
+    pub fn get_mergeable_list(&self, key: &str) -> JsResult<LoroList> {
+        let handler = self.handler.get_mergeable_list(key)?;
+        Ok(LoroList { handler })
+    }
+
+    /// Get or create a mergeable MovableList under the given key.
+    /// See `getMergeableCounter` for semantics.
+    #[wasm_bindgen(js_name = "getMergeableMovableList")]
+    pub fn get_mergeable_movable_list(&self, key: &str) -> JsResult<LoroMovableList> {
+        let handler = self.handler.get_mergeable_movable_list(key)?;
+        Ok(LoroMovableList { handler })
+    }
+
+    /// Get or create a mergeable Text under the given key.
+    /// See `getMergeableCounter` for semantics.
+    #[wasm_bindgen(js_name = "getMergeableText")]
+    pub fn get_mergeable_text(&self, key: &str) -> JsResult<LoroText> {
+        let handler = self.handler.get_mergeable_text(key)?;
+        Ok(LoroText { handler })
+    }
+
+    /// Get or create a mergeable Tree under the given key.
+    /// See `getMergeableCounter` for semantics.
+    #[wasm_bindgen(js_name = "getMergeableTree")]
+    pub fn get_mergeable_tree(&self, key: &str) -> JsResult<LoroTree> {
+        let handler = self.handler.get_mergeable_tree(key)?;
+        Ok(LoroTree { handler })
+    }
+
     /// Subscribe to the changes of the map.
     ///
     /// Returns a subscription callback, which can be used to unsubscribe.

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3282,6 +3282,9 @@ impl LoroMap {
     /// clears that slot like any regular map key; re-calling `getMergeable*` rewrites the
     /// discriminator and resurfaces the preserved child state.
     ///
+    /// Throws if the key already holds a non-mergeable value (a plain scalar or a regular child
+    /// container); the existing value is left untouched.
+    ///
     /// @example
     /// ```ts
     /// import { LoroDoc } from "loro-crdt";

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3053,6 +3053,31 @@ impl Default for LoroText {
 /// The handler of a map container.
 ///
 /// Learn more at https://loro.dev/docs/tutorial/map
+///
+/// ## Mergeable child containers
+///
+/// `getMergeable*` methods create deterministic child containers under a map
+/// key. If two peers independently call the same method with the same parent
+/// map, key, and container type, they get the same child container id and their
+/// subsequent edits merge in that child.
+///
+/// Loro stores the activation value in the parent map slot as a compact binary
+/// mergeable-child ref, not as a reserved string. This avoids reserving
+/// user-visible strings such as `"🤝:Map"`: applications often let users edit
+/// titles, custom properties, metadata, or imported JSON fields directly, and a
+/// user-created string should not accidentally become an internal container
+/// edge. The binary ref includes a small digest of `(parent_id, key, kind)`, so
+/// copied or malformed binary values do not activate a mergeable child in the
+/// wrong map slot.
+///
+/// The ref is not an anti-forgery mechanism. It is a compact marker that makes
+/// accidental or UI-level construction of an internal mergeable edge negligible
+/// while keeping the map slot small. Existing non-mergeable values at the key
+/// are rejected and left untouched by `getMergeable*`.
+///
+/// Deleting the map key clears the ref and hides the mergeable child, but the
+/// child's state is preserved. Calling the same `getMergeable*` method again
+/// writes the ref back and resurfaces the preserved state.
 #[derive(Clone)]
 #[wasm_bindgen]
 pub struct LoroMap {
@@ -3276,11 +3301,8 @@ impl LoroMap {
 
     /// Get or create a mergeable Counter under the given key.
     ///
-    /// Mergeable child containers converge on concurrent first-write across peers: independently
-    /// created children under the same key resolve to one container that merges. Visibility is
-    /// driven by the `"🤝:<kind>"` discriminator the parent map stores at the key, so `delete`
-    /// clears that slot like any regular map key; re-calling `getMergeable*` rewrites the
-    /// discriminator and resurfaces the preserved child state.
+    /// See the `LoroMap` class documentation, section "Mergeable child containers",
+    /// for the storage format and conflict semantics.
     ///
     /// Throws if the key already holds a non-mergeable value (a plain scalar or a regular child
     /// container); the existing value is left untouched.
@@ -3300,7 +3322,8 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Map under the given key.
-    /// See `getMergeableCounter` for semantics.
+    /// See the `LoroMap` class documentation, section "Mergeable child containers",
+    /// for the storage format and conflict semantics.
     #[wasm_bindgen(js_name = "getMergeableMap")]
     pub fn get_mergeable_map(&self, key: &str) -> JsResult<LoroMap> {
         let handler = self.handler.get_mergeable_map(key)?;
@@ -3308,7 +3331,8 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable List under the given key.
-    /// See `getMergeableCounter` for semantics.
+    /// See the `LoroMap` class documentation, section "Mergeable child containers",
+    /// for the storage format and conflict semantics.
     #[wasm_bindgen(js_name = "getMergeableList")]
     pub fn get_mergeable_list(&self, key: &str) -> JsResult<LoroList> {
         let handler = self.handler.get_mergeable_list(key)?;
@@ -3316,7 +3340,8 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable MovableList under the given key.
-    /// See `getMergeableCounter` for semantics.
+    /// See the `LoroMap` class documentation, section "Mergeable child containers",
+    /// for the storage format and conflict semantics.
     #[wasm_bindgen(js_name = "getMergeableMovableList")]
     pub fn get_mergeable_movable_list(&self, key: &str) -> JsResult<LoroMovableList> {
         let handler = self.handler.get_mergeable_movable_list(key)?;
@@ -3324,7 +3349,8 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Text under the given key.
-    /// See `getMergeableCounter` for semantics.
+    /// See the `LoroMap` class documentation, section "Mergeable child containers",
+    /// for the storage format and conflict semantics.
     #[wasm_bindgen(js_name = "getMergeableText")]
     pub fn get_mergeable_text(&self, key: &str) -> JsResult<LoroText> {
         let handler = self.handler.get_mergeable_text(key)?;
@@ -3332,7 +3358,8 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Tree under the given key.
-    /// See `getMergeableCounter` for semantics.
+    /// See the `LoroMap` class documentation, section "Mergeable child containers",
+    /// for the storage format and conflict semantics.
     #[wasm_bindgen(js_name = "getMergeableTree")]
     pub fn get_mergeable_tree(&self, key: &str) -> JsResult<LoroTree> {
         let handler = self.handler.get_mergeable_tree(key)?;
@@ -6935,6 +6962,31 @@ interface LoroMovableList<T = unknown> {
     setContainer<C extends Container>(pos: number, child: C): T extends C ? T : C;
 }
 
+/**
+ * Loro map container.
+ *
+ * ## Mergeable child containers
+ *
+ * `getMergeable*` methods create deterministic child containers under a map key.
+ * If two peers independently call the same method with the same parent map, key,
+ * and container type, they get the same child container id and their subsequent
+ * edits merge in that child.
+ *
+ * Loro stores the activation value in the parent map slot as a compact binary
+ * mergeable-child ref, not as a reserved string. This avoids reserving
+ * user-visible strings such as `"🤝:Map"`: users may edit titles, custom
+ * properties, metadata, or imported JSON fields directly, and a user-created
+ * string should not accidentally become an internal container edge.
+ *
+ * The binary ref includes a small digest of `(parent_id, key, kind)`. It is not
+ * an anti-forgery mechanism; it makes accidental or UI-level construction of an
+ * internal mergeable edge negligible and makes copied or malformed binary values
+ * fail closed unless they are in the exact map slot they were created for.
+ *
+ * Deleting the map key clears the ref and hides the mergeable child, but the
+ * child's state is preserved. Calling the same `getMergeable*` method again
+ * writes the ref back and resurfaces the preserved state.
+ */
 interface LoroMap<T extends Record<string, unknown> = Record<string, unknown>> {
     new(): LoroMap<T>;
     /**
@@ -6969,6 +7021,60 @@ interface LoroMap<T extends Record<string, unknown> = Record<string, unknown>> {
      *  ```
      */
     setContainer<C extends Container, Key extends keyof T>(key: Key, child: C): NonNullableType<T[Key]> extends C ? NonNullableType<T[Key]> : C;
+    /**
+     * Get or create a mergeable Counter under the given key.
+     *
+     * See the `LoroMap` documentation, section "Mergeable child containers",
+     * for the storage format and conflict semantics.
+     *
+     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     */
+    getMergeableCounter(key: string): LoroCounter;
+    /**
+     * Get or create a mergeable Map under the given key.
+     *
+     * See the `LoroMap` documentation, section "Mergeable child containers",
+     * for the storage format and conflict semantics.
+     *
+     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     */
+    getMergeableMap(key: string): LoroMap;
+    /**
+     * Get or create a mergeable List under the given key.
+     *
+     * See the `LoroMap` documentation, section "Mergeable child containers",
+     * for the storage format and conflict semantics.
+     *
+     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     */
+    getMergeableList(key: string): LoroList;
+    /**
+     * Get or create a mergeable MovableList under the given key.
+     *
+     * See the `LoroMap` documentation, section "Mergeable child containers",
+     * for the storage format and conflict semantics.
+     *
+     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     */
+    getMergeableMovableList(key: string): LoroMovableList;
+    /**
+     * Get or create a mergeable Text under the given key.
+     *
+     * See the `LoroMap` documentation, section "Mergeable child containers",
+     * for the storage format and conflict semantics.
+     *
+     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     */
+    getMergeableText(key: string): LoroText;
+    /**
+     * Get or create a mergeable Tree under the given key.
+     *
+     * See the `LoroMap` documentation, section "Mergeable child containers",
+     * for the storage format and conflict semantics.
+     *
+     * Throws if the key already holds a non-mergeable value; the existing value is left untouched.
+     */
+    getMergeableTree(key: string): LoroTree;
     /**
      *  Get the value of the key. If the value is a child container, the corresponding
      *  `Container` will be returned.

--- a/crates/loro-wasm/tests/mergeable.test.ts
+++ b/crates/loro-wasm/tests/mergeable.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test, vi } from "vitest";
+import { LoroDoc } from "../bundler/index";
+
+function sync(a: LoroDoc, b: LoroDoc) {
+  const aBytes = a.export({ mode: "update", from: b.version() });
+  const bBytes = b.export({ mode: "update", from: a.version() });
+  a.import(bBytes);
+  b.import(aBytes);
+}
+
+function oneMs(): Promise<void> {
+  return new Promise((r) => setTimeout(r));
+}
+
+describe("mergeable containers (WASM bindings)", () => {
+  test("concurrent counter increments converge", () => {
+    const a = new LoroDoc();
+    const b = new LoroDoc();
+    a.setPeerId("1");
+    b.setPeerId("2");
+
+    a.getMap("state").getMergeableCounter("revision").increment(1);
+    b.getMap("state").getMergeableCounter("revision").increment(1);
+    a.commit();
+    b.commit();
+    sync(a, b);
+
+    expect(a.toJSON()).toEqual({ state: { revision: 2 } });
+    expect(b.toJSON()).toEqual({ state: { revision: 2 } });
+  });
+
+  test("delete clears the discriminator; re-get resurfaces preserved state", () => {
+    const doc = new LoroDoc();
+    doc.setPeerId("1");
+    const root = doc.getMap("state");
+    const counter = root.getMergeableCounter("revision");
+    counter.increment(3);
+    doc.commit();
+    expect(doc.toJSON()).toEqual({ state: { revision: 3 } });
+
+    // delete clears the discriminator slot, exactly like a regular container delete.
+    root.delete("revision");
+    doc.commit();
+    expect(doc.toJSON()).toEqual({ state: {} });
+
+    // Re-get rewrites the discriminator (the slot is now empty), so the child resurfaces with
+    // its preserved state (3), not a reset to 0.
+    root.getMergeableCounter("revision");
+    doc.commit();
+    expect(doc.toJSON()).toEqual({ state: { revision: 3 } });
+
+    // Further mutation accrues on the preserved state.
+    root.getMergeableCounter("revision").increment(10);
+    doc.commit();
+    expect(doc.toJSON()).toEqual({ state: { revision: 13 } });
+  });
+
+  test("getMergeableMap, getMergeableList, getMergeableText smoke", () => {
+    const doc = new LoroDoc();
+    doc.setPeerId("1");
+    const root = doc.getMap("state");
+
+    root.getMergeableMap("nested").set("k", "v");
+    root.getMergeableList("items").insert(0, 1);
+    root.getMergeableText("body").insert(0, "hello");
+    doc.commit();
+
+    expect(doc.toJSON()).toEqual({
+      state: {
+        nested: { k: "v" },
+        items: [1],
+        body: "hello",
+      },
+    });
+  });
+
+  test("getMergeableMovableList: concurrent inserts converge and mov works end-to-end", () => {
+    const a = new LoroDoc();
+    const b = new LoroDoc();
+    a.setPeerId("1");
+    b.setPeerId("2");
+
+    const aItems = a.getMap("state").getMergeableMovableList("items");
+    const bItems = b.getMap("state").getMergeableMovableList("items");
+    // Deterministic cid: both peers resolve to the same id.
+    expect(aItems.id).toEqual(bItems.id);
+
+    aItems.insert(0, "first");
+    aItems.insert(1, "second");
+    bItems.insert(0, "from_b");
+    a.commit();
+    b.commit();
+    sync(a, b);
+
+    const aValue = a.toJSON() as { state: { items: string[] } };
+    expect(aValue.state.items).toHaveLength(3);
+    expect(new Set(aValue.state.items)).toEqual(
+      new Set(["first", "second", "from_b"]),
+    );
+    expect(b.toJSON()).toEqual(a.toJSON());
+
+    // Exercise the MovableList-specific `move` operation through the handle.
+    const aItemsAgain = a.getMap("state").getMergeableMovableList("items");
+    const preMoveOrder = (a.toJSON() as { state: { items: string[] } }).state
+      .items.slice();
+    aItemsAgain.move(0, aItemsAgain.length - 1);
+    a.commit();
+    const postMoveOrder = (a.toJSON() as { state: { items: string[] } }).state
+      .items;
+    expect(postMoveOrder).not.toEqual(preMoveOrder);
+    expect(new Set(postMoveOrder)).toEqual(new Set(preMoveOrder));
+  });
+
+  test("getMergeableTree: concurrent root creates converge", () => {
+    const a = new LoroDoc();
+    const b = new LoroDoc();
+    a.setPeerId("1");
+    b.setPeerId("2");
+
+    const aTree = a.getMap("state").getMergeableTree("hierarchy");
+    const bTree = b.getMap("state").getMergeableTree("hierarchy");
+    // Deterministic cid: both peers resolve to the same id.
+    expect(aTree.id).toEqual(bTree.id);
+
+    const aRoot = aTree.createNode();
+    aTree.createNode(aRoot.id);
+    bTree.createNode();
+    a.commit();
+    b.commit();
+    sync(a, b);
+
+    // Both peers' root nodes survive on the merged tree.
+    const aValue = a.toJSON() as { state: { hierarchy: unknown[] } };
+    expect(aValue.state.hierarchy).toHaveLength(2);
+    expect(b.toJSON()).toEqual(a.toJSON());
+  });
+
+  // Subscription-flush invariant (see AGENTS.md: "Flush Pending Events In `loro-wasm`").
+  //
+  // The six `getMergeable*` methods on `LoroMap` now emit a discriminator `MapSet` op against
+  // the parent map (loro-dev/loro#759), which DOES produce a document-level event — exactly like
+  // a plain `LoroMap.set`. Plus downstream mutations through the returned handle
+  // (`counter.increment`, `tree.createNode`, list/text inserts) emit events too. All of these go
+  // through the same auto-commit barrier as `LoroMap.set`, whose events are flushed by the
+  // already-decorated `commit`. With an active subscription on the parent, calling
+  // `getMergeable*` and then mutating must NOT leave any events on the JS pending queue past the
+  // microtask boundary.
+  //
+  // This test asserts the contract holds: the subscription fires, AND no
+  // "[LORO_INTERNAL_ERROR] Event not called" line is emitted.
+  test("getMergeable* methods do not leave events pending under an active subscription", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const doc = new LoroDoc();
+      doc.setPeerId("1");
+
+      let parentEvents = 0;
+      doc.getMap("state").subscribe(() => {
+        parentEvents += 1;
+      });
+
+      const root = doc.getMap("state");
+      // Touch every `getMergeable*` flavor while a subscription is active. None of these
+      // calls should leave pending events behind. The downstream mutations below force
+      // event emission; the assertion is that all events were delivered cleanly via the
+      // existing flush path (i.e. through `commit` already in the allowlist), with no
+      // internal "Event not called" warning.
+      const counter = root.getMergeableCounter("revision");
+      const nested = root.getMergeableMap("nested");
+      const list = root.getMergeableList("items");
+      const movable = root.getMergeableMovableList("movable");
+      const text = root.getMergeableText("body");
+      const tree = root.getMergeableTree("hierarchy");
+
+      counter.increment(1);
+      nested.set("k", "v");
+      list.insert(0, "x");
+      movable.insert(0, "y");
+      text.insert(0, "hello");
+      tree.createNode();
+      doc.commit();
+      await oneMs();
+
+      // Sanity: the parent subscription fired at least once for the mutations above.
+      expect(parentEvents).toBeGreaterThan(0);
+      // Invariant: the binding must not log the pending-events error.
+      const sawInternalError = errorSpy.mock.calls.some((args) =>
+        args.some((arg) =>
+          String(arg).includes("[LORO_INTERNAL_ERROR] Event not called"),
+        ),
+      );
+      expect(sawInternalError).toBe(false);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/crates/loro-wasm/tests/mergeable.test.ts
+++ b/crates/loro-wasm/tests/mergeable.test.ts
@@ -19,8 +19,8 @@ describe("mergeable containers (WASM bindings)", () => {
     a.setPeerId("1");
     b.setPeerId("2");
 
-    a.getMap("state").getMergeableCounter("revision").increment(1);
-    b.getMap("state").getMergeableCounter("revision").increment(1);
+    a.getMap("state").ensureMergeableCounter("revision").increment(1);
+    b.getMap("state").ensureMergeableCounter("revision").increment(1);
     a.commit();
     b.commit();
     sync(a, b);
@@ -33,7 +33,7 @@ describe("mergeable containers (WASM bindings)", () => {
     const doc = new LoroDoc();
     doc.setPeerId("1");
     const root = doc.getMap("state");
-    const counter = root.getMergeableCounter("revision");
+    const counter = root.ensureMergeableCounter("revision");
     counter.increment(3);
     doc.commit();
     expect(doc.toJSON()).toEqual({ state: { revision: 3 } });
@@ -45,24 +45,24 @@ describe("mergeable containers (WASM bindings)", () => {
 
     // Re-get rewrites the discriminator (the slot is now empty), so the child resurfaces with
     // its preserved state (3), not a reset to 0.
-    root.getMergeableCounter("revision");
+    root.ensureMergeableCounter("revision");
     doc.commit();
     expect(doc.toJSON()).toEqual({ state: { revision: 3 } });
 
     // Further mutation accrues on the preserved state.
-    root.getMergeableCounter("revision").increment(10);
+    root.ensureMergeableCounter("revision").increment(10);
     doc.commit();
     expect(doc.toJSON()).toEqual({ state: { revision: 13 } });
   });
 
-  test("getMergeableMap, getMergeableList, getMergeableText smoke", () => {
+  test("ensureMergeableMap, ensureMergeableList, ensureMergeableText smoke", () => {
     const doc = new LoroDoc();
     doc.setPeerId("1");
     const root = doc.getMap("state");
 
-    root.getMergeableMap("nested").set("k", "v");
-    root.getMergeableList("items").insert(0, 1);
-    root.getMergeableText("body").insert(0, "hello");
+    root.ensureMergeableMap("nested").set("k", "v");
+    root.ensureMergeableList("items").insert(0, 1);
+    root.ensureMergeableText("body").insert(0, "hello");
     doc.commit();
 
     expect(doc.toJSON()).toEqual({
@@ -74,14 +74,14 @@ describe("mergeable containers (WASM bindings)", () => {
     });
   });
 
-  test("getMergeableMovableList: concurrent inserts converge and mov works end-to-end", () => {
+  test("ensureMergeableMovableList: concurrent inserts converge and mov works end-to-end", () => {
     const a = new LoroDoc();
     const b = new LoroDoc();
     a.setPeerId("1");
     b.setPeerId("2");
 
-    const aItems = a.getMap("state").getMergeableMovableList("items");
-    const bItems = b.getMap("state").getMergeableMovableList("items");
+    const aItems = a.getMap("state").ensureMergeableMovableList("items");
+    const bItems = b.getMap("state").ensureMergeableMovableList("items");
     // Deterministic cid: both peers resolve to the same id.
     expect(aItems.id).toEqual(bItems.id);
 
@@ -100,7 +100,7 @@ describe("mergeable containers (WASM bindings)", () => {
     expect(b.toJSON()).toEqual(a.toJSON());
 
     // Exercise the MovableList-specific `move` operation through the handle.
-    const aItemsAgain = a.getMap("state").getMergeableMovableList("items");
+    const aItemsAgain = a.getMap("state").ensureMergeableMovableList("items");
     const preMoveOrder = (a.toJSON() as { state: { items: string[] } }).state
       .items.slice();
     aItemsAgain.move(0, aItemsAgain.length - 1);
@@ -111,14 +111,14 @@ describe("mergeable containers (WASM bindings)", () => {
     expect(new Set(postMoveOrder)).toEqual(new Set(preMoveOrder));
   });
 
-  test("getMergeableTree: concurrent root creates converge", () => {
+  test("ensureMergeableTree: concurrent root creates converge", () => {
     const a = new LoroDoc();
     const b = new LoroDoc();
     a.setPeerId("1");
     b.setPeerId("2");
 
-    const aTree = a.getMap("state").getMergeableTree("hierarchy");
-    const bTree = b.getMap("state").getMergeableTree("hierarchy");
+    const aTree = a.getMap("state").ensureMergeableTree("hierarchy");
+    const bTree = b.getMap("state").ensureMergeableTree("hierarchy");
     // Deterministic cid: both peers resolve to the same id.
     expect(aTree.id).toEqual(bTree.id);
 
@@ -137,18 +137,18 @@ describe("mergeable containers (WASM bindings)", () => {
 
   // Subscription-flush invariant (see AGENTS.md: "Flush Pending Events In `loro-wasm`").
   //
-  // The six `getMergeable*` methods on `LoroMap` now emit a discriminator `MapSet` op against
+  // The six `ensureMergeable*` methods on `LoroMap` now emit a discriminator `MapSet` op against
   // the parent map (loro-dev/loro#759), which DOES produce a document-level event — exactly like
   // a plain `LoroMap.set`. Plus downstream mutations through the returned handle
   // (`counter.increment`, `tree.createNode`, list/text inserts) emit events too. All of these go
   // through the same auto-commit barrier as `LoroMap.set`, whose events are flushed by the
   // already-decorated `commit`. With an active subscription on the parent, calling
-  // `getMergeable*` and then mutating must NOT leave any events on the JS pending queue past the
+  // `ensureMergeable*` and then mutating must NOT leave any events on the JS pending queue past the
   // microtask boundary.
   //
   // This test asserts the contract holds: the subscription fires, AND no
   // "[LORO_INTERNAL_ERROR] Event not called" line is emitted.
-  test("getMergeable* methods do not leave events pending under an active subscription", async () => {
+  test("ensureMergeable* methods do not leave events pending under an active subscription", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const doc = new LoroDoc();
@@ -160,17 +160,17 @@ describe("mergeable containers (WASM bindings)", () => {
       });
 
       const root = doc.getMap("state");
-      // Touch every `getMergeable*` flavor while a subscription is active. None of these
+      // Touch every `ensureMergeable*` flavor while a subscription is active. None of these
       // calls should leave pending events behind. The downstream mutations below force
       // event emission; the assertion is that all events were delivered cleanly via the
       // existing flush path (i.e. through `commit` already in the allowlist), with no
       // internal "Event not called" warning.
-      const counter = root.getMergeableCounter("revision");
-      const nested = root.getMergeableMap("nested");
-      const list = root.getMergeableList("items");
-      const movable = root.getMergeableMovableList("movable");
-      const text = root.getMergeableText("body");
-      const tree = root.getMergeableTree("hierarchy");
+      const counter = root.ensureMergeableCounter("revision");
+      const nested = root.ensureMergeableMap("nested");
+      const list = root.ensureMergeableList("items");
+      const movable = root.ensureMergeableMovableList("movable");
+      const text = root.ensureMergeableText("body");
+      const tree = root.ensureMergeableTree("hierarchy");
 
       counter.increment(1);
       nested.set("k", "v");

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -2167,6 +2167,9 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Counter at this map key.
+    ///
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
+    /// scalar or a regular child container); the existing value is left untouched.
     #[cfg(feature = "counter")]
     pub fn get_mergeable_counter(&self, key: &str) -> LoroResult<LoroCounter> {
         Ok(LoroCounter::from_handler(
@@ -2175,11 +2178,17 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Map at this map key.
+    ///
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
+    /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_map(&self, key: &str) -> LoroResult<LoroMap> {
         Ok(LoroMap::from_handler(self.handler.get_mergeable_map(key)?))
     }
 
     /// Get or create a mergeable List at this map key.
+    ///
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
+    /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_list(&self, key: &str) -> LoroResult<LoroList> {
         Ok(LoroList::from_handler(
             self.handler.get_mergeable_list(key)?,
@@ -2187,6 +2196,9 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable MovableList at this map key.
+    ///
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
+    /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_movable_list(&self, key: &str) -> LoroResult<LoroMovableList> {
         Ok(LoroMovableList::from_handler(
             self.handler.get_mergeable_movable_list(key)?,
@@ -2194,6 +2206,9 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Text at this map key.
+    ///
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
+    /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_text(&self, key: &str) -> LoroResult<LoroText> {
         Ok(LoroText::from_handler(
             self.handler.get_mergeable_text(key)?,
@@ -2201,6 +2216,9 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Tree at this map key.
+    ///
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
+    /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_tree(&self, key: &str) -> LoroResult<LoroTree> {
         Ok(LoroTree::from_handler(
             self.handler.get_mergeable_tree(key)?,

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -2166,6 +2166,47 @@ impl LoroMap {
         ))
     }
 
+    /// Get or create a mergeable Counter at this map key.
+    #[cfg(feature = "counter")]
+    pub fn get_mergeable_counter(&self, key: &str) -> LoroResult<LoroCounter> {
+        Ok(LoroCounter::from_handler(
+            self.handler.get_mergeable_counter(key)?,
+        ))
+    }
+
+    /// Get or create a mergeable Map at this map key.
+    pub fn get_mergeable_map(&self, key: &str) -> LoroResult<LoroMap> {
+        Ok(LoroMap::from_handler(self.handler.get_mergeable_map(key)?))
+    }
+
+    /// Get or create a mergeable List at this map key.
+    pub fn get_mergeable_list(&self, key: &str) -> LoroResult<LoroList> {
+        Ok(LoroList::from_handler(
+            self.handler.get_mergeable_list(key)?,
+        ))
+    }
+
+    /// Get or create a mergeable MovableList at this map key.
+    pub fn get_mergeable_movable_list(&self, key: &str) -> LoroResult<LoroMovableList> {
+        Ok(LoroMovableList::from_handler(
+            self.handler.get_mergeable_movable_list(key)?,
+        ))
+    }
+
+    /// Get or create a mergeable Text at this map key.
+    pub fn get_mergeable_text(&self, key: &str) -> LoroResult<LoroText> {
+        Ok(LoroText::from_handler(
+            self.handler.get_mergeable_text(key)?,
+        ))
+    }
+
+    /// Get or create a mergeable Tree at this map key.
+    pub fn get_mergeable_tree(&self, key: &str) -> LoroResult<LoroTree> {
+        Ok(LoroTree::from_handler(
+            self.handler.get_mergeable_tree(key)?,
+        ))
+    }
+
     /// Delete all key-value pairs in the map.
     pub fn clear(&self) -> LoroResult<()> {
         self.handler.clear()

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -1988,29 +1988,19 @@ impl Default for LoroList {
 ///
 /// # Mergeable child containers
 ///
-/// The `get_mergeable_*` methods create deterministic child containers under a
+/// The `ensure_mergeable_*` methods create deterministic child containers under a
 /// map key. If two peers independently call the same method with the same
 /// `(parent map, key, container type)`, they get the same child container id and
 /// their subsequent edits merge in that child.
 ///
-/// Internally, the parent map slot stores a compact binary mergeable-child ref,
-/// not a reserved user string. This is deliberate: applications often let end
-/// users edit titles, custom properties, metadata, or imported JSON fields
-/// directly. If mergeable children were activated by a string such as
-/// `"🤝:Map"`, normal user data could collide with Loro's internal structure and
-/// accidentally create a container edge. The binary ref lives outside the normal
-/// string value space and includes a small digest of `(parent_id, key, kind)`,
-/// so copied or malformed binary values fail closed unless they are in the
-/// exact map slot they were created for.
-///
-/// The binary ref is not an anti-forgery mechanism. It is a compact marker that
-/// makes accidental or UI-level construction of an internal mergeable edge
-/// negligible while keeping the map slot small. Existing non-mergeable values
-/// at the key are rejected and left untouched by `get_mergeable_*`.
+/// Internally, activation writes a specially constructed `LoroValue::Binary`
+/// marker into the parent map slot. String values do not activate mergeable
+/// children. If the key already holds a non-mergeable value, `ensure_mergeable_*`
+/// returns an error and leaves the value unchanged.
 ///
 /// Deleting the map key clears the ref and hides the mergeable child, but the
 /// child's state remains addressable by its deterministic id. Calling the same
-/// `get_mergeable_*` method again writes the ref back and resurfaces the
+/// `ensure_mergeable_*` method again writes the ref back and resurfaces the
 /// preserved child state.
 ///
 /// # Example
@@ -2193,80 +2183,80 @@ impl LoroMap {
         ))
     }
 
-    /// Get or create a mergeable Counter at this map key.
+    /// Ensure a mergeable Counter exists at this map key and return it.
     ///
     /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
-    /// section for the storage format and conflict semantics.
+    /// section for merge semantics.
     ///
-    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
-    /// scalar or a regular child container); the existing value is left untouched.
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
+    /// value is left unchanged.
     #[cfg(feature = "counter")]
-    pub fn get_mergeable_counter(&self, key: &str) -> LoroResult<LoroCounter> {
+    pub fn ensure_mergeable_counter(&self, key: &str) -> LoroResult<LoroCounter> {
         Ok(LoroCounter::from_handler(
-            self.handler.get_mergeable_counter(key)?,
+            self.handler.ensure_mergeable_counter(key)?,
         ))
     }
 
-    /// Get or create a mergeable Map at this map key.
+    /// Ensure a mergeable Map exists at this map key and return it.
     ///
     /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
-    /// section for the storage format and conflict semantics.
+    /// section for merge semantics.
     ///
-    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
-    /// scalar or a regular child container); the existing value is left untouched.
-    pub fn get_mergeable_map(&self, key: &str) -> LoroResult<LoroMap> {
-        Ok(LoroMap::from_handler(self.handler.get_mergeable_map(key)?))
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
+    /// value is left unchanged.
+    pub fn ensure_mergeable_map(&self, key: &str) -> LoroResult<LoroMap> {
+        Ok(LoroMap::from_handler(self.handler.ensure_mergeable_map(key)?))
     }
 
-    /// Get or create a mergeable List at this map key.
+    /// Ensure a mergeable List exists at this map key and return it.
     ///
     /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
-    /// section for the storage format and conflict semantics.
+    /// section for merge semantics.
     ///
-    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
-    /// scalar or a regular child container); the existing value is left untouched.
-    pub fn get_mergeable_list(&self, key: &str) -> LoroResult<LoroList> {
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
+    /// value is left unchanged.
+    pub fn ensure_mergeable_list(&self, key: &str) -> LoroResult<LoroList> {
         Ok(LoroList::from_handler(
-            self.handler.get_mergeable_list(key)?,
+            self.handler.ensure_mergeable_list(key)?,
         ))
     }
 
-    /// Get or create a mergeable MovableList at this map key.
+    /// Ensure a mergeable MovableList exists at this map key and return it.
     ///
     /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
-    /// section for the storage format and conflict semantics.
+    /// section for merge semantics.
     ///
-    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
-    /// scalar or a regular child container); the existing value is left untouched.
-    pub fn get_mergeable_movable_list(&self, key: &str) -> LoroResult<LoroMovableList> {
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
+    /// value is left unchanged.
+    pub fn ensure_mergeable_movable_list(&self, key: &str) -> LoroResult<LoroMovableList> {
         Ok(LoroMovableList::from_handler(
-            self.handler.get_mergeable_movable_list(key)?,
+            self.handler.ensure_mergeable_movable_list(key)?,
         ))
     }
 
-    /// Get or create a mergeable Text at this map key.
+    /// Ensure a mergeable Text exists at this map key and return it.
     ///
     /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
-    /// section for the storage format and conflict semantics.
+    /// section for merge semantics.
     ///
-    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
-    /// scalar or a regular child container); the existing value is left untouched.
-    pub fn get_mergeable_text(&self, key: &str) -> LoroResult<LoroText> {
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
+    /// value is left unchanged.
+    pub fn ensure_mergeable_text(&self, key: &str) -> LoroResult<LoroText> {
         Ok(LoroText::from_handler(
-            self.handler.get_mergeable_text(key)?,
+            self.handler.ensure_mergeable_text(key)?,
         ))
     }
 
-    /// Get or create a mergeable Tree at this map key.
+    /// Ensure a mergeable Tree exists at this map key and return it.
     ///
     /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
-    /// section for the storage format and conflict semantics.
+    /// section for merge semantics.
     ///
-    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
-    /// scalar or a regular child container); the existing value is left untouched.
-    pub fn get_mergeable_tree(&self, key: &str) -> LoroResult<LoroTree> {
+    /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
+    /// value is left unchanged.
+    pub fn ensure_mergeable_tree(&self, key: &str) -> LoroResult<LoroTree> {
         Ok(LoroTree::from_handler(
-            self.handler.get_mergeable_tree(key)?,
+            self.handler.ensure_mergeable_tree(key)?,
         ))
     }
 

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -1986,6 +1986,33 @@ impl Default for LoroList {
 ///
 /// It's LWW(Last-Write-Win) Map. It can support Multi-Value Map in the future.
 ///
+/// # Mergeable child containers
+///
+/// The `get_mergeable_*` methods create deterministic child containers under a
+/// map key. If two peers independently call the same method with the same
+/// `(parent map, key, container type)`, they get the same child container id and
+/// their subsequent edits merge in that child.
+///
+/// Internally, the parent map slot stores a compact binary mergeable-child ref,
+/// not a reserved user string. This is deliberate: applications often let end
+/// users edit titles, custom properties, metadata, or imported JSON fields
+/// directly. If mergeable children were activated by a string such as
+/// `"🤝:Map"`, normal user data could collide with Loro's internal structure and
+/// accidentally create a container edge. The binary ref lives outside the normal
+/// string value space and includes a small digest of `(parent_id, key, kind)`,
+/// so copied or malformed binary values fail closed unless they are in the
+/// exact map slot they were created for.
+///
+/// The binary ref is not an anti-forgery mechanism. It is a compact marker that
+/// makes accidental or UI-level construction of an internal mergeable edge
+/// negligible while keeping the map slot small. Existing non-mergeable values
+/// at the key are rejected and left untouched by `get_mergeable_*`.
+///
+/// Deleting the map key clears the ref and hides the mergeable child, but the
+/// child's state remains addressable by its deterministic id. Calling the same
+/// `get_mergeable_*` method again writes the ref back and resurfaces the
+/// preserved child state.
+///
 /// # Example
 /// ```
 /// # use loro::{LoroDoc, ToJson, ExpandType, LoroText, LoroValue};
@@ -2168,6 +2195,9 @@ impl LoroMap {
 
     /// Get or create a mergeable Counter at this map key.
     ///
+    /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
+    /// section for the storage format and conflict semantics.
+    ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
     /// scalar or a regular child container); the existing value is left untouched.
     #[cfg(feature = "counter")]
@@ -2179,6 +2209,9 @@ impl LoroMap {
 
     /// Get or create a mergeable Map at this map key.
     ///
+    /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
+    /// section for the storage format and conflict semantics.
+    ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
     /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_map(&self, key: &str) -> LoroResult<LoroMap> {
@@ -2186,6 +2219,9 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable List at this map key.
+    ///
+    /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
+    /// section for the storage format and conflict semantics.
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
     /// scalar or a regular child container); the existing value is left untouched.
@@ -2197,6 +2233,9 @@ impl LoroMap {
 
     /// Get or create a mergeable MovableList at this map key.
     ///
+    /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
+    /// section for the storage format and conflict semantics.
+    ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
     /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_movable_list(&self, key: &str) -> LoroResult<LoroMovableList> {
@@ -2207,6 +2246,9 @@ impl LoroMap {
 
     /// Get or create a mergeable Text at this map key.
     ///
+    /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
+    /// section for the storage format and conflict semantics.
+    ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
     /// scalar or a regular child container); the existing value is left untouched.
     pub fn get_mergeable_text(&self, key: &str) -> LoroResult<LoroText> {
@@ -2216,6 +2258,9 @@ impl LoroMap {
     }
 
     /// Get or create a mergeable Tree at this map key.
+    ///
+    /// See [`LoroMap`]'s [mergeable child containers](#mergeable-child-containers)
+    /// section for the storage format and conflict semantics.
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value (a plain
     /// scalar or a regular child container); the existing value is left untouched.

--- a/crates/loro/tests/mergeable_public_api.rs
+++ b/crates/loro/tests/mergeable_public_api.rs
@@ -1,0 +1,305 @@
+//! Coverage for the public `loro::LoroMap::get_mergeable_*` wrappers.
+//!
+//! The integration tests in `crates/loro-internal/tests/mergeable_container/*` exercise
+//! the underlying `MapHandler` directly. These tests confirm the public `loro` crate's
+//! wrapper methods on `LoroMap` forward to the handler correctly and that the returned
+//! `LoroCounter` / `LoroMap` / `LoroList` / `LoroMovableList` / `LoroText` / `LoroTree`
+//! values are usable end-to-end through the documented public API.
+
+use loro::{ContainerID, ContainerTrait, ContainerType, ExportMode, LoroDoc, ToJson, TreeParentId};
+use serde_json::json;
+use serial_test::parallel;
+
+fn doc(peer: u64) -> LoroDoc {
+    let d = LoroDoc::new();
+    d.set_peer_id(peer).unwrap();
+    d
+}
+
+fn sync(a: &LoroDoc, b: &LoroDoc) {
+    a.import(&b.export(ExportMode::updates(&a.oplog_vv())).unwrap())
+        .unwrap();
+    b.import(&a.export(ExportMode::updates(&b.oplog_vv())).unwrap())
+        .unwrap();
+}
+
+/// `LoroMap::get_mergeable_counter` returns a working `LoroCounter` whose increments
+/// converge across peers on concurrent first-create.
+#[test]
+#[parallel]
+#[cfg(feature = "counter")]
+fn loro_map_get_mergeable_counter_through_public_api() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_counter = a
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    let b_counter = b
+        .get_map("state")
+        .get_mergeable_counter("revision")
+        .unwrap();
+    assert_eq!(
+        a_counter.id(),
+        b_counter.id(),
+        "both peers must produce the same deterministic cid via the public API"
+    );
+    assert!(a_counter.id().is_mergeable());
+
+    a_counter.increment(1.0).unwrap();
+    b_counter.increment(1.0).unwrap();
+    a.commit();
+    b.commit();
+    sync(&a, &b);
+
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({ "state": { "revision": 2.0 } })
+    );
+    assert_eq!(
+        b.get_deep_value().to_json_value(),
+        a.get_deep_value().to_json_value()
+    );
+}
+
+/// `LoroMap::get_mergeable_map` returns a working `LoroMap` that supports nested
+/// disjoint-key writes converging across peers.
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_map_through_public_api() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_profile = a.get_map("state").get_mergeable_map("profile").unwrap();
+    let b_profile = b.get_map("state").get_mergeable_map("profile").unwrap();
+    assert_eq!(a_profile.id(), b_profile.id());
+
+    a_profile.insert("name", "Ada").unwrap();
+    b_profile.insert("title", "Engineer").unwrap();
+    a.commit();
+    b.commit();
+    sync(&a, &b);
+
+    assert_eq!(
+        a.get_deep_value().to_json_value(),
+        json!({ "state": { "profile": { "name": "Ada", "title": "Engineer" } } })
+    );
+}
+
+/// `LoroMap::get_mergeable_list` returns a working `LoroList` whose concurrent inserts
+/// both survive after sync.
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_list_through_public_api() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_items = a.get_map("state").get_mergeable_list("items").unwrap();
+    let b_items = b.get_map("state").get_mergeable_list("items").unwrap();
+    assert_eq!(a_items.id(), b_items.id());
+
+    a_items.insert(0, "A").unwrap();
+    b_items.insert(0, "B").unwrap();
+    a.commit();
+    b.commit();
+    sync(&a, &b);
+
+    let value = a.get_deep_value().to_json_value();
+    assert!(
+        value == json!({ "state": { "items": ["A", "B"] } })
+            || value == json!({ "state": { "items": ["B", "A"] } }),
+        "both concurrent inserts must survive on the merged list; got {value}"
+    );
+    assert_eq!(b.get_deep_value().to_json_value(), value);
+}
+
+/// `LoroMap::get_mergeable_text` returns a working `LoroText` whose concurrent edits
+/// both survive after sync.
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_text_through_public_api() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_notes = a.get_map("state").get_mergeable_text("notes").unwrap();
+    let b_notes = b.get_map("state").get_mergeable_text("notes").unwrap();
+    assert_eq!(a_notes.id(), b_notes.id());
+
+    a_notes.insert(0, "A").unwrap();
+    b_notes.insert(0, "B").unwrap();
+    a.commit();
+    b.commit();
+    sync(&a, &b);
+
+    let value = a.get_deep_value().to_json_value();
+    assert!(
+        value == json!({ "state": { "notes": "AB" } })
+            || value == json!({ "state": { "notes": "BA" } }),
+        "both concurrent text edits must survive; got {value}"
+    );
+}
+
+/// `LoroMap::get_mergeable_movable_list` returns a working `LoroMovableList` whose
+/// concurrent first-create from two peers resolves to the same deterministic cid,
+/// and inserts on both peers survive after sync. Also exercises the `mov` operation
+/// on the returned handler to confirm the full public surface forwards correctly.
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_movable_list_through_public_api() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_items = a
+        .get_map("state")
+        .get_mergeable_movable_list("items")
+        .unwrap();
+    let b_items = b
+        .get_map("state")
+        .get_mergeable_movable_list("items")
+        .unwrap();
+    assert_eq!(
+        a_items.id(),
+        b_items.id(),
+        "both peers must produce the same deterministic mergeable MovableList cid"
+    );
+    assert!(a_items.id().is_mergeable());
+    assert_eq!(a_items.id().container_type(), ContainerType::MovableList);
+
+    a_items.insert(0, "first").unwrap();
+    a_items.insert(1, "second").unwrap();
+    b_items.insert(0, "from_b").unwrap();
+    a.commit();
+    b.commit();
+    sync(&a, &b);
+
+    let value = a.get_deep_value().to_json_value();
+    let items = value["state"]["items"]
+        .as_array()
+        .expect("items must be a list");
+    assert_eq!(
+        items.len(),
+        3,
+        "both peers' inserts must survive on the merged movable list; got {value}"
+    );
+    assert!(items.contains(&json!("first")));
+    assert!(items.contains(&json!("second")));
+    assert!(items.contains(&json!("from_b")));
+    assert_eq!(b.get_deep_value().to_json_value(), value);
+
+    // Exercise the MovableList-specific `mov` operation through the handler returned
+    // by the mergeable getter to confirm it's a fully-functional MovableList.
+    let pre_move = a.get_deep_value().to_json_value();
+    let a_items_again = a
+        .get_map("state")
+        .get_mergeable_movable_list("items")
+        .unwrap();
+    a_items_again.mov(0, a_items_again.len() - 1).unwrap();
+    a.commit();
+    let post_move = a.get_deep_value().to_json_value();
+    assert_ne!(
+        pre_move, post_move,
+        "mov on the returned MovableList handler must change order"
+    );
+}
+
+/// `LoroMap::get_mergeable_tree` returns a working `LoroTree` whose nodes are
+/// reachable through the deep value and whose tree operations forward correctly
+/// through the public API.
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_tree_through_public_api() {
+    let a = doc(1);
+    let b = doc(2);
+
+    let a_tree = a.get_map("state").get_mergeable_tree("hierarchy").unwrap();
+    let b_tree = b.get_map("state").get_mergeable_tree("hierarchy").unwrap();
+    assert_eq!(
+        a_tree.id(),
+        b_tree.id(),
+        "both peers must produce the same deterministic mergeable Tree cid"
+    );
+    assert!(a_tree.id().is_mergeable());
+    assert_eq!(a_tree.id().container_type(), ContainerType::Tree);
+
+    // Exercise the Tree-specific create operation through the handler returned by
+    // the mergeable getter on both peers, then converge.
+    let a_root_node = a_tree.create(TreeParentId::Root).unwrap();
+    let _a_child = a_tree.create(TreeParentId::Node(a_root_node)).unwrap();
+    let _b_root_node = b_tree.create(TreeParentId::Root).unwrap();
+    a.commit();
+    b.commit();
+    sync(&a, &b);
+
+    let va = a.get_deep_value().to_json_value();
+    let vb = b.get_deep_value().to_json_value();
+    assert_eq!(va, vb, "Tree state must converge across peers after sync");
+
+    // Both root nodes must show up in the merged tree.
+    let hierarchy = &va["state"]["hierarchy"];
+    let roots = hierarchy.as_array().expect("tree value must be an array");
+    assert_eq!(
+        roots.len(),
+        2,
+        "both peers' root nodes must survive on the merged tree; got {va}"
+    );
+}
+
+/// Kind change through the public API: register one mergeable kind under a key,
+/// then ask for another. Requesting a different kind is a deliberate kind change
+/// that rewrites the `"🤝:<kind>"` discriminator, so the public
+/// `LoroMap::get_mergeable_*` wrappers succeed and the active child switches to
+/// the newly requested kind (mirroring
+/// `type_conflict::local_different_kind_request_rewrites_the_discriminator`).
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_kind_change_through_public_api() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    let text = root.get_mergeable_text("field").unwrap();
+    text.insert(0, "hello").unwrap();
+    d.commit();
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "field": "hello" } })
+    );
+
+    // Switch the kind: this rewrites the discriminator to Map.
+    let map = root.get_mergeable_map("field").unwrap();
+    map.insert("k", 1).unwrap();
+    d.commit();
+    assert_eq!(
+        d.get_deep_value().to_json_value(),
+        json!({ "state": { "field": { "k": 1 } } }),
+        "requesting a different kind rewrites the discriminator to that kind"
+    );
+}
+
+/// `LoroDoc::has_container` carve-out: a mergeable cid that has never been written
+/// must report `false`. After mutation, it must report `true`. This guards the
+/// short-circuit for plain `Root` ids from masking mergeable existence checks
+/// through the public API.
+#[test]
+#[parallel]
+#[cfg(feature = "counter")]
+fn loro_has_container_for_mergeable_cid_through_public_api() {
+    let d = doc(1);
+    let root = d.get_map("state");
+
+    let parent_id = root.id();
+    let unwritten_cid = ContainerID::new_mergeable(&parent_id, "revision", ContainerType::Counter);
+    assert!(unwritten_cid.is_mergeable());
+    assert!(
+        !d.has_container(&unwritten_cid),
+        "has_container must report false for an unwritten mergeable cid"
+    );
+
+    let counter = root.get_mergeable_counter("revision").unwrap();
+    counter.increment(1.0).unwrap();
+    assert_eq!(counter.id(), unwritten_cid);
+    assert!(
+        d.has_container(&unwritten_cid),
+        "has_container must report true after the mergeable child has state"
+    );
+}

--- a/crates/loro/tests/mergeable_public_api.rs
+++ b/crates/loro/tests/mergeable_public_api.rs
@@ -303,3 +303,26 @@ fn loro_has_container_for_mergeable_cid_through_public_api() {
         "has_container must report true after the mergeable child has state"
     );
 }
+
+/// `get_mergeable_*` must not silently overwrite a non-mergeable value through the public API:
+/// a scalar already at the key makes the call an `ArgErr` and leaves the value in place.
+#[test]
+#[parallel]
+fn loro_map_get_mergeable_rejects_overwriting_scalar_through_public_api() {
+    use loro::LoroError;
+
+    let d = doc(1);
+    let root = d.get_map("state");
+    root.insert("field", 5).unwrap();
+
+    let err = root
+        .get_mergeable_list("field")
+        .expect_err("get_mergeable over a scalar must error");
+    assert!(matches!(err, LoroError::ArgErr(_)), "expected ArgErr, got {err:?}");
+    let still = root.get("field").expect("scalar must still be present");
+    assert_eq!(
+        still.get_deep_value(),
+        5.into(),
+        "the existing scalar value must be left untouched"
+    );
+}

--- a/crates/loro/tests/mergeable_public_api.rs
+++ b/crates/loro/tests/mergeable_public_api.rs
@@ -6,7 +6,10 @@
 //! `LoroCounter` / `LoroMap` / `LoroList` / `LoroMovableList` / `LoroText` / `LoroTree`
 //! values are usable end-to-end through the documented public API.
 
-use loro::{ContainerID, ContainerTrait, ContainerType, ExportMode, LoroDoc, ToJson, TreeParentId};
+use loro::{
+    ContainerID, ContainerTrait, ContainerType, ExportMode, Index, LoroDoc, ToJson, TreeParentId,
+    ValueOrContainer,
+};
 use serde_json::json;
 use serial_test::parallel;
 
@@ -247,10 +250,8 @@ fn loro_map_get_mergeable_tree_through_public_api() {
 
 /// Kind change through the public API: register one mergeable kind under a key,
 /// then ask for another. Requesting a different kind is a deliberate kind change
-/// that rewrites the `"🤝:<kind>"` discriminator, so the public
-/// `LoroMap::get_mergeable_*` wrappers succeed and the active child switches to
-/// the newly requested kind (mirroring
-/// `type_conflict::local_different_kind_request_rewrites_the_discriminator`).
+/// that rewrites the parent map marker, so the public `LoroMap::get_mergeable_*`
+/// wrappers succeed and the active child switches to the newly requested kind.
 #[test]
 #[parallel]
 fn loro_map_get_mergeable_kind_change_through_public_api() {
@@ -265,15 +266,97 @@ fn loro_map_get_mergeable_kind_change_through_public_api() {
         json!({ "state": { "field": "hello" } })
     );
 
-    // Switch the kind: this rewrites the discriminator to Map.
+    // Switch the kind: this rewrites the marker to Map.
     let map = root.get_mergeable_map("field").unwrap();
     map.insert("k", 1).unwrap();
     d.commit();
     assert_eq!(
         d.get_deep_value().to_json_value(),
         json!({ "state": { "field": { "k": 1 } } }),
-        "requesting a different kind rewrites the discriminator to that kind"
+        "requesting a different kind rewrites the marker to that kind"
     );
+}
+
+/// A logical path returned for a mergeable child must be accepted by `get_by_path`.
+/// The final map slot stores a binary marker internally, but public path lookup
+/// should return the child container, not that raw marker value.
+#[test]
+#[parallel]
+#[cfg(feature = "counter")]
+fn loro_get_by_path_round_trips_mergeable_final_child() {
+    let d = doc(1);
+    let root = d.get_map("state");
+    let counter = root.get_mergeable_counter("revision").unwrap();
+
+    let path = d
+        .get_path_to_container(&counter.id())
+        .expect("mergeable counter should have a logical path");
+    let indexes = path
+        .iter()
+        .map(|(_, index)| index.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![Index::Key("state".into()), Index::Key("revision".into())]
+    );
+
+    let value = d
+        .get_by_path(&indexes)
+        .expect("logical mergeable path should resolve");
+    let ValueOrContainer::Container(container) = value else {
+        panic!("expected mergeable child container from get_by_path");
+    };
+    assert_eq!(container.id(), counter.id());
+}
+
+/// Nested logical paths must resolve through mergeable map intermediates without
+/// materializing or re-getting them first.
+#[test]
+#[parallel]
+#[cfg(feature = "counter")]
+fn loro_get_by_path_round_trips_nested_mergeable_child() {
+    let d = doc(1);
+    let root = d.get_map("state");
+    let profile = root.get_mergeable_map("profile").unwrap();
+    let counter = profile.get_mergeable_counter("revision").unwrap();
+    counter.increment(7.0).unwrap();
+    d.commit();
+
+    let path = d
+        .get_path_to_container(&counter.id())
+        .expect("nested mergeable counter should have a logical path");
+    let indexes = path
+        .iter()
+        .map(|(_, index)| index.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        indexes,
+        vec![
+            Index::Key("state".into()),
+            Index::Key("profile".into()),
+            Index::Key("revision".into()),
+        ]
+    );
+
+    let value = d
+        .get_by_path(&indexes)
+        .expect("nested logical mergeable path should resolve");
+    let ValueOrContainer::Container(container) = value else {
+        panic!("expected nested mergeable child container from get_by_path");
+    };
+    assert_eq!(container.id(), counter.id());
+    let loro::Container::Counter(counter_from_path) = container else {
+        panic!("expected counter container from get_by_path");
+    };
+    assert_eq!(counter_from_path.get_value(), 7.0);
+
+    let profile_value = d
+        .get_by_path(&[Index::Key("state".into()), Index::Key("profile".into())])
+        .expect("mergeable map intermediate should resolve");
+    let ValueOrContainer::Container(container) = profile_value else {
+        panic!("expected mergeable map container from get_by_path");
+    };
+    assert_eq!(container.id(), profile.id());
 }
 
 /// `LoroDoc::has_container` carve-out: a mergeable cid that has never been written
@@ -318,7 +401,10 @@ fn loro_map_get_mergeable_rejects_overwriting_scalar_through_public_api() {
     let err = root
         .get_mergeable_list("field")
         .expect_err("get_mergeable over a scalar must error");
-    assert!(matches!(err, LoroError::ArgErr(_)), "expected ArgErr, got {err:?}");
+    assert!(
+        matches!(err, LoroError::ArgErr(_)),
+        "expected ArgErr, got {err:?}"
+    );
     let still = root.get("field").expect("scalar must still be present");
     assert_eq!(
         still.get_deep_value(),

--- a/crates/loro/tests/mergeable_public_api.rs
+++ b/crates/loro/tests/mergeable_public_api.rs
@@ -1,4 +1,4 @@
-//! Coverage for the public `loro::LoroMap::get_mergeable_*` wrappers.
+//! Coverage for the public `loro::LoroMap::ensure_mergeable_*` wrappers.
 //!
 //! The integration tests in `crates/loro-internal/tests/mergeable_container/*` exercise
 //! the underlying `MapHandler` directly. These tests confirm the public `loro` crate's
@@ -26,22 +26,22 @@ fn sync(a: &LoroDoc, b: &LoroDoc) {
         .unwrap();
 }
 
-/// `LoroMap::get_mergeable_counter` returns a working `LoroCounter` whose increments
+/// `LoroMap::ensure_mergeable_counter` returns a working `LoroCounter` whose increments
 /// converge across peers on concurrent first-create.
 #[test]
 #[parallel]
 #[cfg(feature = "counter")]
-fn loro_map_get_mergeable_counter_through_public_api() {
+fn loro_map_ensure_mergeable_counter_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
     let a_counter = a
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     let b_counter = b
         .get_map("state")
-        .get_mergeable_counter("revision")
+        .ensure_mergeable_counter("revision")
         .unwrap();
     assert_eq!(
         a_counter.id(),
@@ -66,16 +66,16 @@ fn loro_map_get_mergeable_counter_through_public_api() {
     );
 }
 
-/// `LoroMap::get_mergeable_map` returns a working `LoroMap` that supports nested
+/// `LoroMap::ensure_mergeable_map` returns a working `LoroMap` that supports nested
 /// disjoint-key writes converging across peers.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_map_through_public_api() {
+fn loro_map_ensure_mergeable_map_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_profile = a.get_map("state").get_mergeable_map("profile").unwrap();
-    let b_profile = b.get_map("state").get_mergeable_map("profile").unwrap();
+    let a_profile = a.get_map("state").ensure_mergeable_map("profile").unwrap();
+    let b_profile = b.get_map("state").ensure_mergeable_map("profile").unwrap();
     assert_eq!(a_profile.id(), b_profile.id());
 
     a_profile.insert("name", "Ada").unwrap();
@@ -90,16 +90,16 @@ fn loro_map_get_mergeable_map_through_public_api() {
     );
 }
 
-/// `LoroMap::get_mergeable_list` returns a working `LoroList` whose concurrent inserts
+/// `LoroMap::ensure_mergeable_list` returns a working `LoroList` whose concurrent inserts
 /// both survive after sync.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_list_through_public_api() {
+fn loro_map_ensure_mergeable_list_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_items = a.get_map("state").get_mergeable_list("items").unwrap();
-    let b_items = b.get_map("state").get_mergeable_list("items").unwrap();
+    let a_items = a.get_map("state").ensure_mergeable_list("items").unwrap();
+    let b_items = b.get_map("state").ensure_mergeable_list("items").unwrap();
     assert_eq!(a_items.id(), b_items.id());
 
     a_items.insert(0, "A").unwrap();
@@ -117,16 +117,16 @@ fn loro_map_get_mergeable_list_through_public_api() {
     assert_eq!(b.get_deep_value().to_json_value(), value);
 }
 
-/// `LoroMap::get_mergeable_text` returns a working `LoroText` whose concurrent edits
+/// `LoroMap::ensure_mergeable_text` returns a working `LoroText` whose concurrent edits
 /// both survive after sync.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_text_through_public_api() {
+fn loro_map_ensure_mergeable_text_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_notes = a.get_map("state").get_mergeable_text("notes").unwrap();
-    let b_notes = b.get_map("state").get_mergeable_text("notes").unwrap();
+    let a_notes = a.get_map("state").ensure_mergeable_text("notes").unwrap();
+    let b_notes = b.get_map("state").ensure_mergeable_text("notes").unwrap();
     assert_eq!(a_notes.id(), b_notes.id());
 
     a_notes.insert(0, "A").unwrap();
@@ -143,23 +143,23 @@ fn loro_map_get_mergeable_text_through_public_api() {
     );
 }
 
-/// `LoroMap::get_mergeable_movable_list` returns a working `LoroMovableList` whose
+/// `LoroMap::ensure_mergeable_movable_list` returns a working `LoroMovableList` whose
 /// concurrent first-create from two peers resolves to the same deterministic cid,
 /// and inserts on both peers survive after sync. Also exercises the `mov` operation
 /// on the returned handler to confirm the full public surface forwards correctly.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_movable_list_through_public_api() {
+fn loro_map_ensure_mergeable_movable_list_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
     let a_items = a
         .get_map("state")
-        .get_mergeable_movable_list("items")
+        .ensure_mergeable_movable_list("items")
         .unwrap();
     let b_items = b
         .get_map("state")
-        .get_mergeable_movable_list("items")
+        .ensure_mergeable_movable_list("items")
         .unwrap();
     assert_eq!(
         a_items.id(),
@@ -195,7 +195,7 @@ fn loro_map_get_mergeable_movable_list_through_public_api() {
     let pre_move = a.get_deep_value().to_json_value();
     let a_items_again = a
         .get_map("state")
-        .get_mergeable_movable_list("items")
+        .ensure_mergeable_movable_list("items")
         .unwrap();
     a_items_again.mov(0, a_items_again.len() - 1).unwrap();
     a.commit();
@@ -206,17 +206,17 @@ fn loro_map_get_mergeable_movable_list_through_public_api() {
     );
 }
 
-/// `LoroMap::get_mergeable_tree` returns a working `LoroTree` whose nodes are
+/// `LoroMap::ensure_mergeable_tree` returns a working `LoroTree` whose nodes are
 /// reachable through the deep value and whose tree operations forward correctly
 /// through the public API.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_tree_through_public_api() {
+fn loro_map_ensure_mergeable_tree_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_tree = a.get_map("state").get_mergeable_tree("hierarchy").unwrap();
-    let b_tree = b.get_map("state").get_mergeable_tree("hierarchy").unwrap();
+    let a_tree = a.get_map("state").ensure_mergeable_tree("hierarchy").unwrap();
+    let b_tree = b.get_map("state").ensure_mergeable_tree("hierarchy").unwrap();
     assert_eq!(
         a_tree.id(),
         b_tree.id(),
@@ -250,15 +250,15 @@ fn loro_map_get_mergeable_tree_through_public_api() {
 
 /// Kind change through the public API: register one mergeable kind under a key,
 /// then ask for another. Requesting a different kind is a deliberate kind change
-/// that rewrites the parent map marker, so the public `LoroMap::get_mergeable_*`
+/// that rewrites the parent map marker, so the public `LoroMap::ensure_mergeable_*`
 /// wrappers succeed and the active child switches to the newly requested kind.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_kind_change_through_public_api() {
+fn loro_map_ensure_mergeable_kind_change_through_public_api() {
     let d = doc(1);
     let root = d.get_map("state");
 
-    let text = root.get_mergeable_text("field").unwrap();
+    let text = root.ensure_mergeable_text("field").unwrap();
     text.insert(0, "hello").unwrap();
     d.commit();
     assert_eq!(
@@ -267,7 +267,7 @@ fn loro_map_get_mergeable_kind_change_through_public_api() {
     );
 
     // Switch the kind: this rewrites the marker to Map.
-    let map = root.get_mergeable_map("field").unwrap();
+    let map = root.ensure_mergeable_map("field").unwrap();
     map.insert("k", 1).unwrap();
     d.commit();
     assert_eq!(
@@ -286,7 +286,7 @@ fn loro_map_get_mergeable_kind_change_through_public_api() {
 fn loro_get_by_path_round_trips_mergeable_final_child() {
     let d = doc(1);
     let root = d.get_map("state");
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
 
     let path = d
         .get_path_to_container(&counter.id())
@@ -317,8 +317,8 @@ fn loro_get_by_path_round_trips_mergeable_final_child() {
 fn loro_get_by_path_round_trips_nested_mergeable_child() {
     let d = doc(1);
     let root = d.get_map("state");
-    let profile = root.get_mergeable_map("profile").unwrap();
-    let counter = profile.get_mergeable_counter("revision").unwrap();
+    let profile = root.ensure_mergeable_map("profile").unwrap();
+    let counter = profile.ensure_mergeable_counter("revision").unwrap();
     counter.increment(7.0).unwrap();
     d.commit();
 
@@ -378,7 +378,7 @@ fn loro_has_container_for_mergeable_cid_through_public_api() {
         "has_container must report false for an unwritten mergeable cid"
     );
 
-    let counter = root.get_mergeable_counter("revision").unwrap();
+    let counter = root.ensure_mergeable_counter("revision").unwrap();
     counter.increment(1.0).unwrap();
     assert_eq!(counter.id(), unwritten_cid);
     assert!(
@@ -387,11 +387,11 @@ fn loro_has_container_for_mergeable_cid_through_public_api() {
     );
 }
 
-/// `get_mergeable_*` must not silently overwrite a non-mergeable value through the public API:
+/// `ensure_mergeable_*` must not silently overwrite a non-mergeable value through the public API:
 /// a scalar already at the key makes the call an `ArgErr` and leaves the value in place.
 #[test]
 #[parallel]
-fn loro_map_get_mergeable_rejects_overwriting_scalar_through_public_api() {
+fn loro_map_ensure_mergeable_rejects_overwriting_scalar_through_public_api() {
     use loro::LoroError;
 
     let d = doc(1);
@@ -399,8 +399,8 @@ fn loro_map_get_mergeable_rejects_overwriting_scalar_through_public_api() {
     root.insert("field", 5).unwrap();
 
     let err = root
-        .get_mergeable_list("field")
-        .expect_err("get_mergeable over a scalar must error");
+        .ensure_mergeable_list("field")
+        .expect_err("ensure_mergeable over a scalar must error");
     assert!(
         matches!(err, LoroError::ArgErr(_)),
         "expected ArgErr, got {err:?}"


### PR DESCRIPTION
Adds mergeable child containers, which are child containers that you can create under map keys that merge across peers instead of creating two separate containers. Closes loro-dev/loro#759.

```ts
const a = new LoroDoc(), b = new LoroDoc();
a.getMap("state").getMergeableCounter("revision").increment(1);
b.getMap("state").getMergeableCounter("revision").increment(1);
// after sync: one counter == 2, not two conflicting counters
```

They're available as `getMergeable{Counter,Map,List,MovableList,Text,Tree}` on `LoroMap`, in the `loro`, `loro-internal`, and WASM crates.


## Problem

Right now, if two peers each create a child container at the same map key, they end up with two different containers, because the `ContainerID` is derived from the creating op's id. One of them wins and the other peer's edits are stranded on a container nobody looks at. That's a problem any time you want a single shared object regardless of who created it first - a revision counter, a settings sub-map, a shared text body, etc.

## Approach

A mergeable child is a `ContainerID::Root` with a deterministic name derived from `(parent, key, kind)`, in a reserved `"🤝:"` namespace. Both peers compute the same id, so they're talking about the same container.

Which child is "live" is decided by the parent map slot, not by separate bookkeeping. When you call `getMergeable*`, the parent map stores a `"🤝:<kind>"` discriminator string at that key, and the active child is just whatever that key's normal LWW resolves to. Letting the existing map machinery own this gets us a few things mostly for free:

- Delete is just clearing the key (an ordinary `MapSet { value: None }`). No new op types, and no tombstone tracking to keep in sync.
- If two peers pick different kinds for the same key, the map's LWW picks the winner like it would for any value. The loser's container is still reachable by its deterministic name if you ask for that kind again.
- Asking for a different kind under an existing key overwrites the discriminator. The previous kind's contents stick around and come back if you request that kind later.
- Snapshots don't need anything special - the discriminator travels like any other map value. The only thing rebuilt on import is the in-memory parent-edge index.

## Commits

I split this into 6 commits by layer, each one carrying its own tests:

1. `feat(common)` - cid namespace + discriminator encode/parse helpers
2. `feat(internal)` - core mergeable state in `DocState`
3. `feat(internal)` - `get_mergeable_*` handler API
4. `feat(loro)` - public `LoroMap` wrappers
5. `feat(wasm)` - `getMergeable*` bindings
6. `test(fuzz)` - opt-in `mergeable` fuzz surface

There's also a trailing `chore:` commit with the changeset.

## Compatibility

This is all new methods - no existing signatures change, so it shouldn't break anyone. Root names that start with the `"🤝:"` prefix are rejected by `check_root_container_name` so user code can't fabricate one.

## Testing

57 tests across the internal (43), public-API (8), and cid-encoding (6) targets, plus a WASM suite in `mergeable.test.ts` that covers each kind and the subscription-flush invariant from AGENTS.md. There's also an opt-in fuzz target (`cargo +nightly fuzz run mergeable`); the fuzz crate builds with and without the `mergeable` feature.

Between them they cover concurrent same- and different-kind creation, three-peer convergence, delete + recreate, snapshot/update import round-trips, event and path resolution, and `has_container` for mergeable cids.

## AI usage disclosure

Most of the lines in this PR were written by an AI coding assistant (Claude Opus 4.7, primarily). I want to be upfront about that, and equally upfront that the engineering wasn't outsourced. I read every diff and handled every non-trivial engineering decision myself, although I did regularly seek the advice of the agent during the process.

So: the assistant did most of the typing, I did the deciding and the reviewing. I've reviewed the whole change and I stand behind its correctness; treat it as my work and review it as critically as you would anything else.