### PR TITLE
[codex] fix Vitest Node WASM package export

### DIFF
--- a/.changeset/fix-vitest-node-wasm-export.md
+++ b/.changeset/fix-vitest-node-wasm-export.md
@@ -1,0 +1,6 @@
+---
+"loro-crdt": patch
+---
+
+Fix Node and Vitest bare imports by resolving the package root to the Node.js
+WASM entry under the `node` export condition.

--- a/crates/loro-wasm/package.json
+++ b/crates/loro-wasm/package.json
@@ -25,6 +25,7 @@
         "development": "./bundler/index.js",
         "default": "./browser/index.js"
       },
+      "node": "./nodejs/index.js",
       "import": "./bundler/index.js",
       "require": "./nodejs/index.js",
       "default": "./bundler/index.js"

--- a/examples/bundler-smoke-tests/README.md
+++ b/examples/bundler-smoke-tests/README.md
@@ -59,6 +59,8 @@ LORO_SMOKE_PACKAGE=loro-crdt@1.12.1 pnpm --dir examples/bundler-smoke-tests run 
 
 - `vite5`, `vite6`, `vite7`, `vite8`: Vite production builds with bare
   `import "loro-crdt"`.
+- `vitest-node`: Vitest Node runtime with bare `import "loro-crdt"`, covering
+  package conditional exports as seen by test runners.
 - `vite5-dev`, `vite6-dev`, `vite7-dev`, `vite8-dev`: Vite dev servers with
   bare `import "loro-crdt"` and WASM/top-level-await plugins enabled.
 - `vite5-web-mirror-dev`: `import "loro-crdt/web"` plus `loro-mirror`, which

--- a/examples/bundler-smoke-tests/package.json
+++ b/examples/bundler-smoke-tests/package.json
@@ -10,7 +10,7 @@
     "pretest:dev": "playwright install chromium",
     "test:dev": "LORO_SMOKE_MODE=json node ./scripts/run.mjs vite5-dev vite6-dev vite7-dev vite8-dev rolldown-vite-dev webpack5-dev rsbuild2-dev rspack2-dev parcel2-dev next16-turbopack-dev next16-webpack-dev vite5-web-mirror-dev && LORO_SMOKE_MODE=json node ./scripts/dev-runtime.mjs",
     "test:smoke": "pnpm run test:browser && pnpm run test:dev",
-    "test:fast": "node ./scripts/run.mjs vite5 vite6 vite7 vite8 rolldown-vite webpack5 rsbuild2 rspack2 esbuild-default-copy esbuild-base64 rollup-default-copy rollup-base64 parcel2",
+    "test:fast": "node ./scripts/run.mjs vitest-node vite5 vite6 vite7 vite8 rolldown-vite webpack5 rsbuild2 rspack2 esbuild-default-copy esbuild-base64 rollup-default-copy rollup-base64 parcel2",
     "test:next": "node ./scripts/run.mjs next16-turbopack next16-webpack",
     "list": "node ./scripts/run.mjs --list"
   },

--- a/examples/bundler-smoke-tests/scripts/browser-runtime.mjs
+++ b/examples/bundler-smoke-tests/scripts/browser-runtime.mjs
@@ -9,6 +9,8 @@ import { chromium } from "playwright";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(__dirname, "..");
 const tmpRoot = path.join(packageDir, ".tmp");
