### PR TITLE
fix: undo after shallow snapshot import

### DIFF
--- a/.changeset/silent-shallows-undo.md
+++ b/.changeset/silent-shallows-undo.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Fix undo recording for the first local commit after importing shallow snapshots that need import-time state materialization.

--- a/crates/loro-internal/src/encoding/fast_snapshot.rs
+++ b/crates/loro-internal/src/encoding/fast_snapshot.rs
@@ -187,6 +187,7 @@ pub(crate) fn decode_snapshot_inner(
         ));
     }
     let need_calc = state_bytes.is_none();
+    let checkout_origin = origin.clone();
 
     let arena_checkpoint = oplog.arena.checkpoint_for_rollback();
     let decode_result = (|| -> LoroResult<()> {
@@ -243,7 +244,7 @@ pub(crate) fn decode_snapshot_inner(
     drop(oplog);
     if need_calc {
         doc.set_detached(true);
-        if let Err(e) = doc._checkout_to_latest_without_commit(false) {
+        if let Err(e) = doc._checkout_to_latest_without_commit_as_import(false, checkout_origin) {
             doc.set_detached(false);
             doc.app_state()
                 .lock()

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1536,11 +1536,42 @@ impl LoroDoc {
         &self,
         to_commit_then_renew: bool,
     ) -> LoroResult<()> {
+        self._checkout_to_latest_without_commit_with_event(
+            to_commit_then_renew,
+            "checkout".into(),
+            EventTriggerKind::Checkout,
+        )
+    }
+
+    pub(crate) fn _checkout_to_latest_without_commit_as_import(
+        &self,
+        to_commit_then_renew: bool,
+        origin: InternalString,
+    ) -> LoroResult<()> {
+        self._checkout_to_latest_without_commit_with_event(
+            to_commit_then_renew,
+            origin,
+            EventTriggerKind::Import,
+        )
+    }
+
+    fn _checkout_to_latest_without_commit_with_event(
+        &self,
+        to_commit_then_renew: bool,
+        origin: InternalString,
+        triggered_by: EventTriggerKind,
+    ) -> LoroResult<()> {
         tracing::info_span!("CheckoutToLatest", peer = self.peer_id()).in_scope(|| {
             let f = self.oplog_frontiers();
             let this = &self;
             let frontiers = &f;
-            this._checkout_without_emitting(frontiers, false, to_commit_then_renew)?;
+            this._checkout_without_emitting_with_event(
+                frontiers,
+                false,
+                to_commit_then_renew,
+                origin,
+                triggered_by,
+            )?;
             // We don't need to shrink frontiers because oplog's frontiers are already shrinked.
             this.emit_events();
             if this.config.detached_editing() {
@@ -1587,6 +1618,23 @@ impl LoroDoc {
         frontiers: &Frontiers,
         to_shrink_frontiers: bool,
         to_commit_then_renew: bool,
+    ) -> Result<(), LoroError> {
+        self._checkout_without_emitting_with_event(
+            frontiers,
+            to_shrink_frontiers,
+            to_commit_then_renew,
+            "checkout".into(),
+            EventTriggerKind::Checkout,
+        )
+    }
+
+    fn _checkout_without_emitting_with_event(
+        &self,
+        frontiers: &Frontiers,
+        to_shrink_frontiers: bool,
+        _to_commit_then_renew: bool,
+        origin: InternalString,
+        triggered_by: EventTriggerKind,
     ) -> Result<(), LoroError> {
         if !self.txn.is_locked() {
             return Err(LoroError::TransactionError(
@@ -1650,9 +1698,9 @@ impl LoroDoc {
             calc.calc_diff_internal(&oplog, &before, &state.frontiers, after, &frontiers, None);
         state.apply_diff(
             InternalDocDiff {
-                origin: "checkout".into(),
+                origin,
                 diff: Cow::Owned(diff),
-                by: EventTriggerKind::Checkout,
+                by: triggered_by,
                 new_version: Cow::Owned(frontiers.clone()),
             },
             diff_mode,

--- a/crates/loro/tests/integration_test/undo_test.rs
+++ b/crates/loro/tests/integration_test/undo_test.rs
@@ -4,8 +4,8 @@ use std::sync::{
 };
 
 use loro::{
-    undo::UndoItemMeta, ContainerTrait as _, ExportMode, LoroDoc, LoroError, LoroList, LoroMap,
-    LoroResult, LoroText, LoroValue, StyleConfigMap, ToJson, UndoManager,
+    undo::UndoItemMeta, ContainerTrait as _, ExportMode, Frontiers, LoroDoc, LoroError, LoroList,
+    LoroMap, LoroResult, LoroText, LoroValue, StyleConfigMap, ToJson, UndoManager,
 };
 use loro_internal::{configure::StyleConfig, id::ID, loro::CommitOptions};
 use serde_json::json;
@@ -41,6 +41,60 @@ fn basic_list_undo_insertion() -> Result<(), LoroError> {
             "list": []
         })
     );
+
+    Ok(())
+}
+
+#[test]
+fn undo_records_first_local_commit_after_shallow_snapshot_import() -> LoroResult<()> {
+    fn assert_first_post_import_commit_is_undoable(name: &str, bytes: Vec<u8>) -> LoroResult<()> {
+        let doc = LoroDoc::new();
+        doc.set_peer_id(2)?;
+        let mut undo = UndoManager::new(&doc);
+
+        doc.import(&bytes)?;
+        let before = doc.get_deep_value().to_json_value();
+        doc.get_text("t").insert(0, "x")?;
+        doc.commit();
+
+        assert!(
+            undo.can_undo(),
+            "first local commit after {name} import should be undoable"
+        );
+        assert!(undo.undo()?, "undo should execute after {name} import");
+        assert_eq!(doc.get_deep_value().to_json_value(), before);
+        Ok(())
+    }
+
+    let source = LoroDoc::new();
+    source.set_peer_id(1)?;
+    source.get_text("t").insert(0, "synced text")?;
+    source.commit();
+
+    assert_first_post_import_commit_is_undoable(
+        "full snapshot",
+        source.export(ExportMode::Snapshot)?,
+    )?;
+    assert_first_post_import_commit_is_undoable(
+        "shallow snapshot at genesis",
+        source.export(ExportMode::shallow_snapshot(&Frontiers::default()))?,
+    )?;
+    assert_first_post_import_commit_is_undoable(
+        "shallow snapshot at tip",
+        source.export(ExportMode::shallow_snapshot(&source.oplog_frontiers()))?,
+    )?;
+
+    let source = LoroDoc::new();
+    source.set_peer_id(1)?;
+    source.get_text("t").insert(0, "synced text")?;
+    source.commit();
+    let non_tip_anchor = source.oplog_frontiers();
+    source.get_text("t").insert(11, " second")?;
+    source.commit();
+    assert_first_post_import_commit_is_undoable(
+        "shallow snapshot at non-tip",
+        source.export(ExportMode::shallow_snapshot(&non_tip_anchor))?,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #1012.

Shallow snapshot imports that need to materialize latest state currently emit their internal checkout as a `Checkout` event. `UndoManager` treats checkout as a user-visible version switch, clears its stacks, and sets `next_counter` to `None`, so the first local commit after import only reinitializes the undo baseline instead of becoming an undo item.

This change keeps explicit checkout behavior unchanged, but lets the shallow snapshot import materialization path emit that internal checkout as an `Import` event using the original import origin. That preserves subscriber visibility for the imported state while avoiding the UndoManager reset.

## Validation

- `cargo test -p loro --test loro_rust_test undo_records_first_local_commit_after_shallow_snapshot_import -- --nocapture`
- `cargo test -p loro --test loro_rust_test shallow_snapshot -- --nocapture`
- `cargo test -p loro --test issue -- --nocapture`
- `cargo test -p loro --test contracts events_subscriptions -- --nocapture`
- `cargo check -p loro-internal`

Note: `cargo check` still reports the existing `loro-common/src/lib.rs` unused import warning, unrelated to this change.