### PR TITLE
fix: mergeable cid encoding

### DIFF
--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -75,17 +75,14 @@ pub struct CompactId {
 /// The 🤝 ("handshake") sentinel mirrors Loro's `🦜:` brand convention
 /// (`crates/loro-common/src/value.rs::LORO_CONTAINER_ID_PREFIX`) and signals
 /// "two peers agreeing on the same cid." The trailing `:` separates the brand
-/// from the hex-encoded `(parent, key)` payload; the container kind is carried
-/// on the `Root` itself and is not duplicated in the name. Hex characters
-/// (`0-9a-f`) cannot collide with the prefix bytes, so no closing sentinel is
-/// needed. `check_root_container_name` rejects user-created root names that
-/// start with this prefix.
+/// from the flattened path payload; the container kind is carried on the
+/// `Root` itself and is not duplicated in the name. `check_root_container_name`
+/// rejects user-created root names that start with this prefix.
 ///
 /// **Cost of nesting mergeable maps inside mergeable maps**: the payload embeds
-/// `parent_cid_bytes`, which can itself be another mergeable cid. Names grow
-/// roughly linearly with nesting depth × average key length and ride through
-/// every op header, snapshot, and event path. Prefer flatter mergeable maps
-/// over chains of mergeable-inside-mergeable.
+/// the nearest non-mergeable map ancestor once, followed by escaped map keys.
+/// Names grow linearly with nesting depth × average key length and ride through
+/// every op header, snapshot, and event path.
 pub const MERGEABLE_NAMESPACE_PREFIX: &str = "🤝:";
 
 fn write_len_prefixed_segment(out: &mut Vec<u8>, bytes: &[u8]) {
@@ -93,97 +90,246 @@ fn write_len_prefixed_segment(out: &mut Vec<u8>, bytes: &[u8]) {
     out.extend_from_slice(bytes);
 }
 
-/// Append a `(leb128 length, bytes)` segment to `out` as a sequence of lowercase hex chars,
-/// without going through an intermediate `Vec<u8>` buffer. Used by [`ContainerID::new_mergeable`]
-/// on the hot path so each mergeable cid construction skips two allocations (the encoded
-/// payload buffer and the separate hex string).
-fn push_len_prefixed_segment_hex(out: &mut String, bytes: &[u8]) {
-    let mut len_buf = [0u8; 10];
-    let mut writer = &mut len_buf[..];
-    let writer_start_len = writer.len();
-    leb128::write::unsigned(&mut writer, bytes.len() as u64).unwrap();
-    let len_bytes_written = writer_start_len - writer.len();
-    push_hex_bytes(out, &len_buf[..len_bytes_written]);
-    push_hex_bytes(out, bytes);
-}
-
-fn push_hex_bytes(out: &mut String, bytes: &[u8]) {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    out.reserve(bytes.len() * 2);
-    for &byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
+fn push_mergeable_escaped(out: &mut String, segment: &str) {
+    for ch in segment.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '>' => out.push_str("\\>"),
+            '/' => out.push_str("\\s"),
+            '\0' => out.push_str("\\0"),
+            _ => out.push(ch),
+        }
     }
 }
 
-fn read_len_prefixed_segment(input: &mut &[u8]) -> Option<Vec<u8>> {
-    let len = leb128::read::unsigned(input).ok()? as usize;
-    if input.len() < len {
-        return None;
-    }
-    let (segment, rest) = input.split_at(len);
-    *input = rest;
-    Some(segment.to_vec())
-}
-
-/// Fast structural check for a mergeable cid name. Returns `Some(())` if `name` starts with the
-/// mergeable namespace prefix and the hex payload decodes into exactly two length-prefixed
-/// segments (`parent_bytes`, `key_bytes`) with a parseable parent and a UTF-8 key.
-///
-/// Used by [`ContainerID::is_mergeable`]. The prefix check short-circuits non-mergeable names
-/// without allocating; for actual mergeable names we pay one `Vec` allocation sized to the
-/// decoded payload (small — recursively-encoded parent + utf8 key) and the recursive parent
-/// `ContainerID::try_from_bytes`.
-fn validate_mergeable_payload(name: &str) -> Option<()> {
-    let payload = name.strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
-    let decoded = hex_decode(payload)?;
-    let mut input = decoded.as_slice();
-    let parent_len = leb128::read::unsigned(&mut input).ok()? as usize;
-    if input.len() < parent_len {
-        return None;
-    }
-    let (parent_bytes, rest) = input.split_at(parent_len);
-    input = rest;
-    let key_len = leb128::read::unsigned(&mut input).ok()? as usize;
-    if input.len() != key_len {
-        return None;
-    }
-    let key_bytes = input;
-    std::str::from_utf8(key_bytes).ok()?;
-    ContainerID::try_from_bytes(parent_bytes).ok()?;
-    Some(())
-}
-
-#[cfg(test)]
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
-}
-
-fn hex_decode(s: &str) -> Option<Vec<u8>> {
-    fn value(byte: u8) -> Option<u8> {
-        match byte {
-            b'0'..=b'9' => Some(byte - b'0'),
-            b'a'..=b'f' => Some(byte - b'a' + 10),
-            b'A'..=b'F' => Some(byte - b'A' + 10),
-            _ => None,
+fn decode_mergeable_segment(segment: &str) -> Option<String> {
+    let mut out = String::with_capacity(segment.len());
+    let mut chars = segment.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                let escaped = chars.next()?;
+                match escaped {
+                    '\\' => out.push('\\'),
+                    '>' => out.push('>'),
+                    's' => out.push('/'),
+                    '0' => out.push('\0'),
+                    _ => return None,
+                }
+            }
+            '/' | '\0' => return None,
+            _ => out.push(ch),
         }
     }
 
-    if !s.len().is_multiple_of(2) {
+    Some(out)
+}
+
+fn split_mergeable_payload(payload: &str) -> Option<Vec<String>> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut chars = payload.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                let escaped = chars.next()?;
+                match escaped {
+                    '\\' => current.push('\\'),
+                    '>' => current.push('>'),
+                    's' => current.push('/'),
+                    '0' => current.push('\0'),
+                    _ => return None,
+                }
+            }
+            '>' => {
+                segments.push(current);
+                current = String::new();
+            }
+            '/' | '\0' => return None,
+            _ => current.push(ch),
+        }
+    }
+    segments.push(current);
+    Some(segments)
+}
+
+fn find_last_mergeable_separator(payload: &str) -> Option<usize> {
+    let mut last = None;
+    let mut escaped = false;
+    for (idx, ch) in payload.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '>' => last = Some(idx),
+            _ => {}
+        }
+    }
+
+    if escaped {
+        None
+    } else {
+        last
+    }
+}
+
+fn push_u64_base36(out: &mut String, mut value: u64) {
+    const DIGITS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    if value == 0 {
+        out.push('0');
+        return;
+    }
+
+    let mut buf = [0u8; 13];
+    let mut idx = buf.len();
+    while value > 0 {
+        idx -= 1;
+        buf[idx] = DIGITS[(value % 36) as usize];
+        value /= 36;
+    }
+
+    out.push_str(std::str::from_utf8(&buf[idx..]).unwrap());
+}
+
+fn push_i32_base36(out: &mut String, value: i32) {
+    if value < 0 {
+        out.push('-');
+    }
+    let magnitude = if value < 0 {
+        (-(i64::from(value))) as u64
+    } else {
+        value as u64
+    };
+    push_u64_base36(out, magnitude);
+}
+
+fn parse_base36_digit(byte: u8) -> Option<u64> {
+    match byte {
+        b'0'..=b'9' => Some(u64::from(byte - b'0')),
+        b'a'..=b'z' => Some(u64::from(byte - b'a' + 10)),
+        _ => None,
+    }
+}
+
+fn parse_u64_base36(s: &str) -> Option<u64> {
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() > 1 && s.starts_with('0') {
         return None;
     }
 
-    let mut out = Vec::with_capacity(s.len() / 2);
-    for pair in s.as_bytes().chunks_exact(2) {
-        out.push((value(pair[0])? << 4) | value(pair[1])?);
+    let mut value = 0u64;
+    for byte in s.bytes() {
+        value = value.checked_mul(36)?;
+        value = value.checked_add(parse_base36_digit(byte)?)?;
     }
-    Some(out)
+    Some(value)
+}
+
+fn parse_i32_base36(s: &str) -> Option<i32> {
+    if let Some(rest) = s.strip_prefix('-') {
+        let value = parse_u64_base36(rest)?;
+        if value == 0 {
+            return None;
+        }
+        let signed = -(i64::try_from(value).ok()?);
+        i32::try_from(signed).ok()
+    } else {
+        let value = parse_u64_base36(s)?;
+        i32::try_from(value).ok()
+    }
+}
+
+fn parse_mergeable_base_parent(segment: &str) -> Option<ContainerID> {
+    let mut chars = segment.chars();
+    match chars.next()? {
+        '$' => {
+            let name = &segment['$'.len_utf8()..];
+            if !check_root_container_name(name) {
+                return None;
+            }
+            Some(ContainerID::Root {
+                name: name.into(),
+                container_type: ContainerType::Map,
+            })
+        }
+        '@' => {
+            let rest = &segment['@'.len_utf8()..];
+            let (peer, counter) = rest.split_once(':')?;
+            Some(ContainerID::Normal {
+                peer: parse_u64_base36(peer)?,
+                counter: parse_i32_base36(counter)?,
+                container_type: ContainerType::Map,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn validate_mergeable_payload(payload: &str) -> Option<()> {
+    let segments = split_mergeable_payload(payload)?;
+    if segments.len() < 2 {
+        return None;
+    }
+
+    parse_mergeable_base_parent(&segments[0])?;
+    Some(())
+}
+
+fn parse_mergeable_payload(payload: &str) -> Option<(ContainerID, String)> {
+    validate_mergeable_payload(payload)?;
+    let separator = find_last_mergeable_separator(payload)?;
+    let parent_payload = &payload[..separator];
+    let key = decode_mergeable_segment(&payload[separator + '>'.len_utf8()..])?;
+
+    let parent = if find_last_mergeable_separator(parent_payload).is_some() {
+        ContainerID::Root {
+            name: format!("{MERGEABLE_NAMESPACE_PREFIX}{parent_payload}").into(),
+            container_type: ContainerType::Map,
+        }
+    } else {
+        let parent_segment = decode_mergeable_segment(parent_payload)?;
+        parse_mergeable_base_parent(&parent_segment)?
+    };
+
+    Some((parent, key))
+}
+
+fn mergeable_payload_for_parent(parent: &ContainerID) -> Option<&str> {
+    let ContainerID::Root {
+        name,
+        container_type: ContainerType::Map,
+    } = parent
+    else {
+        return None;
+    };
+    let payload = name.as_str().strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
+    validate_mergeable_payload(payload)?;
+    Some(payload)
+}
+
+fn push_mergeable_parent(out: &mut String, parent: &ContainerID) {
+    if let Some(payload) = mergeable_payload_for_parent(parent) {
+        out.push_str(payload);
+        return;
+    }
+
+    match parent {
+        ContainerID::Root { name, .. } => {
+            out.push('$');
+            push_mergeable_escaped(out, name.as_str());
+        }
+        ContainerID::Normal { peer, counter, .. } => {
+            out.push('@');
+            push_u64_base36(out, *peer);
+            out.push(':');
+            push_i32_base36(out, *counter);
+        }
+    }
 }
 
 /// Return whether the given name is a valid root container name.
@@ -846,34 +992,39 @@ mod container {
 
         /// Create a mergeable container ID for the given parent, key, and container type.
         ///
-        /// The cid is a Root container with a reserved namespace prefix and a hex-encoded
-        /// `(parent, key)` payload, so two peers calling this with the same arguments produce
-        /// the identical `ContainerID`.
+        /// The cid is a Root container with a reserved namespace prefix and a flattened
+        /// map-path payload, so two peers calling this with the same arguments produce the
+        /// identical `ContainerID`.
         ///
-        /// The container kind is intentionally *not* hex-encoded into the name: it already
+        /// The container kind is intentionally *not* encoded into the name: it already
         /// lives in `ContainerID::Root::container_type`, so encoding it twice would waste two
-        /// hex chars per cid, and `ContainerID` equality already keeps two `(parent, key)`
+        /// bytes per cid, and `ContainerID` equality already keeps two `(parent, key)`
         /// mergeable cids of different kinds distinct.
         ///
-        /// Hot path: `MapHandler::values` / `for_each` / Map diff emission can call this once
-        /// per active mergeable child per read, so the body writes the name string directly
-        /// instead of materializing an intermediate `Vec` for the encoded payload, a separate
-        /// hex `String`, and a `format!` concatenation.
+        /// Only maps can be mergeable parents. The encoded payload records the nearest
+        /// non-mergeable map ancestor (`$root-name` or `@peer:counter`) once, then appends
+        /// escaped map keys separated by `>`. This keeps nested mergeable map names linear
+        /// in path length instead of recursively embedding the full parent cid.
         pub fn new_mergeable(
             parent: &ContainerID,
             key: &str,
             container_type: ContainerType,
         ) -> Self {
-            let parent_bytes = parent.to_bytes();
-            let key_bytes = key.as_bytes();
-            // Bound generously: leb128 of either length fits in 10 bytes; each payload byte
-            // produces 2 hex chars.
-            let cap = MERGEABLE_NAMESPACE_PREFIX.len()
-                + (parent_bytes.len() + key_bytes.len() + 20) * 2;
+            assert_eq!(
+                parent.container_type(),
+                ContainerType::Map,
+                "mergeable child parent must be a map"
+            );
+            let parent_len_hint = match parent {
+                ContainerID::Root { name, .. } => name.len(),
+                ContainerID::Normal { .. } => 24,
+            };
+            let cap = MERGEABLE_NAMESPACE_PREFIX.len() + parent_len_hint + key.len() + 16;
             let mut name = String::with_capacity(cap);
             name.push_str(MERGEABLE_NAMESPACE_PREFIX);
-            push_len_prefixed_segment_hex(&mut name, &parent_bytes);
-            push_len_prefixed_segment_hex(&mut name, key_bytes);
+            push_mergeable_parent(&mut name, parent);
+            name.push('>');
+            push_mergeable_escaped(&mut name, key);
 
             Self::Root {
                 name: name.into(),
@@ -885,20 +1036,21 @@ mod container {
         /// `new_mergeable`).
         ///
         /// A Root whose name merely starts with the reserved mergeable prefix but does not
-        /// decode to a valid `(parent, key)` payload is an ordinary root, not a mergeable
-        /// container. The check is structural; a fabricated `"🤝:not-valid-hex"` Root is not
+        /// decode to a valid path payload is an ordinary root, not a mergeable
+        /// container. The check is structural; a fabricated `"🤝:not-valid"` Root is not
         /// treated as mergeable.
         ///
         /// Constant-time short-circuit when the name doesn't start with the mergeable prefix
-        /// (most container ids). For names that do match the prefix, runs one `Vec` allocation
-        /// for the hex decode plus a recursive `ContainerID::try_from_bytes` on the parent
-        /// segment — cheaper than `parse_mergeable` (which additionally allocates a `String`
-        /// for the key) but not free.
+        /// (most container ids). For names that do match the prefix, validates segment
+        /// escaping and the compact base-parent encoding.
         pub fn is_mergeable(&self) -> bool {
             let Self::Root { name, .. } = self else {
                 return false;
             };
-            validate_mergeable_payload(name).is_some()
+            name.as_str()
+                .strip_prefix(MERGEABLE_NAMESPACE_PREFIX)
+                .and_then(validate_mergeable_payload)
+                .is_some()
         }
 
         /// Decode a mergeable container ID back into its `(parent, key, container_type)` components.
@@ -915,15 +1067,7 @@ mod container {
                 return None;
             };
             let payload = name.strip_prefix(MERGEABLE_NAMESPACE_PREFIX)?;
-            let decoded = hex_decode(payload)?;
-            let mut input = decoded.as_slice();
-            let parent_bytes = read_len_prefixed_segment(&mut input)?;
-            let key_bytes = read_len_prefixed_segment(&mut input)?;
-            if !input.is_empty() {
-                return None;
-            }
-            let key = String::from_utf8(key_bytes).ok()?;
-            let parent = ContainerID::try_from_bytes(&parent_bytes).ok()?;
+            let (parent, key) = parse_mergeable_payload(payload)?;
             Some((parent, key, *container_type))
         }
     }
@@ -1176,23 +1320,23 @@ mod test {
 
     #[test]
     fn is_mergeable_rejects_prefix_only_roots() {
-        let prefix_only = ContainerID::Root {
-            name: "🤝:abc".into(),
+        let missing_key = ContainerID::Root {
+            name: "🤝:$state".into(),
             container_type: ContainerType::Map,
         };
         assert!(
-            !prefix_only.is_mergeable(),
-            "prefix-only root must not be mergeable"
+            !missing_key.is_mergeable(),
+            "payload without a key segment must not be mergeable"
         );
-        assert!(prefix_only.parse_mergeable().is_none());
+        assert!(missing_key.parse_mergeable().is_none());
 
-        let bad_hex = ContainerID::Root {
-            name: "🤝:not-valid-hex".into(),
+        let bad_escape = ContainerID::Root {
+            name: "🤝:$state>not\\xvalid".into(),
             container_type: ContainerType::Map,
         };
         assert!(
-            !bad_hex.is_mergeable(),
-            "non-hex payload must not be mergeable"
+            !bad_escape.is_mergeable(),
+            "unknown escapes in the payload must not be mergeable"
         );
 
         let parent = ContainerID::new_root("state", ContainerType::Map);
@@ -1203,50 +1347,33 @@ mod test {
         );
     }
 
-    /// A `🤝:` payload can be valid hex with a well-formed len-prefixed structure, yet still carry
-    /// a parent segment whose bytes do not decode to a `ContainerID`. `parse_mergeable` returns
-    /// `Option`, so such input must yield `None`, never a panic from an internal
-    /// `ContainerID::from_bytes` unwrap.
+    /// A `🤝:` payload can be malformed in several ways. `parse_mergeable` returns
+    /// `Option`, so such input must yield `None`, never panic.
     #[test]
-    fn parse_mergeable_rejects_undecodable_parent_bytes() {
-        // Hand-encode a payload whose parent segment is empty. An empty byte slice is a
-        // valid len-prefixed segment but `ContainerID::try_from_bytes(&[])` is an error.
-        let mut encoded = Vec::new();
-        crate::write_len_prefixed_segment(&mut encoded, &[]); // empty parent bytes
-        crate::write_len_prefixed_segment(&mut encoded, b"key");
-
-        let name = format!(
-            "{}{}",
-            crate::MERGEABLE_NAMESPACE_PREFIX,
-            crate::hex_encode(&encoded)
-        );
-        let cid = ContainerID::Root {
-            name: name.into(),
-            container_type: ContainerType::Map,
-        };
-
-        assert_eq!(
-            cid.parse_mergeable(),
-            None,
-            "undecodable parent bytes must reject, not panic"
-        );
-        assert!(!cid.is_mergeable());
-
-        // A parent segment of arbitrary garbage bytes must also reject rather than panic.
-        let mut encoded = Vec::new();
-        crate::write_len_prefixed_segment(&mut encoded, &[0xff, 0xff, 0xff]);
-        crate::write_len_prefixed_segment(&mut encoded, b"key");
-
-        let name = format!(
-            "{}{}",
-            crate::MERGEABLE_NAMESPACE_PREFIX,
-            crate::hex_encode(&encoded)
-        );
-        let cid = ContainerID::Root {
-            name: name.into(),
-            container_type: ContainerType::Map,
-        };
-        assert_eq!(cid.parse_mergeable(), None);
+    fn parse_mergeable_rejects_malformed_path_payloads() {
+        for name in [
+            "🤝:",
+            "🤝:$>key",
+            "🤝:%state>key",
+            "🤝:@1>key",
+            "🤝:@:1>key",
+            "🤝:@1:zzzzzzzzzzzzzz>key",
+            "🤝:@Z:0>key",
+            "🤝:@001:0>key",
+            "🤝:@1:00>key",
+            "🤝:@1:-0>key",
+            "🤝:$state>dangling\\",
+            "🤝:$state>unknown\\xescape",
+            "🤝:$state>raw/slash",
+            "🤝:$state>raw\0nul",
+        ] {
+            let cid = ContainerID::Root {
+                name: name.into(),
+                container_type: ContainerType::Map,
+            };
+            assert_eq!(cid.parse_mergeable(), None, "payload {name:?}");
+            assert!(!cid.is_mergeable(), "payload {name:?}");
+        }
     }
 
     #[test]

--- a/crates/loro-common/src/lib.rs
+++ b/crates/loro-common/src/lib.rs
@@ -125,32 +125,22 @@ fn decode_mergeable_segment(segment: &str) -> Option<String> {
     Some(out)
 }
 
-fn split_mergeable_payload(payload: &str) -> Option<Vec<String>> {
-    let mut segments = Vec::new();
-    let mut current = String::new();
-    let mut chars = payload.chars();
-    while let Some(ch) = chars.next() {
+fn find_first_mergeable_separator(payload: &str) -> Option<usize> {
+    let mut escaped = false;
+    for (idx, ch) in payload.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
         match ch {
-            '\\' => {
-                let escaped = chars.next()?;
-                match escaped {
-                    '\\' => current.push('\\'),
-                    '>' => current.push('>'),
-                    's' => current.push('/'),
-                    '0' => current.push('\0'),
-                    _ => return None,
-                }
-            }
-            '>' => {
-                segments.push(current);
-                current = String::new();
-            }
-            '/' | '\0' => return None,
-            _ => current.push(ch),
+            '\\' => escaped = true,
+            '>' => return Some(idx),
+            _ => {}
         }
     }
-    segments.push(current);
-    Some(segments)
+
+    None
 }
 
 fn find_last_mergeable_separator(payload: &str) -> Option<usize> {
@@ -271,12 +261,61 @@ fn parse_mergeable_base_parent(segment: &str) -> Option<ContainerID> {
 }
 
 fn validate_mergeable_payload(payload: &str) -> Option<()> {
-    let segments = split_mergeable_payload(payload)?;
-    if segments.len() < 2 {
+    let separator = find_first_mergeable_separator(payload)?;
+    validate_mergeable_base_parent(&payload[..separator])?;
+    validate_mergeable_key_path(&payload[separator + '>'.len_utf8()..])
+}
+
+fn validate_mergeable_base_parent(segment: &str) -> Option<()> {
+    match segment.as_bytes().first().copied()? {
+        b'$' => validate_mergeable_root_base_parent(&segment['$'.len_utf8()..]),
+        b'@' => validate_mergeable_normal_base_parent(&segment['@'.len_utf8()..]),
+        _ => None,
+    }
+}
+
+fn validate_mergeable_root_base_parent(name: &str) -> Option<()> {
+    if name.is_empty() || name.starts_with(MERGEABLE_NAMESPACE_PREFIX) {
         return None;
     }
 
-    parse_mergeable_base_parent(&segments[0])?;
+    let mut chars = name.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => match chars.next()? {
+                '\\' | '>' => {}
+                // Root container names cannot contain slash or NUL after decoding.
+                's' | '0' => return None,
+                _ => return None,
+            },
+            '/' | '\0' => return None,
+            _ => {}
+        }
+    }
+
+    Some(())
+}
+
+fn validate_mergeable_normal_base_parent(segment: &str) -> Option<()> {
+    let (peer, counter) = segment.split_once(':')?;
+    parse_u64_base36(peer)?;
+    parse_i32_base36(counter)?;
+    Some(())
+}
+
+fn validate_mergeable_key_path(path: &str) -> Option<()> {
+    let mut chars = path.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => match chars.next()? {
+                '\\' | '>' | 's' | '0' => {}
+                _ => return None,
+            },
+            '/' | '\0' => return None,
+            _ => {}
+        }
+    }
+
     Some(())
 }
 
@@ -1362,6 +1401,8 @@ mod test {
             "🤝:@001:0>key",
             "🤝:@1:00>key",
             "🤝:@1:-0>key",
+            "🤝:$root\\sname>key",
+            "🤝:$root\\0name>key",
             "🤝:$state>dangling\\",
             "🤝:$state>unknown\\xescape",
             "🤝:$state>raw/slash",

--- a/crates/loro-internal/docs/mergeable-container-id.md
+++ b/crates/loro-internal/docs/mergeable-container-id.md
@@ -1,0 +1,87 @@
+# Mergeable Container ID Encoding
+
+Mergeable child containers are represented as synthetic `ContainerID::Root`
+values. The root name is internal and starts with the reserved namespace prefix:
+
+```text
+🤝:<payload>
+```
+
+The child container type is not encoded in `<payload>`. It is carried by
+`ContainerID::Root.container_type`, exactly like ordinary root containers.
+
+## Payload
+
+`<payload>` is a flattened map path:
+
+```text
+payload = base-parent ">" key-1 ">" key-2 ...
+```
+
+There is no version byte in this format. It replaces the previous unpublished
+encoding.
+
+`<base-parent>` is the nearest non-mergeable map ancestor:
+
+```text
+$<escaped-root-name>
+@<peer-base36>:<counter-base36>
+```
+
+`$` means the base parent is a root map. The rest of the segment is the escaped
+root name. `@` means the base parent is a normal op-created map. The peer id and
+counter are canonical lowercase base36 encoded to keep the payload compact.
+Leading zeroes, uppercase digits, and `-0` are rejected by the parser because
+`new_mergeable` never emits them.
+
+Every following segment is one escaped map key. Intermediate mergeable parents
+are always maps, so their type is omitted. The final container's type is the
+`Root.container_type` field.
+
+For example:
+
+```text
+Root map "state", key "note-1", child map:
+🤝:$state>note-1        with Root.container_type = Map
+
+Nested key "body" under that mergeable map, child text:
+🤝:$state>note-1>body   with Root.container_type = Text
+```
+
+Parsing `🤝:$state>note-1>body` as a `Text` returns:
+
+```text
+parent = Root("🤝:$state>note-1", Map)
+key = "body"
+container_type = Text
+```
+
+This keeps nesting growth linear in the total path length. It does not embed the
+full serialized parent cid at each level.
+
+## Escaping
+
+Segments are escaped before being placed in the synthetic root name:
+
+```text
+\  -> \\
+>  -> \>
+/  -> \s
+NUL -> \0
+```
+
+`>` is the only structural delimiter. `\` introduces an escape. `/` and NUL are
+also escaped so synthetic root names keep the same safety property as the old
+hex encoding: they do not contain raw slash or raw NUL bytes.
+
+The parser rejects dangling backslashes, unknown escapes, raw slash, and raw NUL.
+This prevents malformed synthetic roots from being treated as mergeable ids.
+
+## Marker Relationship
+
+The parent map slot still stores the binary mergeable marker. The marker binds
+`(parent container id, key, child type)` through its digest and is not changed by
+this encoding.
+
+The root name encoding only controls the deterministic identity of the child
+container. Visibility remains controlled by the parent map slot marker.

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -40,7 +40,7 @@ struct ArenaContainers {
     /// Subset of `root_c_idx` containing only top-level (non-mergeable) roots. This is the
     /// list user-facing APIs enumerate (`preferred_root_containers`, `get_value`,
     /// `get_deep_value`, jsonpath, ...). Keeping it pre-filtered means those paths do
-    /// not pay a per-mergeable `is_mergeable()` (and its hex-decode) on every call.
+    /// not pay a per-mergeable `is_mergeable()` parse on every call.
     top_level_root_c_idx: Vec<ContainerIdx>,
     /// Optional resolver used when querying parent for a container that has not been registered yet.
     /// If set, `get_parent` will try this resolver to lazily fetch and register the parent.
@@ -115,8 +115,8 @@ impl ArenaContainers {
         self.container_idx_to_id.push(id.clone());
         let idx = ContainerIdx::from_index_and_type(idx as u32, id.container_type());
         self.container_id_to_idx.insert(id.clone(), idx);
-        // Resolve the cid's kind once. `is_mergeable` is non-trivial (it hex-decodes the cid
-        // name), so we avoid calling it twice on the same id.
+        // Resolve the cid's kind once. `is_mergeable` is non-trivial for mergeable names,
+        // so we avoid calling it twice on the same id.
         let mergeable_parts = if id.is_root() {
             id.parse_mergeable()
         } else {

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -4496,9 +4496,9 @@ impl MapHandler {
 
     /// Ensure a mergeable Map child exists under `key` and return its handler.
     ///
-    /// Prefer to avoid mergeable maps nested directly inside other mergeable maps: mergeable cids
-    /// embed their parent's cid bytes, so deep nesting inflates cid size (and every op/snapshot
-    /// reference to it). See [`MERGEABLE_NAMESPACE_PREFIX`](loro_common::MERGEABLE_NAMESPACE_PREFIX).
+    /// Prefer to avoid very deep mergeable-map chains: mergeable cids encode their flattened
+    /// logical path, so cid size still grows with depth and rides through every op/snapshot
+    /// reference to it. See [`MERGEABLE_NAMESPACE_PREFIX`](loro_common::MERGEABLE_NAMESPACE_PREFIX).
     pub fn ensure_mergeable_map(&self, key: &str) -> LoroResult<MapHandler> {
         self.ensure_mergeable_container(key, MapHandler::new_detached())
     }

--- a/crates/loro-internal/tests/mergeable_cid_encoding.rs
+++ b/crates/loro-internal/tests/mergeable_cid_encoding.rs
@@ -81,6 +81,17 @@ fn parse_mergeable_rejects_malformed_payloads() {
     };
     assert!(dangling.parse_mergeable().is_none());
 
+    for name in ["🤝:$root\\sname>key", "🤝:$root\\0name>key"] {
+        let invalid_root_name = ContainerID::Root {
+            name: name.into(),
+            container_type: ContainerType::Counter,
+        };
+        assert!(
+            invalid_root_name.parse_mergeable().is_none(),
+            "root base parent must reject decoded slash/NUL: {name:?}"
+        );
+    }
+
     for name in [
         "🤝:@Z:0>key",
         "🤝:@001:0>key",

--- a/crates/loro-internal/tests/mergeable_cid_encoding.rs
+++ b/crates/loro-internal/tests/mergeable_cid_encoding.rs
@@ -1,10 +1,10 @@
 //! Encoding and decoding of mergeable container ids.
 
-use loro_internal::ContainerType;
-
 #[test]
 #[cfg(feature = "counter")]
 fn mergeable_container_id_roundtrips_parent_key_and_type() {
+    use loro_internal::ContainerType;
+
     let parent = loro_common::ContainerID::new_root("state", ContainerType::Map);
     let key = "field\u{1}with/slash:and:semicolon";
     let cid = loro_common::ContainerID::new_mergeable(&parent, key, ContainerType::Counter);
@@ -39,17 +39,17 @@ fn parse_mergeable_rejects_malformed_payloads() {
     let plain_root = ContainerID::new_root("ordinary", ContainerType::Map);
     assert!(plain_root.parse_mergeable().is_none());
 
-    // Mergeable prefix but invalid hex.
-    let bad_hex = ContainerID::Root {
-        name: "🤝:zzzz".into(),
+    // Mergeable prefix but missing the required key segment.
+    let no_key = ContainerID::Root {
+        name: "🤝:$state".into(),
         container_type: ContainerType::Counter,
     };
     assert!(
-        bad_hex.parse_mergeable().is_none(),
-        "non-hex chars in payload must reject"
+        no_key.parse_mergeable().is_none(),
+        "payload without a key segment must reject"
     );
 
-    // Mergeable prefix, valid hex, but truncated (no segments).
+    // Mergeable prefix, but empty payload.
     let truncated = ContainerID::Root {
         name: "🤝:".into(),
         container_type: ContainerType::Counter,
@@ -59,22 +59,43 @@ fn parse_mergeable_rejects_malformed_payloads() {
         "empty payload must reject"
     );
 
-    // Mergeable prefix, valid hex, but trailing garbage past the (parent, key) segments.
-    let parent = ContainerID::new_root("state", ContainerType::Map);
-    let cid = ContainerID::new_mergeable(&parent, "k", ContainerType::Counter);
-    let mut name = match &cid {
-        ContainerID::Root { name, .. } => name.to_string(),
-        _ => panic!("expected Root"),
-    };
-    name.push_str("ff"); // append one extra byte's worth of hex
-    let with_garbage = ContainerID::Root {
-        name: name.into(),
+    // Unknown escapes, raw slash, and dangling backslash must reject.
+    let malformed = ContainerID::Root {
+        name: "🤝:$state>bad\\xescape".into(),
         container_type: ContainerType::Counter,
     };
     assert!(
-        with_garbage.parse_mergeable().is_none(),
-        "trailing bytes after the (parent, key) segments must reject"
+        malformed.parse_mergeable().is_none(),
+        "unknown escape in payload must reject"
     );
+
+    let raw_slash = ContainerID::Root {
+        name: "🤝:$state>raw/slash".into(),
+        container_type: ContainerType::Counter,
+    };
+    assert!(raw_slash.parse_mergeable().is_none());
+
+    let dangling = ContainerID::Root {
+        name: "🤝:$state>dangling\\".into(),
+        container_type: ContainerType::Counter,
+    };
+    assert!(dangling.parse_mergeable().is_none());
+
+    for name in [
+        "🤝:@Z:0>key",
+        "🤝:@001:0>key",
+        "🤝:@1:00>key",
+        "🤝:@1:-0>key",
+    ] {
+        let non_canonical = ContainerID::Root {
+            name: name.into(),
+            container_type: ContainerType::Counter,
+        };
+        assert!(
+            non_canonical.parse_mergeable().is_none(),
+            "non-canonical base36 payload must reject: {name:?}"
+        );
+    }
 }
 
 /// `LoroDoc::get_map` must reject names in the mergeable namespace at the
@@ -119,17 +140,7 @@ fn mergeable_cid_roundtrips_for_every_container_kind() {
     use loro_common::{ContainerID, ContainerType};
     let parent = ContainerID::new_root("state", ContainerType::Map);
 
-    let mut kinds: Vec<ContainerType> = vec![
-        ContainerType::Map,
-        ContainerType::List,
-        ContainerType::MovableList,
-        ContainerType::Text,
-        ContainerType::Tree,
-    ];
-    #[cfg(feature = "counter")]
-    kinds.push(ContainerType::Counter);
-
-    for kind in kinds {
+    for kind in ContainerType::ALL_TYPES {
         let cid = ContainerID::new_mergeable(&parent, "field", kind);
         assert!(cid.is_mergeable(), "kind {kind:?}: must be mergeable");
         let again = ContainerID::new_mergeable(&parent, "field", kind);
@@ -143,10 +154,10 @@ fn mergeable_cid_roundtrips_for_every_container_kind() {
     }
 }
 
-/// Key encoding is len-prefixed binary, so it must round-trip cleanly for
-/// degenerate inputs: empty, long, embedded NUL, and embedded mergeable
-/// prefix substring. Catches off-by-one and ad-hoc string-split mistakes
-/// in any future decoder change.
+/// Key encoding is escaped path segments, so it must round-trip cleanly for
+/// degenerate inputs: empty, long, delimiters, embedded NUL, and embedded
+/// mergeable prefix substring. Catches off-by-one and ad-hoc string-split
+/// mistakes in any future decoder change.
 #[test]
 fn mergeable_cid_roundtrips_for_degenerate_keys() {
     use loro_common::{ContainerID, ContainerType};
@@ -161,6 +172,9 @@ fn mergeable_cid_roundtrips_for_degenerate_keys() {
         "starts_with_🤝:_prefix",
         "trailing_emoji_🤝:",
         "ascii/slash/looking",
+        "contains>separator",
+        "contains\\backslash",
+        "mixed>\\/\0chars",
     ];
 
     for key in cases {
@@ -173,4 +187,117 @@ fn mergeable_cid_roundtrips_for_degenerate_keys() {
         assert_eq!(decoded_key, key, "key {key:?}: round-trip mismatch");
         assert_eq!(decoded_kind, ContainerType::Map);
     }
+}
+
+#[test]
+fn mergeable_cid_uses_flattened_path_payload() {
+    use loro_common::{ContainerID, ContainerType, MERGEABLE_NAMESPACE_PREFIX};
+
+    let parent = ContainerID::new_root("state", ContainerType::Map);
+    let child = ContainerID::new_mergeable(&parent, "note>1", ContainerType::Map);
+    let grandchild = ContainerID::new_mergeable(&child, "body/slash\\nul\0", ContainerType::Text);
+
+    let name = match &grandchild {
+        ContainerID::Root { name, .. } => name.as_str(),
+        _ => panic!("expected Root"),
+    };
+    assert!(
+        name.starts_with(MERGEABLE_NAMESPACE_PREFIX),
+        "mergeable cid must use the reserved namespace"
+    );
+    assert_eq!(
+        name, "🤝:$state>note\\>1>body\\sslash\\\\nul\\0",
+        "nested mergeable ids must extend the flattened path, not embed parent cid bytes"
+    );
+    assert!(
+        !name.contains('/'),
+        "synthetic root names must not contain raw slash"
+    );
+    assert!(
+        !name.contains('\0'),
+        "synthetic root names must not contain raw NUL"
+    );
+
+    let (decoded_parent, decoded_key, decoded_kind) = grandchild.parse_mergeable().unwrap();
+    assert_eq!(decoded_parent, child);
+    assert_eq!(decoded_key, "body/slash\\nul\0");
+    assert_eq!(decoded_kind, ContainerType::Text);
+}
+
+#[test]
+fn mergeable_cid_roundtrips_normal_base_parent() {
+    use loro_common::{ContainerID, ContainerType, ID};
+
+    let parent = ContainerID::new_normal(
+        ID {
+            peer: u64::MAX,
+            counter: i32::MIN,
+        },
+        ContainerType::Map,
+    );
+    let cid = ContainerID::new_mergeable(&parent, "field", ContainerType::List);
+    let name = match &cid {
+        ContainerID::Root { name, .. } => name.as_str(),
+        _ => panic!("expected Root"),
+    };
+    assert!(
+        name.starts_with("🤝:@3w5e11264sgsf:-zik0zk>"),
+        "normal parent ids should use compact base36 encoding; got {name:?}"
+    );
+
+    let (decoded_parent, decoded_key, decoded_kind) = cid.parse_mergeable().unwrap();
+    assert_eq!(decoded_parent, parent);
+    assert_eq!(decoded_key, "field");
+    assert_eq!(decoded_kind, ContainerType::List);
+}
+
+#[test]
+fn mergeable_cid_roundtrips_escaped_root_base_parent() {
+    use loro_common::{ContainerID, ContainerType};
+
+    let parent = ContainerID::new_root("root>\\name", ContainerType::Map);
+    let cid = ContainerID::new_mergeable(&parent, "field", ContainerType::Tree);
+    let name = match &cid {
+        ContainerID::Root { name, .. } => name.as_str(),
+        _ => panic!("expected Root"),
+    };
+    assert_eq!(name, "🤝:$root\\>\\\\name>field");
+
+    let (decoded_parent, decoded_key, decoded_kind) = cid.parse_mergeable().unwrap();
+    assert_eq!(decoded_parent, parent);
+    assert_eq!(decoded_key, "field");
+    assert_eq!(decoded_kind, ContainerType::Tree);
+}
+
+#[test]
+#[should_panic(expected = "mergeable child parent must be a map")]
+fn mergeable_cid_rejects_non_map_parent() {
+    use loro_common::{ContainerID, ContainerType};
+
+    let parent = ContainerID::new_root("content", ContainerType::Text);
+    let _ = ContainerID::new_mergeable(&parent, "field", ContainerType::Map);
+}
+
+#[test]
+fn nested_mergeable_cid_size_grows_linearly() {
+    use loro_common::{ContainerID, ContainerType};
+
+    let mut cid = ContainerID::new_root("state", ContainerType::Map);
+    let mut sizes = Vec::new();
+    for _ in 0..=8 {
+        cid = ContainerID::new_mergeable(&cid, "k", ContainerType::Map);
+        sizes.push(cid.to_bytes().len());
+    }
+
+    for window in sizes.windows(2) {
+        assert_eq!(
+            window[1] - window[0],
+            2,
+            "each additional one-byte key should add only separator + key bytes; sizes={sizes:?}"
+        );
+    }
+    assert!(
+        sizes[8] < 64,
+        "depth 8 should stay compact with flattened encoding; sizes={sizes:?}"
+    );
 }

--- a/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
+++ b/crates/loro-internal/tests/mergeable_container/events_and_paths.rs
@@ -173,7 +173,7 @@ fn undo_manager_reverts_mergeable_counter_mutation() {
 /// but they are conceptually parented to a regular Map. The top-level root enumeration
 /// (driven by `DocState::preferred_root_containers`, surfaced through
 /// `LoroDoc::get_value`) must NOT include the synthetic mergeable Root — otherwise
-/// the doc would expose a top-level key with a `🤝:...` hex name alongside the real
+/// the doc would expose a top-level key in the `🤝:` namespace alongside the real
 /// roots.
 ///
 /// This guards the `id.is_mergeable()` skip in `preferred_root_containers` against
@@ -195,7 +195,7 @@ fn top_level_root_enumeration_skips_mergeable_roots() {
     assert!(mergeable_cid.is_mergeable());
 
     // `get_value()` returns a Map keyed by top-level root names. The mergeable cid's
-    // synthetic Root name (🤝:<hex>) must NOT appear here.
+    // synthetic Root name must NOT appear here.
     let top_level = doc.get_value().to_json_value();
     let map = top_level
         .as_object()

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3314,9 +3314,9 @@ impl LoroMap {
     /// If the key already holds a non-mergeable value, this throws and leaves
     /// the value unchanged.
     ///
-    /// Prefer to avoid mergeable maps nested directly inside other mergeable maps:
-    /// mergeable cids embed their parent's cid bytes, so deep nesting inflates
-    /// cid size and every op/snapshot reference to it.
+    /// Prefer to avoid very deep mergeable-map chains: mergeable cids encode
+    /// their flattened logical path, so cid size still grows with depth and
+    /// rides through every op/snapshot reference to it.
     #[wasm_bindgen(js_name = "ensureMergeableMap")]
     pub fn ensure_mergeable_map(&self, key: &str) -> JsResult<LoroMap> {
         let handler = self.handler.ensure_mergeable_map(key)?;


### PR DESCRIPTION
## Summary

Replace the unpublished recursive hex mergeable container id payload with a flattened path encoding.

The previous design encoded mergeable child identity by recursively embedding `parent.to_bytes()` in the synthetic root name. When a mergeable map was nested under another mergeable map, that parent cid already contained its own parent payload, so the size grew roughly exponentially. This PR changes the synthetic root name to encode the nearest non-mergeable map parent once, followed by escaped map keys. Nested mergeable cid size is now linear in logical path length.

## Design: Synthetic Root Container ID

A mergeable child container is still represented as a synthetic `ContainerID::Root`:

```text
ContainerID::Root {
  name: "🤝:" + payload,
  container_type: child_container_type,
}
```

The child container type is not encoded in `payload`. It is carried by `Root.container_type`, just like ordinary root containers. This means two mergeable cids with the same parent/key but different child types have the same root name string but remain different `ContainerID` values because `container_type` differs.

There is no version byte in the payload. This replaces an unpublished format, so no old-format decoder is kept.

## Payload Grammar

The payload is a flattened map path:

```text
payload      = base-parent ">" key-segment *( ">" key-segment )
base-parent  = "$" escaped-root-name
             | "@" peer-base36 ":" counter-base36
key-segment  = escaped string segment
```

`base-parent` is the nearest non-mergeable map ancestor:

- `$<escaped-root-name>` means the base parent is a root map.
- `@<peer-base36>:<counter-base36>` means the base parent is a normal op-created map.

Every segment after `base-parent` is one map key. Intermediate mergeable parents are always maps, so their type is omitted. The final container's type is `Root.container_type`.

Example:

```text
Root map "state", key "note-1", child map:
  Root { name: "🤝:$state>note-1", container_type: Map }

Nested key "body" under that mergeable map, child text:
  Root { name: "🤝:$state>note-1>body", container_type: Text }
```

Parsing `Root { name: "🤝:$state>note-1>body", container_type: Text }` returns:

```text
parent = Root { name: "🤝:$state>note-1", container_type: Map }
key = "body"
container_type = Text
```

## Encoding Algorithm

`ContainerID::new_mergeable(parent, key, child_type)` does:

1. Assert `parent.container_type() == Map`. This is a hard release assertion, not only a debug assertion, because the payload omits parent type.
2. Start `name` with `MERGEABLE_NAMESPACE_PREFIX`, currently `🤝:`.
3. Append the parent payload:
   - If `parent` is a valid mergeable map root, reuse its existing payload without re-encoding the full parent cid.
   - Else if `parent` is a root map, append `$` plus the escaped root name.
   - Else if `parent` is a normal map, append `@`, the peer id in canonical lowercase base36, `:`, then the counter in canonical lowercase base36.
4. Append `>`.
5. Append the escaped `key`.
6. Return `ContainerID::Root { name, container_type: child_type }`.

This is the key property that prevents recursive growth: a nested mergeable parent contributes only its already-flattened payload, not serialized parent bytes.

## Escaping Rules

Segments are escaped before being placed in the synthetic root name:

```text
\    -> \\
>    -> \>
/    -> \s
NUL  -> \0
```

`>` is the only structural delimiter. `\` introduces an escape. `/` and NUL are escaped so synthetic root names keep the old safety property that raw slash and raw NUL do not appear in root names.

The parser rejects:

- dangling backslash
- unknown escapes
- raw slash
- raw NUL

Root base-parent names additionally reject decoded slash and decoded NUL, because ordinary root names cannot contain those characters. Key segments may contain slash or NUL through `\s` and `\0`.

## Base36 Rules

Normal op-created map parents use canonical lowercase base36:

```text
@<peer-base36>:<counter-base36>
```

Rules:

- Digits are `0-9a-z` only.
- Uppercase digits are rejected.
- Leading zeroes are rejected except for the literal `0`.
- Negative counters are encoded with a leading `-` followed by the positive magnitude.
- `-0` is rejected.
- Overflow while parsing `u64` peer or `i32` counter rejects the payload.

Examples:

```text
peer = u64::MAX, counter = i32::MIN
@3w5e11264sgsf:-zik0zk
```

## Decoding Algorithm

There are two decoding levels:

- `ContainerID::is_mergeable()` performs structural validation only. It is intentionally allocation-free: it scans for the first unescaped `>`, validates the base-parent segment on borrowed `&str` slices, and then scans the remaining key path for valid escapes/delimiters. It does not build `Vec<String>` or decode the whole path.
- `ContainerID::parse_mergeable()` first runs the same validator, then allocates only the values it must return: the decoded final key string and, when needed, the parent mergeable root name.

`ContainerID::parse_mergeable()` does:

1. Require the id to be `ContainerID::Root`.
2. Strip `MERGEABLE_NAMESPACE_PREFIX`; reject if absent.
3. Validate the payload structure and escaping using the allocation-free validator.
4. Find the last unescaped `>`.
5. Decode the segment after that separator as `key`.
6. Decode the parent:
   - If the prefix before the last separator contains another unescaped `>`, the parent is a mergeable map root:
     `Root { name: "🤝:" + parent_payload, container_type: Map }`.
   - Otherwise decode the single base-parent segment as either a root map (`$...`) or normal map (`@peer:counter`).
7. Return `(parent, key, Root.container_type)`.

A root whose name merely starts with `🤝:` but does not match the grammar is treated as an ordinary root, not as a mergeable container.

## Map Slot Marker Relationship

This PR does not change the map slot marker format.

The parent `LoroMap` slot still stores a compact binary activation marker:

```text
MAGIC[4] + KIND[1] + CRC24(parent_id, key, kind)[3]
```

The marker binds `(parent container id, key, child type)` and controls visibility of the mergeable child under that map key. The synthetic root cid controls deterministic child identity. These two layers remain separate:

- cid payload answers: "which CRDT container is this logical child?"
- map slot marker answers: "is this child currently visible at this key, and which type is active?"

The only remaining `parent.to_bytes()` in this area is inside marker CRC input. That is intentional and is not part of synthetic root name encoding.

## Compatibility

This changes an unpublished mergeable cid payload format before release. Existing public `setContainer` / regular child container identity is unchanged. Existing marker bytes are unchanged.

Old hex/recursive mergeable cid name decoding is intentionally not retained. User-created root names are still rejected if they start with the reserved `🤝:` namespace.

## Tests Added / Updated

Coverage includes:

- Exact flattened payload string for nested mergeable map/text ids.
- Escaping round trips for empty keys, long keys, `>`, `\`, `/`, NUL, and embedded `🤝:` substrings.
- Root base parent round trip, including escaped root names.
- Normal op-created map base parent round trip with peer/counter base36.
- Malformed payload rejection, including invalid escapes, raw slash/NUL, and root base parents that would decode to slash/NUL.
- Non-canonical base36 rejection: uppercase, leading zeroes, and `-0`.
- Non-map parent rejection in `new_mergeable`.
- Linear nested cid size growth.
- Existing mergeable container convergence/path/snapshot/public API behavior.

## Validation

- `rustfmt --check crates/loro-common/src/lib.rs crates/loro-internal/tests/mergeable_cid_encoding.rs`
- `rustfmt --check crates/loro-common/src/lib.rs crates/loro-internal/tests/mergeable_cid_encoding.rs crates/loro-wasm/src/lib.rs crates/loro-internal/tests/mergeable_container/events_and_paths.rs`
- `cargo test -p loro-internal --test mergeable_cid_encoding -- --nocapture`
- `cargo test -p loro-common mergeable -- --nocapture`
- `cargo test -p loro-internal --test mergeable_container -- --nocapture`
- `cargo test -p loro --test mergeable_public_api -- --nocapture`
- Repository grep audit for old hex/recursive mergeable cid encoding terms returned no matches.

Note: full-file `rustfmt --check` on `crates/loro-internal/src/handler.rs` reports pre-existing unrelated formatting differences, so this PR avoids formatting that whole file.