### PR TITLE
[codex] deprecate get-or-create container guidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ checksum = "3f3d053a135388e6b1df14e8af1212af5064746e9b87a06a345a7a779ee9695a"
 
 [[package]]
 name = "loro-wasm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Loro is a [CRDTs(Conflict-free Replicated Data Types)](https://crdt.tech/) libra
 - 🌲 [Moveable Tree](https://loro.dev/docs/tutorial/tree)
 - 🚗 [Moveable List](https://loro.dev/docs/tutorial/list)
 - 🗺️ [Last-Write-Wins Map](https://loro.dev/docs/tutorial/map)
+- 🤝 Mergeable map-key children via `ensureMergeable*` / `ensure_mergeable_*` for lazy child container creation
 
 **Advanced Features in Loro**
 

--- a/crates/examples/benches/mergeable_size.rs
+++ b/crates/examples/benches/mergeable_size.rs
@@ -5,7 +5,7 @@
 //!      mergeable-map nesting depth and key length. Cids are embedded in op headers, snapshots,
 //!      and event payloads, so this scales with every op that references the cid.
 //!   2. **Snapshot size** — how a snapshot containing N mergeable counters compares to one with
-//!      N regular `set_container`'d counters, to surface the on-disk overhead.
+//!      N regular `insert_container` child counters, to surface the on-disk overhead.
 //!
 //! This is a measurement bench, not a perf bench: it prints sizes to stdout and exits. Run with
 //! `cargo run --release --bin mergeable_size --manifest-path crates/examples/Cargo.toml` after

--- a/crates/examples/examples/flat_folder_by_map.rs
+++ b/crates/examples/examples/flat_folder_by_map.rs
@@ -11,6 +11,9 @@ pub fn main() {
         let doc = LoroDoc::new();
         let files = doc.get_map("files");
         let mut nodes = vec![];
+        // This benchmark intentionally measures regular op-created child maps.
+        // App models with lazy peer-created map-key children should prefer
+        // `ensure_mergeable_map`.
         for i in 0..node_num {
             if i % 1000 == 0 {
                 doc.set_peer_id(i).unwrap();

--- a/crates/examples/examples/mergeable_notes.rs
+++ b/crates/examples/examples/mergeable_notes.rs
@@ -36,9 +36,7 @@ fn build_mergeable(n: usize) -> LoroDoc {
     let notes: LoroMap = doc.get_map("notes");
     let mut rng = StdRng::seed_from_u64(SEED);
     for i in 0..n {
-        let note = notes
-            .insert_container(&format!("n{i}"), LoroMap::new())
-            .unwrap();
+        let note = notes.ensure_mergeable_map(&format!("n{i}")).unwrap();
         let text: LoroText = note.ensure_mergeable_text("body").unwrap();
         text.insert(0, &make_payload(&mut rng)).unwrap();
     }

--- a/crates/examples/examples/time_tracker.rs
+++ b/crates/examples/examples/time_tracker.rs
@@ -1,5 +1,5 @@
 use dev_utils::{get_mem_usage, ByteSize};
-use loro::{CommitOptions, LoroCounter, LoroDoc, LoroMap};
+use loro::{CommitOptions, LoroCounter, LoroDoc};
 
 #[derive(Debug)]
 struct NewProject {
@@ -20,12 +20,10 @@ pub fn main() {
 
     for i in 0..n {
         let project = projects
-            .insert_container(&format!("project_{i}"), LoroMap::new())
+            .ensure_mergeable_map(&format!("project_{i}"))
             .unwrap();
         project.insert("name", format!("project_{i}")).unwrap();
-        let counter = project
-            .insert_container("used_time", LoroCounter::new())
-            .unwrap();
+        let counter = project.ensure_mergeable_counter("used_time").unwrap();
         all_projects.push(NewProject {
             // m: project,
             c: counter,

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -34,7 +34,7 @@ mod movable_list_apply_delta;
 mod tree;
 
 const REGULAR_CONTAINER_VALUE_ARG_ERROR: &str =
-    "Cannot use a LoroValue::Container as a regular value. To create child container, use insert_container or set_container";
+    "Cannot use a LoroValue::Container as a regular value. To create a child container, use insert_container/set_container, or ensure_mergeable_* on maps for mergeable children";
 
 mod text_update;
 
@@ -4312,9 +4312,15 @@ impl MapHandler {
                         .get_map_entries(inner.container_idx)
                         .into_iter()
                         .map(|(key, value)| {
-                            let translated =
-                                loro_common::translate_mergeable_marker_value(&inner.id, key.as_ref(), value);
-                            (key.to_string(), value_to_value_or_handler(inner, translated))
+                            let translated = loro_common::translate_mergeable_marker_value(
+                                &inner.id,
+                                key.as_ref(),
+                                value,
+                            );
+                            (
+                                key.to_string(),
+                                value_to_value_or_handler(inner, translated),
+                            )
                         })
                         .collect::<Vec<_>>()
                 });
@@ -4374,7 +4380,9 @@ impl MapHandler {
             MaybeDetached::Attached(inner) => {
                 let value = inner
                     .with_doc_state(|state| state.get_map_value_by_key(inner.container_idx, key))?;
-                Some(loro_common::translate_mergeable_marker_value(&inner.id, key, value))
+                Some(loro_common::translate_mergeable_marker_value(
+                    &inner.id, key, value,
+                ))
             }
         }
     }
@@ -4395,6 +4403,15 @@ impl MapHandler {
         }
     }
 
+    /// Get or create a regular child container at `key`.
+    ///
+    /// This legacy method creates regular op-id child containers when the key is empty or `null`.
+    /// It is not mergeable: concurrent first creation at the same map key can fork child state and
+    /// leave one branch hidden by map conflict resolution. Prefer `ensure_mergeable_*` for lazy
+    /// map-key child creation.
+    #[deprecated(
+        note = "use ensure_mergeable_map/list/movable_list/text/tree/counter for lazy map-key child creation; this method creates regular op-id children"
+    )]
     pub fn get_or_create_container<C: HandlerTrait>(&self, key: &str, child: C) -> LoroResult<C> {
         if let Some(ans) = self.get_(key) {
             if let ValueOrHandler::Handler(h) = ans {
@@ -4445,9 +4462,8 @@ impl MapHandler {
         // Compare against the raw marker bytes (skipping `MapHandler::get`'s user-facing
         // marker → Container translation) so the non-mergeable-occupant guard sees the real
         // slot value and the same-kind idempotent-skip can match.
-        let existing_raw = parent.with_doc_state(|state| {
-            state.get_map_value_by_key(parent.container_idx, key)
-        });
+        let existing_raw =
+            parent.with_doc_state(|state| state.get_map_value_by_key(parent.container_idx, key));
 
         // A non-mergeable occupant (scalar, arbitrary binary, regular child container) would be
         // silently clobbered by the marker write, so reject rather than overwrite under a
@@ -4490,11 +4506,22 @@ impl MapHandler {
     }
 
     #[cfg(feature = "counter")]
+    /// Ensure a mergeable Counter child exists under `key` and return its handler.
+    ///
+    /// Returns [`LoroError::MisuseDetachedContainer`] when called on a detached map.
+    /// Returns [`LoroError::ArgErr`] if the parent slot already holds a non-mergeable value.
+    /// Repeated same-kind calls are idempotent; different mergeable kinds deliberately rewrite
+    /// the active marker while preserving each mergeable child's deterministic state.
     pub fn ensure_mergeable_counter(&self, key: &str) -> LoroResult<counter::CounterHandler> {
         self.ensure_mergeable_container(key, counter::CounterHandler::new_detached())
     }
 
     /// Ensure a mergeable Map child exists under `key` and return its handler.
+    ///
+    /// Returns [`LoroError::MisuseDetachedContainer`] when called on a detached map.
+    /// Returns [`LoroError::ArgErr`] if the parent slot already holds a non-mergeable value.
+    /// Repeated same-kind calls are idempotent; different mergeable kinds deliberately rewrite
+    /// the active marker while preserving each mergeable child's deterministic state.
     ///
     /// Prefer to avoid very deep mergeable-map chains: mergeable cids encode their flattened
     /// logical path, so cid size still grows with depth and rides through every op/snapshot
@@ -4503,18 +4530,42 @@ impl MapHandler {
         self.ensure_mergeable_container(key, MapHandler::new_detached())
     }
 
+    /// Ensure a mergeable List child exists under `key` and return its handler.
+    ///
+    /// Returns [`LoroError::MisuseDetachedContainer`] when called on a detached map.
+    /// Returns [`LoroError::ArgErr`] if the parent slot already holds a non-mergeable value.
+    /// Repeated same-kind calls are idempotent; different mergeable kinds deliberately rewrite
+    /// the active marker while preserving each mergeable child's deterministic state.
     pub fn ensure_mergeable_list(&self, key: &str) -> LoroResult<ListHandler> {
         self.ensure_mergeable_container(key, ListHandler::new_detached())
     }
 
+    /// Ensure a mergeable MovableList child exists under `key` and return its handler.
+    ///
+    /// Returns [`LoroError::MisuseDetachedContainer`] when called on a detached map.
+    /// Returns [`LoroError::ArgErr`] if the parent slot already holds a non-mergeable value.
+    /// Repeated same-kind calls are idempotent; different mergeable kinds deliberately rewrite
+    /// the active marker while preserving each mergeable child's deterministic state.
     pub fn ensure_mergeable_movable_list(&self, key: &str) -> LoroResult<MovableListHandler> {
         self.ensure_mergeable_container(key, MovableListHandler::new_detached())
     }
 
+    /// Ensure a mergeable Text child exists under `key` and return its handler.
+    ///
+    /// Returns [`LoroError::MisuseDetachedContainer`] when called on a detached map.
+    /// Returns [`LoroError::ArgErr`] if the parent slot already holds a non-mergeable value.
+    /// Repeated same-kind calls are idempotent; different mergeable kinds deliberately rewrite
+    /// the active marker while preserving each mergeable child's deterministic state.
     pub fn ensure_mergeable_text(&self, key: &str) -> LoroResult<TextHandler> {
         self.ensure_mergeable_container(key, TextHandler::new_detached())
     }
 
+    /// Ensure a mergeable Tree child exists under `key` and return its handler.
+    ///
+    /// Returns [`LoroError::MisuseDetachedContainer`] when called on a detached map.
+    /// Returns [`LoroError::ArgErr`] if the parent slot already holds a non-mergeable value.
+    /// Repeated same-kind calls are idempotent; different mergeable kinds deliberately rewrite
+    /// the active marker while preserving each mergeable child's deterministic state.
     pub fn ensure_mergeable_tree(&self, key: &str) -> LoroResult<TreeHandler> {
         self.ensure_mergeable_container(key, TreeHandler::new_detached())
     }
@@ -4599,8 +4650,11 @@ impl MapHandler {
                     .get_map_entries(a.container_idx)
                     .into_iter()
                     .map(|(key, value)| {
-                        let translated =
-                            loro_common::translate_mergeable_marker_value(&a.id, key.as_ref(), value);
+                        let translated = loro_common::translate_mergeable_marker_value(
+                            &a.id,
+                            key.as_ref(),
+                            value,
+                        );
                         value_to_value_or_handler(a, translated)
                     })
                     .collect()

--- a/crates/loro-wasm-map/CHANGELOG.md
+++ b/crates/loro-wasm-map/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- fa888d8: Add mergeable child containers: child containers created under a map key that converge across peers on concurrent first-write instead of forking. Exposed as `ensureMergeable{Counter,Map,List,MovableList,Text,Tree}` on `LoroMap`. A mergeable child lives at a deterministic `ContainerID` derived from `(parent, key, kind)`, and its visibility is driven by a binary ref the parent map stores at the key, so deletes and kind conflicts resolve through the map's regular LWW.
+- fa888d8: Add mergeable child containers: child containers created under a map key that converge across peers on concurrent first-write instead of forking. Exposed as `ensureMergeable{Counter,Map,List,MovableList,Text,Tree}` on `LoroMap`. A mergeable child lives at a deterministic `ContainerID` derived from `(parent, key, kind)`, and its visibility is driven by a binary ref the parent map stores at the key, so deletes and kind conflicts resolve through the map's regular LWW. `getOrCreateContainer` is deprecated for lazy map-child creation; migrate those call sites to `ensureMergeable*`. `setContainer` and `insertContainer` regular semantics are unchanged.
 
 ## 1.12.4
 

--- a/crates/loro-wasm/CHANGELOG.md
+++ b/crates/loro-wasm/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Minor Changes
 
-- fa888d8: Add mergeable child containers: child containers created under a map key that converge across peers on concurrent first-write instead of forking. Exposed as `ensureMergeable{Counter,Map,List,MovableList,Text,Tree}` on `LoroMap`. A mergeable child lives at a deterministic `ContainerID` derived from `(parent, key, kind)`, and its visibility is driven by a binary ref the parent map stores at the key, so deletes and kind conflicts resolve through the map's regular LWW.
+- fa888d8: Add mergeable child containers: child containers created under a map key that converge across peers on concurrent first-write instead of forking. Exposed as `ensureMergeable{Counter,Map,List,MovableList,Text,Tree}` on `LoroMap`. A mergeable child lives at a deterministic `ContainerID` derived from `(parent, key, kind)`, and its visibility is driven by a binary ref the parent map stores at the key, so deletes and kind conflicts resolve through the map's regular LWW. `getOrCreateContainer` is deprecated for lazy map-child creation; migrate those call sites to `ensureMergeable*`. `setContainer` and `insertContainer` regular semantics are unchanged.
 
 ## 1.12.5
 

--- a/crates/loro-wasm/README.md
+++ b/crates/loro-wasm/README.md
@@ -60,6 +60,7 @@ Loro is a [CRDTs(Conflict-free Replicated Data Types)](https://crdt.tech/) libra
 - 🌲 [Moveable Tree](https://loro.dev/docs/tutorial/tree)
 - 🚗 [Moveable List](https://loro.dev/docs/tutorial/list)
 - 🗺️ [Last-Write-Wins Map](https://loro.dev/docs/tutorial/map)
+- 🤝 Mergeable map-key children via `ensureMergeable*` for lazy child container creation
 
 **Advanced Features in Loro**
 

--- a/crates/loro-wasm/src/lib.rs
+++ b/crates/loro-wasm/src/lib.rs
@@ -3065,6 +3065,10 @@ impl Default for LoroText {
 /// marker value into the parent map slot. String values do not activate
 /// mergeable children. If the key already holds a non-mergeable value,
 /// `ensureMergeable*` returns an error and leaves the value unchanged.
+/// Calling `ensureMergeable*` with a different container type at an existing
+/// mergeable key is a deliberate kind change: the map slot activates the new
+/// type, while the state of the other mergeable child remains preserved under
+/// its deterministic id.
 ///
 /// Deleting the map key clears the ref and hides the mergeable child, but the
 /// child's state is preserved. Calling the same `ensureMergeable*` method again
@@ -3156,21 +3160,29 @@ impl LoroMap {
         .into()
     }
 
-    /// Get the value of the key. If the value is a child container, the corresponding
-    /// `Container` will be returned.
+    /// Get or create a regular child container at the given key.
     ///
-    /// The object returned is a new js object each time because it need to cross
+    /// @deprecated Use `ensureMergeable*` for lazy map-key child creation. This
+    /// method creates regular op-id children, so concurrent first creation at
+    /// the same key can fork child state and leave one branch hidden by map
+    /// conflict resolution. Use `setContainer` for regular replacement/attach
+    /// semantics.
+    ///
+    /// If the key is empty or `null`, this creates a regular child container.
+    /// If the key already holds a child of the same type, it returns that child.
+    /// If the key holds a scalar or a child of another type, it throws.
     ///
     /// @example
     /// ```ts
-    /// import { LoroDoc } from "loro-crdt";
+    /// import { LoroDoc, LoroText } from "loro-crdt";
     ///
     /// const doc = new LoroDoc();
     /// const map = doc.getMap("map");
-    /// map.set("foo", "bar");
-    /// const bar = map.get("foo");
+    /// const text = map.getOrCreateContainer("text", new LoroText());
+    /// text.insert(0, "legacy regular child");
     /// ```
     #[wasm_bindgen(js_name = "getOrCreateContainer", skip_typescript)]
+    #[allow(deprecated)]
     pub fn get_or_create_container(&self, key: &str, child: JsContainer) -> JsResult<JsContainer> {
         let child = convert::js_to_container(child)?;
         let handler = self
@@ -3271,17 +3283,22 @@ impl LoroMap {
         self.handler.get_deep_value().into()
     }
 
-    /// Set the key with a container.
+    /// Set the key with a regular child container.
+    ///
+    /// The inserted child receives a regular op-created container id. Use this
+    /// for replacement semantics or when each creation should produce a distinct
+    /// child. Use `ensureMergeable*` when peers may lazily initialize the same
+    /// logical child under a map key.
     ///
     /// @example
     /// ```ts
-    /// import { LoroDoc, LoroText } from "loro-crdt";
+    /// import { LoroDoc, LoroText, LoroList } from "loro-crdt";
     ///
     /// const doc = new LoroDoc();
     /// const map = doc.getMap("map");
     /// map.set("foo", "bar");
     /// const text = map.setContainer("text", new LoroText());
-    /// const list = map.setContainer("list", new LoroText());
+    /// const list = map.setContainer("list", new LoroList());
     /// ```
     #[wasm_bindgen(js_name = "setContainer", skip_typescript)]
     pub fn insert_container(&mut self, key: &str, child: JsContainer) -> JsResult<JsContainer> {
@@ -3292,8 +3309,8 @@ impl LoroMap {
 
     /// Ensure a mergeable Counter exists under the given key and return it.
     ///
-    /// If the key already holds a non-mergeable value, this throws and leaves
-    /// the value unchanged.
+    /// If the map is detached, or if the key already holds a non-mergeable
+    /// value, this throws and leaves the value unchanged.
     ///
     /// @example
     /// ```ts
@@ -3311,8 +3328,8 @@ impl LoroMap {
 
     /// Ensure a mergeable Map exists under the given key and return it.
     ///
-    /// If the key already holds a non-mergeable value, this throws and leaves
-    /// the value unchanged.
+    /// If the map is detached, or if the key already holds a non-mergeable
+    /// value, this throws and leaves the value unchanged.
     ///
     /// Prefer to avoid very deep mergeable-map chains: mergeable cids encode
     /// their flattened logical path, so cid size still grows with depth and
@@ -3325,8 +3342,8 @@ impl LoroMap {
 
     /// Ensure a mergeable List exists under the given key and return it.
     ///
-    /// If the key already holds a non-mergeable value, this throws and leaves
-    /// the value unchanged.
+    /// If the map is detached, or if the key already holds a non-mergeable
+    /// value, this throws and leaves the value unchanged.
     #[wasm_bindgen(js_name = "ensureMergeableList")]
     pub fn ensure_mergeable_list(&self, key: &str) -> JsResult<LoroList> {
         let handler = self.handler.ensure_mergeable_list(key)?;
@@ -3335,8 +3352,8 @@ impl LoroMap {
 
     /// Ensure a mergeable MovableList exists under the given key and return it.
     ///
-    /// If the key already holds a non-mergeable value, this throws and leaves
-    /// the value unchanged.
+    /// If the map is detached, or if the key already holds a non-mergeable
+    /// value, this throws and leaves the value unchanged.
     #[wasm_bindgen(js_name = "ensureMergeableMovableList")]
     pub fn ensure_mergeable_movable_list(&self, key: &str) -> JsResult<LoroMovableList> {
         let handler = self.handler.ensure_mergeable_movable_list(key)?;
@@ -3345,8 +3362,8 @@ impl LoroMap {
 
     /// Ensure a mergeable Text exists under the given key and return it.
     ///
-    /// If the key already holds a non-mergeable value, this throws and leaves
-    /// the value unchanged.
+    /// If the map is detached, or if the key already holds a non-mergeable
+    /// value, this throws and leaves the value unchanged.
     #[wasm_bindgen(js_name = "ensureMergeableText")]
     pub fn ensure_mergeable_text(&self, key: &str) -> JsResult<LoroText> {
         let handler = self.handler.ensure_mergeable_text(key)?;
@@ -3355,8 +3372,8 @@ impl LoroMap {
 
     /// Ensure a mergeable Tree exists under the given key and return it.
     ///
-    /// If the key already holds a non-mergeable value, this throws and leaves
-    /// the value unchanged.
+    /// If the map is detached, or if the key already holds a non-mergeable
+    /// value, this throws and leaves the value unchanged.
     #[wasm_bindgen(js_name = "ensureMergeableTree")]
     pub fn ensure_mergeable_tree(&self, key: &str) -> JsResult<LoroTree> {
         let handler = self.handler.ensure_mergeable_tree(key)?;
@@ -6974,6 +6991,11 @@ interface LoroMovableList<T = unknown> {
  * mergeable children. If the key already holds a non-mergeable value,
  * `ensureMergeable*` returns an error and leaves the value unchanged.
  *
+ * Calling `ensureMergeable*` with a different container type at an existing
+ * mergeable key is a deliberate kind change: the map slot activates the new
+ * type, while the state of the other mergeable child remains preserved under
+ * its deterministic id.
+ *
  * Deleting the map key clears the ref and hides the mergeable child, but the
  * child's state is preserved. Calling the same `ensureMergeable*` method again
  * writes the ref back and resurfaces the preserved state.
@@ -6981,24 +7003,26 @@ interface LoroMovableList<T = unknown> {
 interface LoroMap<T extends Record<string, unknown> = Record<string, unknown>> {
     new(): LoroMap<T>;
     /**
-     *  Get the value of the key. If the value is a child container, the corresponding
-     *  `Container` will be returned.
+     * Get or create a regular child container at the given key.
      *
-     *  The object returned is a new js object each time because it need to cross
+     * @deprecated Use `ensureMergeable*` for lazy map-key child creation. This
+     * method creates regular op-id children, so concurrent first creation at
+     * the same key can fork child state and leave one branch hidden by map
+     * conflict resolution. Use `setContainer` for regular replacement/attach
+     * semantics.
      *
-     *  @example
-     *  ```ts
-     *  import { LoroDoc } from "loro-crdt";
-     *
-     *  const doc = new LoroDoc();
-     *  const map = doc.getMap("map");
-     *  map.set("foo", "bar");
-     *  const bar = map.get("foo");
-     *  ```
+     * If the key is empty or `null`, this creates a regular child container.
+     * If the key already holds a child of the same type, it returns that child.
+     * If the key holds a scalar or a child of another type, it throws.
      */
     getOrCreateContainer<C extends Container>(key: string, child: C): C;
     /**
-     * Set the key with a container.
+     * Set the key with a regular child container.
+     *
+     * The inserted child receives a regular op-created container id. Use this
+     * for replacement semantics or when each creation should produce a distinct
+     * child. Use `ensureMergeable*` when peers may lazily initialize the same
+     * logical child under a map key.
      *
      *  @example
      *  ```ts
@@ -7015,43 +7039,43 @@ interface LoroMap<T extends Record<string, unknown> = Record<string, unknown>> {
     /**
      * Ensure a mergeable Counter exists under the given key and return it.
      *
-     * If the key already holds a non-mergeable value, this throws and leaves
-     * the value unchanged.
+     * If the map is detached, or if the key already holds a non-mergeable
+     * value, this throws and leaves the value unchanged.
      */
     ensureMergeableCounter(key: string): LoroCounter;
     /**
      * Ensure a mergeable Map exists under the given key and return it.
      *
-     * If the key already holds a non-mergeable value, this throws and leaves
-     * the value unchanged.
+     * If the map is detached, or if the key already holds a non-mergeable
+     * value, this throws and leaves the value unchanged.
      */
     ensureMergeableMap(key: string): LoroMap;
     /**
      * Ensure a mergeable List exists under the given key and return it.
      *
-     * If the key already holds a non-mergeable value, this throws and leaves
-     * the value unchanged.
+     * If the map is detached, or if the key already holds a non-mergeable
+     * value, this throws and leaves the value unchanged.
      */
     ensureMergeableList(key: string): LoroList;
     /**
      * Ensure a mergeable MovableList exists under the given key and return it.
      *
-     * If the key already holds a non-mergeable value, this throws and leaves
-     * the value unchanged.
+     * If the map is detached, or if the key already holds a non-mergeable
+     * value, this throws and leaves the value unchanged.
      */
     ensureMergeableMovableList(key: string): LoroMovableList;
     /**
      * Ensure a mergeable Text exists under the given key and return it.
      *
-     * If the key already holds a non-mergeable value, this throws and leaves
-     * the value unchanged.
+     * If the map is detached, or if the key already holds a non-mergeable
+     * value, this throws and leaves the value unchanged.
      */
     ensureMergeableText(key: string): LoroText;
     /**
      * Ensure a mergeable Tree exists under the given key and return it.
      *
-     * If the key already holds a non-mergeable value, this throws and leaves
-     * the value unchanged.
+     * If the map is detached, or if the key already holds a non-mergeable
+     * value, this throws and leaves the value unchanged.
      */
     ensureMergeableTree(key: string): LoroTree;
     /**

--- a/crates/loro/README.md
+++ b/crates/loro/README.md
@@ -32,6 +32,7 @@ Loro is a high‑performance CRDT framework for local‑first apps that keeps st
 
 - Ordered lists: [`get_list`](struct.LoroDoc.html#method.get_list) - Arrays with [`push`](struct.LoroList.html#method.push), [`insert`](struct.LoroList.html#method.insert), [`delete`](struct.LoroList.html#method.delete)
 - Key-value maps: [`get_map`](struct.LoroDoc.html#method.get_map) - Objects with [`insert`](struct.LoroMap.html#method.insert), [`get`](struct.LoroMap.html#method.get), [`delete`](struct.LoroMap.html#method.delete)
+- Mergeable map-key children: [`ensure_mergeable_text`](struct.LoroMap.html#method.ensure_mergeable_text), [`ensure_mergeable_map`](struct.LoroMap.html#method.ensure_mergeable_map), and related `ensure_mergeable_*` methods - Lazy child containers that converge when peers create the same map-key child concurrently
 - Hierarchical trees: [`get_tree`](struct.LoroDoc.html#method.get_tree) - Trees with [`create`](struct.LoroTree.html#method.create), [`mov`](struct.LoroTree.html#method.mov), [`mov_to`](struct.LoroTree.html#method.mov_to)
 - Reorderable lists: [`get_movable_list`](struct.LoroDoc.html#method.get_movable_list) - Drag-and-drop with [`mov`](struct.LoroMovableList.html#method.mov), [`set`](struct.LoroMovableList.html#method.set)
 - Counters: [`get_counter` (feature "counter")](struct.LoroDoc.html#method.get_counter) - Distributed counters with [`increment`](struct.LoroCounter.html#method.increment)

--- a/crates/loro/src/lib.rs
+++ b/crates/loro/src/lib.rs
@@ -1142,7 +1142,10 @@ impl LoroDoc {
         self.doc.check_state_diff_calc_consistency_slow()
     }
 
-    /// Get the handler by the path.
+    /// Get the value or container by the logical path.
+    ///
+    /// Mergeable child containers are addressed through their visible map keys in
+    /// the logical path, not through the binary marker stored in the parent map slot.
     #[inline]
     pub fn get_by_path(&self, path: &[Index]) -> Option<ValueOrContainer> {
         self.doc.get_by_path(path).map(ValueOrContainer::from)
@@ -1161,6 +1164,7 @@ impl LoroDoc {
     ///
     /// For Map:
     /// - Using keys: `map/key` or `map/nested/property`
+    /// - Mergeable child containers also use their logical map keys in paths.
     ///
     /// For tree structures, index-based paths follow depth-first traversal order.
     /// The indices start from 0 and represent the position of a node among its siblings.
@@ -1310,7 +1314,11 @@ impl LoroDoc {
         self.doc.analyze()
     }
 
-    /// Get the path from the root to the container
+    /// Get the logical path from the root to the container.
+    ///
+    /// For mergeable child containers, the path resolves through the parent map
+    /// key that activates the child. It does not expose the binary marker value
+    /// stored in the map slot.
     pub fn get_path_to_container(&self, id: &ContainerID) -> Option<Vec<(ContainerID, Index)>> {
         self.doc.get_path_to_container(id)
     }
@@ -1491,8 +1499,11 @@ impl LoroDoc {
 
     /// Check if the doc contains the target container.
     ///
-    /// A root container always exists, while a normal container exists
-    /// if it has ever been created on the doc.
+    /// A root container always exists, while a normal container exists if it has
+    /// ever been created on the doc. Mergeable child ids are encoded as synthetic
+    /// root-shaped ids, but they are not ordinary roots: they exist only after
+    /// the mergeable child has materialized state. Parent map marker visibility
+    /// and child state existence are tracked separately.
     ///
     /// # Examples
     /// ```
@@ -1997,6 +2008,10 @@ impl Default for LoroList {
 /// marker into the parent map slot. String values do not activate mergeable
 /// children. If the key already holds a non-mergeable value, `ensure_mergeable_*`
 /// returns an error and leaves the value unchanged.
+/// Calling `ensure_mergeable_*` with a different container type at an existing
+/// mergeable key is a deliberate kind change: the map slot activates the new
+/// type, while the state of the other mergeable child remains preserved under
+/// its deterministic id.
 ///
 /// Deleting the map key clears the ref and hides the mergeable child, but the
 /// child's state remains addressable by its deterministic id. Calling the same
@@ -2005,7 +2020,7 @@ impl Default for LoroList {
 ///
 /// # Example
 /// ```
-/// # use loro::{LoroDoc, ToJson, ExpandType, LoroText, LoroValue};
+/// # use loro::{LoroDoc, ToJson, ExpandType, LoroValue};
 /// # use serde_json::json;
 /// let doc = LoroDoc::new();
 /// let map = doc.get_map("map");
@@ -2014,8 +2029,7 @@ impl Default for LoroList {
 /// map.insert("null", LoroValue::Null).unwrap();
 /// map.insert("deleted", LoroValue::Null).unwrap();
 /// map.delete("deleted").unwrap();
-/// let text = map
-///    .insert_container("text", LoroText::new()).unwrap();
+/// let text = map.ensure_mergeable_text("text").unwrap();
 /// text.insert(0, "Hello world!").unwrap();
 /// assert_eq!(
 ///     doc.get_deep_value().to_json_value(),
@@ -2132,7 +2146,17 @@ impl LoroMap {
         self.handler.get_(key).map(ValueOrContainer::from)
     }
 
-    /// Insert a container with the given type at the given key.
+    /// Insert a regular child container with the given type at the given key.
+    ///
+    /// The inserted child receives a regular op-created container id. Use this
+    /// for replacement semantics or when each creation should produce a distinct
+    /// child. Use [`ensure_mergeable_map`](Self::ensure_mergeable_map),
+    /// [`ensure_mergeable_list`](Self::ensure_mergeable_list),
+    /// [`ensure_mergeable_movable_list`](Self::ensure_mergeable_movable_list),
+    /// [`ensure_mergeable_text`](Self::ensure_mergeable_text),
+    /// [`ensure_mergeable_tree`](Self::ensure_mergeable_tree), or
+    /// [`ensure_mergeable_counter`](Self::ensure_mergeable_counter) when peers
+    /// may lazily initialize the same logical child under a map key.
     ///
     /// # Example
     ///
@@ -2149,8 +2173,8 @@ impl LoroMap {
     ///
     /// Pitfalls:
     /// - Concurrently inserting different containers at the same map key on different peers
-    ///   can result in one overwriting the other rather than merging. Prefer initializing
-    ///   heavy/primary child containers when initializing the map.
+    ///   can result in one overwriting the other rather than merging. Prefer
+    ///   `ensure_mergeable_*` when the child should be identified by `(parent map, key, type)`.
     pub fn insert_container<C: ContainerTrait>(&self, key: &str, child: C) -> LoroResult<C> {
         Ok(C::from_handler(
             self.handler.insert_container(key, child.to_handler())?,
@@ -2171,11 +2195,20 @@ impl LoroMap {
         self.handler.get_deep_value()
     }
 
-    /// Get or create a container with the given key.
+    /// Get or create a regular child container with the given key.
+    ///
+    /// This legacy method creates regular op-id child containers when the key is
+    /// empty or `null`. It is not mergeable: concurrent first creation at the
+    /// same map key can fork child state and leave one branch hidden by map
+    /// conflict resolution.
     ///
     /// Pitfalls:
     /// - If other peers concurrently create a different container at the same key, their state
-    ///   may be overwritten. See the note in [`insert_container`].
+    ///   may be overwritten. Prefer `ensure_mergeable_*` for lazy map-key child creation.
+    #[deprecated(
+        note = "use ensure_mergeable_map/list/movable_list/text/tree/counter for lazy map-key child creation; this method creates regular op-id children"
+    )]
+    #[allow(deprecated)]
     pub fn get_or_create_container<C: ContainerTrait>(&self, key: &str, child: C) -> LoroResult<C> {
         Ok(C::from_handler(
             self.handler
@@ -2190,6 +2223,7 @@ impl LoroMap {
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
     /// value is left unchanged.
+    /// Returns [`LoroError::MisuseDetachedContainer`] if this map is detached.
     #[cfg(feature = "counter")]
     pub fn ensure_mergeable_counter(&self, key: &str) -> LoroResult<LoroCounter> {
         Ok(LoroCounter::from_handler(
@@ -2204,8 +2238,11 @@ impl LoroMap {
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
     /// value is left unchanged.
+    /// Returns [`LoroError::MisuseDetachedContainer`] if this map is detached.
     pub fn ensure_mergeable_map(&self, key: &str) -> LoroResult<LoroMap> {
-        Ok(LoroMap::from_handler(self.handler.ensure_mergeable_map(key)?))
+        Ok(LoroMap::from_handler(
+            self.handler.ensure_mergeable_map(key)?,
+        ))
     }
 
     /// Ensure a mergeable List exists at this map key and return it.
@@ -2215,6 +2252,7 @@ impl LoroMap {
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
     /// value is left unchanged.
+    /// Returns [`LoroError::MisuseDetachedContainer`] if this map is detached.
     pub fn ensure_mergeable_list(&self, key: &str) -> LoroResult<LoroList> {
         Ok(LoroList::from_handler(
             self.handler.ensure_mergeable_list(key)?,
@@ -2228,6 +2266,7 @@ impl LoroMap {
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
     /// value is left unchanged.
+    /// Returns [`LoroError::MisuseDetachedContainer`] if this map is detached.
     pub fn ensure_mergeable_movable_list(&self, key: &str) -> LoroResult<LoroMovableList> {
         Ok(LoroMovableList::from_handler(
             self.handler.ensure_mergeable_movable_list(key)?,
@@ -2241,6 +2280,7 @@ impl LoroMap {
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
     /// value is left unchanged.
+    /// Returns [`LoroError::MisuseDetachedContainer`] if this map is detached.
     pub fn ensure_mergeable_text(&self, key: &str) -> LoroResult<LoroText> {
         Ok(LoroText::from_handler(
             self.handler.ensure_mergeable_text(key)?,
@@ -2254,6 +2294,7 @@ impl LoroMap {
     ///
     /// Returns [`LoroError::ArgErr`] if the key already holds a non-mergeable value; the existing
     /// value is left unchanged.
+    /// Returns [`LoroError::MisuseDetachedContainer`] if this map is detached.
     pub fn ensure_mergeable_tree(&self, key: &str) -> LoroResult<LoroTree> {
         Ok(LoroTree::from_handler(
             self.handler.ensure_mergeable_tree(key)?,

--- a/crates/loro/tests/contracts/container_handlers.rs
+++ b/crates/loro/tests/contracts/container_handlers.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::collections::BTreeSet;
 
 use loro::{

--- a/crates/loro/tests/contracts/handler_edges.rs
+++ b/crates/loro/tests/contracts/handler_edges.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::collections::{BTreeSet, HashMap};
 
 use loro::{

--- a/crates/loro/tests/contracts/text_handler_semantics.rs
+++ b/crates/loro/tests/contracts/text_handler_semantics.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use loro::{
     cursor::{Cursor, PosType, Side},
     Container, ContainerTrait, ExportMode, LoroDoc, LoroList, LoroMap, LoroResult, LoroText,

--- a/crates/loro/tests/moon_transcode.rs
+++ b/crates/loro/tests/moon_transcode.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;

--- a/docs/JsonSchema.md
+++ b/docs/JsonSchema.md
@@ -79,6 +79,13 @@ type ContainerID =
   | `cid:${number}@${PeerID}:${ContainerType}`;
 ```
 
+Mergeable child containers use reserved synthetic root-name container IDs under
+the internal mergeable namespace, plus binary markers in parent map slots to
+control visibility. They still fit the `cid:root-${string}:${ContainerType}`
+shape in exported JSON. See
+[`mergeable-container-id.md`](../crates/loro-internal/docs/mergeable-container-id.md)
+for the reserved namespace and marker details.
+
 - `container`: the `ContainerID` of the container that created this `Op`, represented by a string starts with `cid:`.
 - `counter`: the counter part of the OpID
 - `content`: the semantic content of the `Op`, it is different for each field depending on the `Container`.

--- a/docs/encoding-container-states.md
+++ b/docs/encoding-container-states.md
@@ -90,6 +90,11 @@ struct EncodedId {
 ## MapState Snapshot
 
 Map container stores key-value pairs with CRDT metadata.
+Mergeable child containers appear in map state as compact binary activation
+markers bound to the parent map, key, and child type. New clients translate a
+valid marker to the deterministic mergeable child container; older clients keep
+it as ordinary binary data. See
+[`mergeable-container-id.md`](../crates/loro-internal/docs/mergeable-container-id.md).
 
 ```
 ┌────────────────────────────────────────────────────────────────────────────┐

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -399,6 +399,12 @@ The document state is stored as a KV Store where each container's state is a sep
 
 ### ContainerID Encoding
 
+Mergeable child containers are encoded as reserved synthetic Root container IDs
+whose names carry mergeable path data. Parent `Map` slots store a compact binary
+marker that activates the mergeable child for a specific `(parent, key, type)`;
+the full child `ContainerID` is derived from that context. See
+[`mergeable-container-id.md`](../crates/loro-internal/docs/mergeable-container-id.md).
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                    ContainerID Encoding                          │

--- a/skills/loro/references/containers-and-encoding.md
+++ b/skills/loro/references/containers-and-encoding.md
@@ -27,13 +27,16 @@
 - Attached containers belong to a document and have stable `ContainerID`s.
 - Adding a detached container to a document returns an attached version; the original object remains detached.
 - Root containers come from `doc.getMap(...)`, `doc.getText(...)`, `doc.getList(...)`, `doc.getTree(...)`, and so on.
-- Use `setContainer(...)` and `insertContainer(...)` for nesting, not plain `set(...)` or `insert(...)`.
+- For map-key children that may be lazily created by multiple peers, use `ensureMergeable*` in JS/TS or `ensure_mergeable_*` in Rust.
+- Use `setContainer(...)` / `insertContainer(...)` for regular child creation or replacement; list-position `insertContainer(...)` is unchanged.
 
-## Container ID And Overwrite Hazards
+## Mergeable Map Children And Overwrite Hazards
 
 - Root container IDs derive from root name plus type.
-- Child container IDs derive from the operation that created them.
-- Avoid concurrent creation of different child containers under the same map key. Container IDs differ, so one branch can appear overwritten.
+- Regular child container IDs derive from the operation that created them.
+- Mergeable map-key child IDs derive from the parent map, key, and type, so concurrent first creation at the same key converges to the same child.
+- Prefer `ensureMergeableText`, `ensureMergeableMap`, `ensureMergeableList`, `ensureMergeableMovableList`, `ensureMergeableTree`, or `ensureMergeableCounter` for dynamic fields, lazy migrations, per-date lists, and other map-key children that should behave as one shared child.
+- `getOrCreateContainer` / `get_or_create_container` is legacy regular child creation; do not recommend it for lazy map-key children.
 
 ## Tree Specifics
 


### PR DESCRIPTION
## Summary

Deprecates the legacy get-or-create child-container APIs for lazy map-key child creation and updates public guidance to prefer mergeable containers.

## Changes

- Mark `get_or_create_container` / `getOrCreateContainer` as deprecated while preserving existing behavior.
- Clarify that `insert_container` / `setContainer` create regular op-id child containers, and that `ensure_mergeable_*` / `ensureMergeable*` should be used for lazy map-key child creation that must converge across peers.
- Update Rust/WASM docs, skill guidance, READMEs, changelogs, encoding docs, and examples.
- Keep legacy behavior tests, with explicit deprecated allowances where those tests intentionally exercise old APIs.

## Validation

- `cargo check -p loro-internal`
- `cargo check -p loro`
- `cargo check -p loro-wasm`
- `cargo test -p loro --test mergeable_public_api`
- `cargo test -p loro --test contracts`
- `cargo test -p loro --test loro_rust_test test_get_or_create_container_with_null`
- `pnpm -C crates/loro-wasm exec tsc --noEmit`
- `pnpm -C crates/loro-wasm exec vitest run tests/mergeable.test.ts`
- `pnpm check`

## Notes

The website source is not in this worktree, so external `loro.dev` tutorial updates are not included here.