### PR TITLE
fix: recover two per-op editing slowdowns regressed since 1.11

### DIFF
--- a/.changeset/perf-per-op-editing-regression.md
+++ b/.changeset/perf-per-op-editing-regression.md
@@ -1,0 +1,24 @@
+---
+"loro-crdt": patch
+"loro-crdt-map": patch
+---
+
+Recover two per-operation editing slowdowns regressed since 1.11.
+
+Both are constant-factor regressions on the per-op (auto-commit) editing path
+introduced by the lazy-snapshot work in #985, measured against the 1.11.1
+release.
+
+1. Every `MapHandler`/`ListHandler`/`MovableListHandler` insert validated its
+   value with `ensure_no_regular_container_value`, which heap-allocated a `Vec`
+   on each call even for scalar values (the common case). A scalar fast-path now
+   skips the allocation and traversal entirely. `map create 10^4 key`:
+   ~19.4ms -> ~10.7ms.
+
+2. The per-op text bounds check (`TextHandler::len`/`len_unicode`/`len_utf16`)
+   took two `DocState` locks — one to check whether the container state was
+   decoded, then another to query the length. These are now consolidated into a
+   single `DocState::get_text_len` that takes one lock and one container-store
+   lookup. The lazy-snapshot memory behavior is preserved: a still-lazy
+   container reads its cached length metadata without materializing the full
+   richtext state. `bench_text B4 apply` (per-op text editing): ~389ms -> ~352ms.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ checksum = "3f3d053a135388e6b1df14e8af1212af5064746e9b87a06a345a7a779ee9695a"
 
 [[package]]
 name = "loro-wasm"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -39,6 +39,18 @@ const REGULAR_CONTAINER_VALUE_ARG_ERROR: &str =
 mod text_update;
 
 fn ensure_no_regular_container_value(value: &LoroValue) -> LoroResult<()> {
+    // Fast path: scalar values can never transitively hold a container, so we
+    // skip the heap allocation + traversal below. This is the common case on
+    // the per-op insert hot path (inserting numbers/strings/bools), where the
+    // previous unconditional `vec![value]` allocation showed up as a measurable
+    // regression.
+    if !matches!(
+        value,
+        LoroValue::Container(_) | LoroValue::List(_) | LoroValue::Map(_)
+    ) {
+        return Ok(());
+    }
+
     let mut stack = vec![value];
     while let Some(value) = stack.pop() {
         match value {
@@ -1506,7 +1518,7 @@ impl TextHandler {
                 t.value.len_utf16()
             }
             MaybeDetached::Attached(a) => {
-                a.with_doc_state(|state| state.get_text_utf16_len(a.container_idx))
+                a.with_doc_state(|state| state.get_text_len(a.container_idx, PosType::Utf16))
             }
         }
     }
@@ -1518,7 +1530,7 @@ impl TextHandler {
                 t.value.len_unicode()
             }
             MaybeDetached::Attached(a) => {
-                a.with_doc_state(|state| state.get_text_unicode_len(a.container_idx))
+                a.with_doc_state(|state| state.get_text_len(a.container_idx, PosType::Unicode))
             }
         }
     }