+const expectedSmokeJson = { map: { text: "mergeable-smoke" } };
+const expectedSmokeJsonLiteral = JSON.stringify(expectedSmokeJson);
 
 const defaultCases = [
   "vite5",
@@ -228,11 +230,11 @@ async function verifyPage(browser, name, url) {
     }
 
     await page.waitForFunction(
-      () => {
+      (expected) => {
         const value = globalThis.__LORO_JSON_SMOKE__;
-        return value?.t === "hi" && Object.keys(value).length === 1;
+        return JSON.stringify(value) === JSON.stringify(expected);
       },
-      null,
+      expectedSmokeJson,
       { timeout: 60_000 },
     );
     await page.waitForTimeout(250);
@@ -254,17 +256,15 @@ async function verifyPage(browser, name, url) {
       );
     }
 
-    if (JSON.stringify(jsonSmokeValue) !== JSON.stringify({ t: "hi" })) {
+    if (JSON.stringify(jsonSmokeValue) !== expectedSmokeJsonLiteral) {
       throw new Error(
         `${name}: unexpected JSON smoke value ${JSON.stringify(jsonSmokeValue)}`,
       );
     }
 
-    if (!bodyText.includes('{"t":"hi"}')) {
+    if (!bodyText.includes(expectedSmokeJsonLiteral)) {
       throw new Error(
-        `${name}: expected body to include {"t":"hi"}, got ${JSON.stringify(
-          bodyText,
-        )}`,
+        `${name}: expected body to include ${expectedSmokeJsonLiteral}, got ${JSON.stringify(bodyText)}`,
       );
     }
 

--- a/examples/bundler-smoke-tests/scripts/dev-runtime.mjs
+++ b/examples/bundler-smoke-tests/scripts/dev-runtime.mjs
@@ -8,6 +8,8 @@ import { chromium } from "playwright";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(__dirname, "..");
 const tmpRoot = path.join(packageDir, ".tmp");
+const expectedSmokeJson = { map: { text: "mergeable-smoke" } };
+const expectedSmokeJsonLiteral = JSON.stringify(expectedSmokeJson);
 
 const defaultCases = [
   "vite5-dev",
@@ -177,11 +179,11 @@ async function verifyPage(browser, name, url) {
     }
 
     await page.waitForFunction(
-      () => {
+      (expected) => {
         const value = globalThis.__LORO_JSON_SMOKE__;
-        return value?.t === "hi" && Object.keys(value).length === 1;
+        return JSON.stringify(value) === JSON.stringify(expected);
       },
-      null,
+      expectedSmokeJson,
       { timeout: 10_000 },
     );
     await page.waitForTimeout(250);
@@ -199,7 +201,7 @@ async function verifyPage(browser, name, url) {
     const jsonSmokeValue = await page.evaluate(
       () => globalThis.__LORO_JSON_SMOKE__ ?? null,
     );
-    if (JSON.stringify(jsonSmokeValue) !== JSON.stringify({ t: "hi" })) {
+    if (JSON.stringify(jsonSmokeValue) !== expectedSmokeJsonLiteral) {
       throw new Error(
         `${name}: unexpected JSON smoke value ${JSON.stringify(jsonSmokeValue)}`,
       );

--- a/examples/bundler-smoke-tests/scripts/run.mjs
+++ b/examples/bundler-smoke-tests/scripts/run.mjs
@@ -21,7 +21,8 @@ const localLoroPackage = path.join(repoRoot, "crates/loro-wasm");
 const loroPackageSpec = normalizeLoroPackageSpec(
   process.env.LORO_SMOKE_PACKAGE ?? `file:${localLoroPackage}`,
 );
-const smokeMode = process.env.LORO_SMOKE_MODE ?? "default";
+const expectedSmokeJson = { map: { text: "mergeable-smoke" } };
+const expectedSmokeJsonLiteral = JSON.stringify(expectedSmokeJson);
 
 function normalizeLoroPackageSpec(spec) {
   if (spec === "loro-crdt" || spec.startsWith("loro-crdt@")) {
@@ -31,43 +32,33 @@ function normalizeLoroPackageSpec(spec) {
   return spec;
 }
 
-const sharedApp = (importPath) => {
-  if (smokeMode === "json") {
-    return `import { LoroDoc } from "${importPath}";
-
-const doc = new LoroDoc();
-doc.getText("t").insert(0, "hi");
+function loroSmokeBody({ renderToDom = true } = {}) {
+  return `const doc = new Loro();
+const map = doc.getMap("map");
+const text = map.ensureMergeableText("text");
+text.insert(0, "mergeable-smoke");
 const value = doc.toJSON();
+const expected = ${expectedSmokeJsonLiteral};
 
-if (value.t !== "hi" || Object.keys(value).length !== 1) {
+if (JSON.stringify(value) !== JSON.stringify(expected)) {
   throw new Error(\`Unexpected Loro JSON: \${JSON.stringify(value)}\`);
 }
 
-console.log(value);
 globalThis.__LORO_JSON_SMOKE__ = value;
-const app = document.getElementById("app");
+globalThis.__LORO_SMOKE__ = value.map.text;
+${renderToDom
+    ? `const app = document.getElementById("app");
 if (app) {
   app.textContent = JSON.stringify(value);
 }
-`;
-  }
-
-  return `import { LoroDoc } from "${importPath}";
-
-const doc = new LoroDoc();
-const text = doc.getText("text");
-text.insert(0, "bundler-smoke");
-
-const value = doc.toJSON().text;
-if (value !== "bundler-smoke") {
-  throw new Error(\`Unexpected Loro value: \${value}\`);
+`
+    : ""}`;
 }
 
-globalThis.__LORO_SMOKE__ = value;
-const app = document.getElementById("app");
-if (app) {
-  app.textContent = value;
-}
+const sharedApp = (importPath) => {
+  return `import { Loro } from "${importPath}";
+
+${loroSmokeBody()}
 `;
 };
 
@@ -85,6 +76,15 @@ const html = `<!doctype html>
 `;
 
 const cases = {
+  "vitest-node": {
+    description: "Vitest Node runtime with bare loro-crdt import",
+    dependencies: {},
+    devDependencies: {
+      vitest: "3.2.6",
+    },
+    setup: setupVitestNode,
+    command: ["pnpm", "exec", "vitest", "run"],
+  },
   vite5: viteCase("vite5", "vite", "^5.4.21"),
   vite6: viteCase("vite6", "vite", "^6.4.2"),
   vite7: viteCase("vite7", "vite", "^7.3.2"),
@@ -356,6 +356,22 @@ async function setupBasic(dir, importPath) {
   await writeFile(path.join(dir, "src/main.js"), sharedApp(importPath));
 }
 
+async function setupVitestNode(dir) {
+  await writeFile(
+    path.join(dir, "loro.test.ts"),
+    `import { describe, expect, it } from "vitest";
+import { Loro } from "loro-crdt";
+
+describe("loro-crdt", () => {
+  it("runs the mergeable text smoke test", () => {
+    ${loroSmokeBody({ renderToDom: false }).replaceAll("\n", "\n    ")}
+    expect(value).toStrictEqual(${expectedSmokeJsonLiteral});
+  });
+});
+`,
+  );
+}
+
 async function setupVite(dir) {
   await setupBasic(dir, "loro-crdt");
   await writeFile(
@@ -374,25 +390,13 @@ async function setupViteWebMirror(dir) {
   await writeFile(path.join(dir, "index.html"), html);
   await writeFile(
     path.join(dir, "src/main.js"),
-    `import init, { LoroDoc } from "loro-crdt/web";
+    `import init, { Loro } from "loro-crdt/web";
 import wasmUrl from "loro-crdt/web/loro_wasm_bg.wasm?url";
 import * as mirror from "loro-mirror";
 
 await init(wasmUrl);
-const doc = new LoroDoc();
-doc.getText("t").insert(0, "hi");
-const value = doc.toJSON();
-
-if (value.t !== "hi" || Object.keys(value).length !== 1) {
-  throw new Error(\`Unexpected Loro JSON: \${JSON.stringify(value)}\`);
-}
-
-globalThis.__LORO_JSON_SMOKE__ = value;
+${loroSmokeBody()}
 globalThis.__LORO_MIRROR_KEYS__ = Object.keys(mirror);
-const app = document.getElementById("app");
-if (app) {
-  app.textContent = JSON.stringify(value);
-}
 `,
   );
   await writeViteWasmConfig(dir);
@@ -545,34 +549,13 @@ export default function Page() {
   );
   await writeFile(
     path.join(dir, "components/Smoke.jsx"),
-    smokeMode === "json"
-      ? `"use client";
+    `"use client";
 
-import { LoroDoc } from "${importPath}";
+import { Loro } from "${importPath}";
 
 export default function Smoke() {
-  const doc = new LoroDoc();
-  doc.getText("t").insert(0, "hi");
-  const value = doc.toJSON();
-
-  if (value.t !== "hi" || Object.keys(value).length !== 1) {
-    throw new Error(\`Unexpected Loro JSON: \${JSON.stringify(value)}\`);
-  }
-
-  console.log(value);
-  globalThis.__LORO_JSON_SMOKE__ = value;
+  ${loroSmokeBody({ renderToDom: false }).replaceAll("\n", "\n  ")}
   return <main>{JSON.stringify(value)}</main>;
-}
-`
-      : `"use client";
-
-import { LoroDoc } from "${importPath}";
-
-export default function Smoke() {
-  const doc = new LoroDoc();
-  const text = doc.getText("text");
-  text.insert(0, "bundler-smoke");
-  return <main>{doc.toJSON().text}</main>;
 }
 `,
   );
@@ -661,7 +644,9 @@ async function runCase(name, testCase) {
   if (testCase.afterBuild) {
     await testCase.afterBuild(dir);
   }
-  await inspectOutput(dir, testCase.inspect);
+  if (testCase.inspect) {
+    await inspectOutput(dir, testCase.inspect);
+  }
   console.log(`[${name}] ok`);
 }
 


### PR DESCRIPTION
## Summary

Fix `loro-crdt` package resolution for Node/Vitest bare imports by adding a `node` condition before the root `import` condition. This makes Node test runners resolve to the existing `nodejs` WASM entry instead of the bundler WASM entry.

The bundler smoke tests now exercise a stronger Loro scenario across generated apps: `new Loro()`, `getMap()`, `ensureMergeableText()`, text insertion, and `toJSON()` verification. A new `vitest-node` smoke case covers the issue #1005 path by installing `loro-crdt` into a temporary Vitest project and importing it by package name from `node_modules`.

## Root Cause

`loro-crdt@1.13.0` added conditional exports where ESM `import` resolved to `./bundler/index.js`. Vitest externalizes dependencies in `node_modules`, so Node loaded the bundler WASM entry directly and hit `undefined.memory` during WASM startup. The Node-specific package condition should resolve to the Node entry before the generic `import` condition.

## Validation

- `node --check examples/bundler-smoke-tests/scripts/run.mjs`
- `node --check examples/bundler-smoke-tests/scripts/browser-runtime.mjs`
- `node --check examples/bundler-smoke-tests/scripts/dev-runtime.mjs`
- Reproduced failure with `LORO_SMOKE_PACKAGE=loro-crdt@1.13.0 pnpm --dir examples/bundler-smoke-tests run test vitest-node`
- Simulated the package export fix in the temporary Vitest install and confirmed `loro-crdt` resolves to `nodejs/index.js` and the Vitest test passes
- `pnpm exec vite build` in the generated `vite7` smoke project still emits the browser WASM asset
- `pnpm --dir examples/bundler-smoke-tests exec node ./scripts/browser-runtime.mjs vite7` passes with `{"map":{"text":"mergeable-smoke"}}`