### PR TITLE
[codex] use crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     if: |
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.title, 'chore: release rust crates v')
@@ -25,9 +29,13 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           echo "${{ steps.extract_flags.outputs.EXCLUDED_FLAGS }}"
           cargo install cargo-release


### PR DESCRIPTION
## Summary

- Switch the Rust crates publish workflow from a long-lived `CARGO_REGISTRY_TOKEN` secret to crates.io Trusted Publishing.
- Add the GitHub OIDC permission and `release` environment required for trusted publisher matching.
- Keep `contents: write` because the publish job still pushes cargo-release tags after publishing.

## Why

The current workflow fails at crates.io with `403 Forbidden: authentication failed` because the stored `CARGO_REGISTRY_TOKEN` is invalid or no longer has the required publish permissions. `loro-ffi` already uses `rust-lang/crates-io-auth-action@v1` successfully, so this aligns `loro` with that approach and removes the need for a long-lived crates.io token in GitHub Secrets.

## Validation

- Parsed `.github/workflows/publish-crates.yml` with Ruby YAML.
- Reviewed the staged diff; only `publish-crates.yml` changed.

## Follow-up

Before the next Rust release, configure Trusted Publishing on crates.io for each crate this workflow publishes:

- repository: `loro-dev/loro`
- workflow: `.github/workflows/publish-crates.yml`
- environment: `release`
