### PR TITLE
Disable default postcard features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ enum_dispatch = "0.3.11"
 enum-as-inner = "0.6.0"
 rustc-hash = "2.1.1"
 tracing = { version = "0.1" }
-serde_columnar = { version = "0.3.14" }
+serde_columnar = { version = "0.3.14", default-features = false }
 serde_json = "1.0"
 thiserror = "1"
 smallvec = { version = "1.8.0", features = ["serde"] }

--- a/crates/loro-internal/Cargo.toml
+++ b/crates/loro-internal/Cargo.toml
@@ -35,7 +35,7 @@ itertools = { workspace = true }
 enum_dispatch = { workspace = true }
 once_cell = { workspace = true }
 arbitrary = { version = "1", optional = true }
-postcard = { version = "1", features = ["use-std"] }
+postcard = { version = "1", default-features = false, features = ["use-std"] }
 append-only-bytes = { version = "0.1.12", features = ["u32_range"] }
 im = { version = "15.1.0", features = ["serde"] }
 tabled = { version = "0.10.0", optional = true }


### PR DESCRIPTION
## Summary

- Disable default features for the direct `postcard` dependency while keeping `use-std`.
- Disable default features for the workspace `serde_columnar` dependency.

## Why

These dependencies only need the std/alloc-backed postcard surface here. Avoiding postcard defaults prevents the extra `heapless-cas` / `atomic-polyfill` dependency path from being pulled into downstream production graphs.

## Validation

- `cargo metadata --format-version 1 --no-deps`
- `cargo check -p loro-common -p loro-internal`