@@ -1536,25 +1548,9 @@ impl TextHandler {
     fn len(&self, pos_type: PosType) -> usize {
         match &self.inner {
             MaybeDetached::Detached(t) => t.lock().value.len(pos_type),
-            MaybeDetached::Attached(a) if a.has_decoded_state() || pos_type == PosType::Entity => {
-                a.with_state(|state| state.as_richtext_state_mut().unwrap().len(pos_type))
+            MaybeDetached::Attached(a) => {
+                a.with_doc_state(|state| state.get_text_len(a.container_idx, pos_type))
             }
-            MaybeDetached::Attached(a) => match pos_type {
-                PosType::Bytes => a.get_value().as_string().unwrap().len(),
-                PosType::Unicode => {
-                    a.with_doc_state(|state| state.get_text_unicode_len(a.container_idx))
-                }
-                PosType::Utf16 => {
-                    a.with_doc_state(|state| state.get_text_utf16_len(a.container_idx))
-                }
-                PosType::Event if cfg!(feature = "wasm") => {
-                    a.with_doc_state(|state| state.get_text_utf16_len(a.container_idx))
-                }
-                PosType::Event => {
-                    a.with_doc_state(|state| state.get_text_unicode_len(a.container_idx))
-                }
-                PosType::Entity => unreachable!("entity length is handled by the state path"),
-            },
         }
     }
 

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1504,10 +1504,9 @@ impl TextHandler {
                 let t = t.lock();
                 t.value.len_utf8()
             }
-            MaybeDetached::Attached(a) if a.has_decoded_state() => {
-                a.with_state(|state| state.as_richtext_state_mut().unwrap().len_utf8())
+            MaybeDetached::Attached(a) => {
+                a.with_doc_state(|state| state.get_text_len(a.container_idx, PosType::Bytes))
             }
-            MaybeDetached::Attached(a) => a.get_value().as_string().unwrap().len(),
         }
     }
 

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -976,6 +976,10 @@ impl DocState {
         self.store.text_utf16_len(container_idx).unwrap_or(0)
     }
 
+    pub(crate) fn get_text_utf8_len(&mut self, container_idx: ContainerIdx) -> usize {
+        self.store.text_utf8_len(container_idx).unwrap_or(0)
+    }
+
     pub(crate) fn has_decoded_container_state(&mut self, container_idx: ContainerIdx) -> bool {
         self.store.has_decoded_state(container_idx)
     }
@@ -996,10 +1000,7 @@ impl DocState {
             PosType::Utf16 => self.get_text_utf16_len(container_idx),
             PosType::Event if cfg!(feature = "wasm") => self.get_text_utf16_len(container_idx),
             PosType::Event => self.get_text_unicode_len(container_idx),
-            PosType::Bytes => self
-                .get_value_by_idx(container_idx)
-                .as_string()
-                .map_or(0, |s| s.len()),
+            PosType::Bytes => self.get_text_utf8_len(container_idx),
             PosType::Entity => self.with_state_mut(container_idx, |state| {
                 state.as_richtext_state_mut().unwrap().len(PosType::Entity)
             }),

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -17,7 +17,7 @@ use tracing::{info_span, instrument, warn};
 use crate::{
     configure::{Configure, DefaultRandom, SecureRandomGenerator},
     container::{idx::ContainerIdx, richtext::config::StyleConfigMap},
-    cursor::Cursor,
+    cursor::{Cursor, PosType},
     delta::TreeExternalDiff,
     diff_calc::{DiffCalculator, DiffMode},
     event::{Diff, EventTriggerKind, Index, InternalContainerDiff, InternalDiff},
@@ -978,6 +978,32 @@ impl DocState {
 
     pub(crate) fn has_decoded_container_state(&mut self, container_idx: ContainerIdx) -> bool {
         self.store.has_decoded_state(container_idx)
+    }
+
+    /// Length of a text container in the given `pos_type`, taking a single
+    /// `DocState` lock and a single container-store lookup.
+    ///
+    /// The per-`pos_type` store helpers already branch on decoded-vs-lazy
+    /// internally, and their lazy branch reads the cheap length metadata
+    /// without materializing the full richtext state — preserving the
+    /// lazy-snapshot memory behavior. Callers previously took two separate
+    /// locks (one to check decoded-ness, one to query), which showed up as a
+    /// per-op regression on the text editing hot path. Only `Entity` length has
+    /// no store helper and falls back to the state path.
+    pub(crate) fn get_text_len(&mut self, container_idx: ContainerIdx, pos_type: PosType) -> usize {
+        match pos_type {
+            PosType::Unicode => self.get_text_unicode_len(container_idx),
+            PosType::Utf16 => self.get_text_utf16_len(container_idx),
+            PosType::Event if cfg!(feature = "wasm") => self.get_text_utf16_len(container_idx),
+            PosType::Event => self.get_text_unicode_len(container_idx),
+            PosType::Bytes => self
+                .get_value_by_idx(container_idx)
+                .as_string()
+                .map_or(0, |s| s.len()),
+            PosType::Entity => self.with_state_mut(container_idx, |state| {
+                state.as_richtext_state_mut().unwrap().len(PosType::Entity)
+            }),
+        }
     }
 
     /// Set the state of the container with the given container idx.

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -161,6 +161,11 @@ impl ContainerStore {
             .with_container_for_read(idx, |c| c.text_utf16_len(idx, ctx!(self)))?
     }
 
+    pub fn text_utf8_len(&mut self, idx: ContainerIdx) -> Option<usize> {
+        self.store
+            .with_container_for_read(idx, |c| c.text_utf8_len(idx, ctx!(self)))?
+    }
+
     pub fn has_decoded_state(&mut self, idx: ContainerIdx) -> bool {
         self.store.has_decoded_state(idx)
     }

--- a/crates/loro-internal/src/state/container_store/container_wrapper.rs
+++ b/crates/loro-internal/src/state/container_store/container_wrapper.rs
@@ -103,6 +103,15 @@ impl LazyDecodedValue {
             _ => None,
         }
     }
+
+    fn utf8_len(&self) -> Option<usize> {
+        match self {
+            // The decoded text value is the string itself, so its byte length
+            // is a cheap `str::len` — no need to cache a separate field.
+            Self::Text { value, .. } => value.as_string().map(|s| s.len()),
+            _ => None,
+        }
+    }
 }
 
 impl ContainerWrapper {
@@ -332,6 +341,25 @@ impl ContainerWrapper {
                         Some(state.as_richtext_state_mut().unwrap().len_utf16())
                     }
                     ContainerData::Lazy(lazy) => lazy.value.as_ref()?.utf16_len(),
+                }
+            }
+        }
+    }
+
+    pub fn text_utf8_len(
+        &mut self,
+        idx: ContainerIdx,
+        ctx: ContainerCreationContext,
+    ) -> Option<usize> {
+        match &mut self.data {
+            ContainerData::State(state) => Some(state.as_richtext_state_mut().unwrap().len_utf8()),
+            ContainerData::Lazy(_) => {
+                self.decode_value(idx, ctx).unwrap();
+                match &mut self.data {
+                    ContainerData::State(state) => {
+                        Some(state.as_richtext_state_mut().unwrap().len_utf8())
+                    }
+                    ContainerData::Lazy(lazy) => lazy.value.as_ref()?.utf8_len(),
                 }
             }
         }


### PR DESCRIPTION
## Summary

Recovers two **constant-factor per-operation editing regressions** that crept in
between the 1.11.1 release and current HEAD. Both were introduced by the
lazy-snapshot work in #985 and were found by bisecting the public-API editing
benchmarks against the `loro-internal-v1.11.1` tag.

These are distinct from #1019 (which fixed genuine *O(n²)* editing paths); these
are O(1)-per-op overheads that nonetheless added ~15–20% to common editing
workloads.

## Fixes

**1. Per-insert allocation in `ensure_no_regular_container_value` (`handler.rs`)**

Every `MapHandler`/`ListHandler`/`MovableListHandler` insert (14 call sites)
heap-allocated a `Vec` to walk the value for nested containers — even for scalar
values, which is the overwhelmingly common case. Added a scalar fast-path that
returns before allocating.

**2. Double `DocState` lock on the text bounds check (`handler.rs` → `state.rs`)**

`TextHandler::len`/`len_unicode`/`len_utf16` are called on every public text
`insert`/`delete`. Post-#985 they took **two** `DocState` locks — one to check
whether the container state was decoded, then another to query the length.
Consolidated into a single `DocState::get_text_len` taking **one** lock + one
container-store lookup. The per-`pos_type` store helpers already branch
decoded-vs-lazy internally, so the lazy-snapshot memory optimization is fully
preserved: a still-lazy container reads its cached length metadata without
materializing the richtext state.

## Benchmarks (clean, back-to-back, same machine)

| Benchmark | Before (HEAD) | After | vs 1.11.1 |
|---|---|---|---|
| `map create 10^4 key` | ~19.4 ms | **~10.7 ms** (−45%) | was 16.9 ms → now faster than 1.11 |
| `bench_text B4 apply` (per-op text) | ~389 ms | **~352 ms** (−9.5%) | recovers ~half of #985's regression |

## Validation

- `cargo test -p loro-internal --lib --features test_utils,counter` — 287 passed
  (incl. the lazy-decode invariant tests `text_lazy_event_queries_match_decoded_state`
  and `text_snapshot_string_queries_do_not_decode_state`, which guard #985's
  no-force-decode behavior).
- `cargo test -p loro-internal --test mergeable_container` — 22 passed.
- `cargo test -p loro --test contracts list_movable_boundary` — 4 passed
  (incl. the container-rejection error path for fix #1).

## Not addressed here

The remaining ~half of the text per-op regression comes from #985's lazy
`ContainerWrapper` indirection on the **state-apply** path
(`with_state_mut → get_or_create_mut → ContainerWrapper::get_state_mut →
decode_state`). That is the core of #985's design and warrants a separate,
carefully-benched follow-up rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
