### PR TITLE
fix: avoid lazy parent resolver kv deadlock

### DIFF
--- a/.changeset/quick-kv-deadlock-fix.md
+++ b/.changeset/quick-kv-deadlock-fix.md
@@ -1,0 +1,6 @@
+---
+"loro-crdt": patch
+"loro-crdt-map": patch
+---
+
+Fix a potential deadlock when lazy snapshot loading resolves mergeable container parent depths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ checksum = "3f3d053a135388e6b1df14e8af1212af5064746e9b87a06a345a7a779ee9695a"
 
 [[package]]
 name = "loro-wasm"
-version = "1.13.4"
+version = "1.13.5"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -29,7 +29,8 @@ type ParentResolver = dyn Fn(ContainerID) -> Option<ContainerID> + Send + Sync +
 #[derive(Default)]
 struct ArenaContainers {
     container_idx_to_id: Vec<ContainerID>,
-    // 0 stands for unknown, 1 stands for root containers
+    /// Cached container depth. `None` means unknown or waiting on an unknown parent depth.
+    /// Use `get_depth()` for authoritative reads; direct access is only a cache fast path.
     depth: Vec<Option<NonZeroU16>>,
     container_id_to_idx: FxHashMap<ContainerID, ContainerIdx>,
     /// The parent of each container.
@@ -44,6 +45,9 @@ struct ArenaContainers {
     top_level_root_c_idx: Vec<ContainerIdx>,
     /// Optional resolver used when querying parent for a container that has not been registered yet.
     /// If set, `get_parent` will try this resolver to lazily fetch and register the parent.
+    ///
+    /// Locking: the resolver may read the state KV store. Code that loads from KV must snapshot
+    /// KV data and release the KV lock before taking the arena lock.
     parent_resolver: Option<Arc<ParentResolver>>,
 }
 
@@ -152,8 +156,10 @@ impl ArenaContainers {
 
         match parent {
             Some(p) => {
-                // Keep parent linking side-effect free: resolving a missing parent depth may
-                // re-enter lazy storage while callers are already holding unrelated locks.
+                // Keep parent linking side-effect free. Calling `get_depth()` here may invoke the
+                // lazy parent resolver, which can acquire the state KV lock. Import/load paths may
+                // be assembling parent edges from KV snapshots, so resolving depth here would make
+                // arena -> KV and KV -> arena lock orders coexist.
                 if let Some(d) = self.depth[p.to_index() as usize] {
                     self.depth[child.to_index() as usize] = NonZeroU16::new(d.get() + 1);
                 } else {

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -152,7 +152,9 @@ impl ArenaContainers {
 
         match parent {
             Some(p) => {
-                if let Some(d) = self.get_depth(p) {
+                // Keep parent linking side-effect free: resolving a missing parent depth may
+                // re-enter lazy storage while callers are already holding unrelated locks.
+                if let Some(d) = self.depth[p.to_index() as usize] {
                     self.depth[child.to_index() as usize] = NonZeroU16::new(d.get() + 1);
                 } else {
                     self.depth[child.to_index() as usize] = None;
@@ -190,21 +192,20 @@ impl ArenaContainers {
                 // a mergeable cid) lands in `root_c_idx`, gets its own parent edge wired up,
                 // and has `parents` initialized — instead of being half-registered with just
                 // `idx_to_id` / `id_to_idx` / `depth` and silently missing from retention walks.
-                let parent_idx = if let Some(idx) =
-                    self.container_id_to_idx.get(&parent_id).copied()
-                {
-                    // Already in the arena. For a top-level root that was hand-registered
-                    // somewhere else without a `parents` entry, ensure it has one.
-                    if parent_id.is_root() && !parent_id.is_mergeable() {
-                        self.parents.entry(idx).or_insert(None);
-                        if self.depth[idx.to_index() as usize].is_none() {
-                            self.depth[idx.to_index() as usize] = NonZeroU16::new(1);
+                let parent_idx =
+                    if let Some(idx) = self.container_id_to_idx.get(&parent_id).copied() {
+                        // Already in the arena. For a top-level root that was hand-registered
+                        // somewhere else without a `parents` entry, ensure it has one.
+                        if parent_id.is_root() && !parent_id.is_mergeable() {
+                            self.parents.entry(idx).or_insert(None);
+                            if self.depth[idx.to_index() as usize].is_none() {
+                                self.depth[idx.to_index() as usize] = NonZeroU16::new(1);
+                            }
                         }
-                    }
-                    idx
-                } else {
-                    self.register_container(&parent_id)
-                };
+                        idx
+                    } else {
+                        self.register_container(&parent_id)
+                    };
 
                 Some(parent_idx)
             }
@@ -766,6 +767,10 @@ impl SharedArena {
 mod tests {
     use super::*;
     use loro_common::ContainerType;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     /// When a non-mergeable child is registered, then later asks for its depth and the parent
     /// resolver yields a mergeable cid, the mergeable parent must be registered through the
@@ -778,12 +783,8 @@ mod tests {
         let arena = SharedArena::new();
 
         let top_root = ContainerID::new_root("state", ContainerType::Map);
-        let mergeable_parent =
-            ContainerID::new_mergeable(&top_root, "profile", ContainerType::Map);
-        let child = ContainerID::new_normal(
-            loro_common::ID::new(1, 0),
-            ContainerType::List,
-        );
+        let mergeable_parent = ContainerID::new_mergeable(&top_root, "profile", ContainerType::Map);
+        let child = ContainerID::new_normal(loro_common::ID::new(1, 0), ContainerType::List);
 
         let mergeable_parent_for_resolver = mergeable_parent.clone();
         let child_for_resolver = child.clone();
@@ -809,7 +810,9 @@ mod tests {
 
         let flag = LoadAllFlag;
         assert!(
-            !arena.top_level_root_containers(flag).contains(&mergeable_idx),
+            !arena
+                .top_level_root_containers(flag)
+                .contains(&mergeable_idx),
             "mergeable parent must not appear in user-facing top-level enumeration"
         );
 
@@ -822,6 +825,26 @@ mod tests {
                 .top_level_root_containers(flag)
                 .contains(&top_root_idx),
             "the mergeable parent's grandparent (a top-level root) must be in the top-level list"
+        );
+    }
+
+    #[test]
+    fn set_parent_does_not_resolve_missing_parent_depth() {
+        let arena = SharedArena::new();
+        let parent = ContainerID::new_normal(loro_common::ID::new(1, 0), ContainerType::Map);
+        let child = ContainerID::new_mergeable(&parent, "field", ContainerType::Text);
+        let resolver_called = Arc::new(AtomicBool::new(false));
+        let called = resolver_called.clone();
+        arena.set_parent_resolver(Some(move |_| {
+            called.store(true, Ordering::SeqCst);
+            None
+        }));
+
+        arena.register_container(&child);
+
+        assert!(
+            !resolver_called.load(Ordering::SeqCst),
+            "registering a mergeable child must not invoke the lazy parent resolver"
         );
     }
 }

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use bytes::Bytes;
 use loro_common::ContainerID;
-use std::ops::Bound;
 
 use super::ContainerWrapper;
 
@@ -298,21 +297,19 @@ impl InnerStore {
             .import(bytes_b)
             .map_err(|e| loro_common::LoroError::DecodeError(e.into_boxed_str()))?;
         self.kv.remove(FRONTIERS_KEY);
+        let entries = self.kv.scan_all_entries();
         let store = &mut self.store;
         let arena = &self.arena;
-        self.kv.with_kv(|kv| {
-            arena.with_guards(|guards| {
-                let iter = kv.scan(Bound::Unbounded, Bound::Unbounded);
-                for (k, v) in iter {
-                    let cid = ContainerID::from_bytes(&k);
-                    let c = ContainerWrapper::new_from_bytes(v);
-                    let parent = c.parent();
-                    let idx = guards.register_container(&cid);
-                    let p = parent.as_ref().map(|p| guards.register_container(p));
-                    guards.set_parent(idx, p);
-                    if Self::insert_entry(store, idx, c).is_some() {}
-                }
-            });
+        arena.with_guards(|guards| {
+            for (k, v) in entries {
+                let cid = ContainerID::from_bytes(&k);
+                let c = ContainerWrapper::new_from_bytes(v);
+                let parent = c.parent();
+                let idx = guards.register_container(&cid);
+                let p = parent.as_ref().map(|p| guards.register_container(p));
+                guards.set_parent(idx, p);
+                if Self::insert_entry(store, idx, c).is_some() {}
+            }
         });
 
         self.load_state = LoadState::AllLoaded;
@@ -324,24 +321,22 @@ impl InnerStore {
             return;
         }
 
+        let entries = self.kv.scan_all_entries();
         let store = &mut self.store;
         let arena = &self.arena;
-        self.kv.with_kv(|kv| {
-            let iter = kv.scan(Bound::Unbounded, Bound::Unbounded);
-            arena.with_guards(|guards| {
-                for (k, v) in iter {
-                    let cid = ContainerID::from_bytes(&k);
-                    let idx = guards.register_container(&cid);
-                    if Self::contains_idx_in(store, idx) {
-                        // the container is already loaded
-                        // the content in `store` is guaranteed to be newer than the content in `kv`
-                        continue;
-                    }
-
-                    let container = ContainerWrapper::new_from_bytes(v);
-                    Self::insert_entry(store, idx, container);
+        arena.with_guards(|guards| {
+            for (k, v) in entries {
+                let cid = ContainerID::from_bytes(&k);
+                let idx = guards.register_container(&cid);
+                if Self::contains_idx_in(store, idx) {
+                    // the container is already loaded
+                    // the content in `store` is guaranteed to be newer than the content in `kv`
+                    continue;
                 }
-            });
+
+                let container = ContainerWrapper::new_from_bytes(v);
+                Self::insert_entry(store, idx, container);
+            }
         });
 
         self.load_state = LoadState::AllLoaded;
@@ -353,16 +348,14 @@ impl InnerStore {
         }
 
         let arena = &self.arena;
-        self.kv.with_kv(|kv| {
-            let iter = kv.scan(Bound::Unbounded, Bound::Unbounded);
-            arena.with_guards(|guards| {
-                for (k, _) in iter {
-                    let cid = ContainerID::from_bytes(&k);
-                    if cid.is_root() {
-                        guards.register_container(&cid);
-                    }
+        let keys = self.kv.scan_all_keys();
+        arena.with_guards(|guards| {
+            for k in keys {
+                let cid = ContainerID::from_bytes(&k);
+                if cid.is_root() {
+                    guards.register_container(&cid);
                 }
-            });
+            }
         });
         self.load_state = LoadState::RootsLoaded;
     }
@@ -409,33 +402,10 @@ impl InnerStore {
 mod tests {
     use super::*;
     use loro_common::{ContainerType, ID};
-    use std::{
-        panic::{catch_unwind, AssertUnwindSafe},
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            mpsc, Arc,
-        },
-        time::Duration,
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
     };
-
-    fn assert_completes_without_deadlock(name: &'static str, f: impl FnOnce() + Send + 'static) {
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let result = catch_unwind(AssertUnwindSafe(f));
-            let _ = tx.send(result);
-        });
-
-        match rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(Ok(())) => {}
-            Ok(Err(payload)) => std::panic::resume_unwind(payload),
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                panic!("{name} did not complete; possible recursive KV lock deadlock")
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("{name} thread disconnected without a result")
-            }
-        }
-    }
 
     fn encoded_container_header(kind: ContainerType, parent: Option<ContainerID>) -> Bytes {
         let mut output = Vec::new();
@@ -452,14 +422,19 @@ mod tests {
         (child_id, value)
     }
 
-    fn install_reentrant_parent_resolver(arena: &SharedArena, kv: KvWrapper) -> Arc<AtomicBool> {
+    fn install_parent_resolver_guard(
+        arena: &SharedArena,
+        loading: Arc<AtomicBool>,
+    ) -> Arc<AtomicBool> {
         let resolver_called = Arc::new(AtomicBool::new(false));
         let called = resolver_called.clone();
-        arena.set_parent_resolver(Some(move |child_id: ContainerID| {
+        arena.set_parent_resolver(Some(move |_child_id: ContainerID| {
+            assert!(
+                !loading.load(Ordering::SeqCst),
+                "lazy parent resolver must not run while loading from KV"
+            );
             called.store(true, Ordering::SeqCst);
-            let value = kv.get(&child_id.to_bytes())?;
-            let container = ContainerWrapper::new_from_bytes(value);
-            container.parent().cloned()
+            None
         }));
         resolver_called
     }
@@ -471,71 +446,77 @@ mod tests {
     }
 
     #[test]
-    fn load_all_does_not_resolve_parent_while_kv_lock_is_held() {
+    fn load_all_does_not_resolve_parent_while_loading_from_kv() {
         let arena = SharedArena::new();
         let mut store = InnerStore::new(arena.clone(), Configure::default());
-        let resolver_called = install_reentrant_parent_resolver(&arena, store.kv.arc_clone());
+        let loading = Arc::new(AtomicBool::new(false));
+        let resolver_called = install_parent_resolver_guard(&arena, loading.clone());
         let (child_id, value) = mergeable_child_entry();
         let child_id_for_depth = child_id.clone();
-        let arena_for_depth = arena.clone();
         store.load_state = LoadState::Lazy;
         store
             .kv
             .set_all(vec![(Bytes::from(child_id.to_bytes()), value)]);
 
-        assert_completes_without_deadlock("load_all", move || {
-            store.load_all();
-            let child_idx = arena_for_depth.id_to_idx(&child_id_for_depth).unwrap();
-            let _ = arena_for_depth.get_depth(child_idx);
-            assert!(
-                resolver_called.load(Ordering::SeqCst),
-                "lazy parent resolver should still work after load_all returns"
-            );
-        });
+        loading.store(true, Ordering::SeqCst);
+        store.load_all();
+        loading.store(false, Ordering::SeqCst);
+        assert!(!resolver_called.load(Ordering::SeqCst));
+
+        let child_idx = arena.id_to_idx(&child_id_for_depth).unwrap();
+        let _ = arena.get_depth(child_idx);
+        assert!(
+            resolver_called.load(Ordering::SeqCst),
+            "lazy parent resolver should still work after load_all returns"
+        );
     }
 
     #[test]
-    fn load_roots_does_not_resolve_parent_while_kv_lock_is_held() {
+    fn load_roots_does_not_resolve_parent_while_loading_from_kv() {
         let arena = SharedArena::new();
         let mut store = InnerStore::new(arena.clone(), Configure::default());
-        let resolver_called = install_reentrant_parent_resolver(&arena, store.kv.arc_clone());
+        let loading = Arc::new(AtomicBool::new(false));
+        let resolver_called = install_parent_resolver_guard(&arena, loading.clone());
         let (child_id, value) = mergeable_child_entry();
         let child_id_for_depth = child_id.clone();
-        let arena_for_depth = arena.clone();
         store.load_state = LoadState::Lazy;
         store
             .kv
             .set_all(vec![(Bytes::from(child_id.to_bytes()), value)]);
 
-        assert_completes_without_deadlock("load_roots", move || {
-            store.load_roots();
-            let child_idx = arena_for_depth.id_to_idx(&child_id_for_depth).unwrap();
-            let _ = arena_for_depth.get_depth(child_idx);
-            assert!(
-                resolver_called.load(Ordering::SeqCst),
-                "lazy parent resolver should still work after load_roots returns"
-            );
-        });
+        loading.store(true, Ordering::SeqCst);
+        store.load_roots();
+        loading.store(false, Ordering::SeqCst);
+        assert!(!resolver_called.load(Ordering::SeqCst));
+
+        let child_idx = arena.id_to_idx(&child_id_for_depth).unwrap();
+        let _ = arena.get_depth(child_idx);
+        assert!(
+            resolver_called.load(Ordering::SeqCst),
+            "lazy parent resolver should still work after load_roots returns"
+        );
     }
 
     #[test]
-    fn decode_twice_does_not_resolve_parent_while_kv_lock_is_held() {
+    fn decode_twice_does_not_resolve_parent_while_loading_from_kv() {
         let arena = SharedArena::new();
         let mut store = InnerStore::new(arena.clone(), Configure::default());
-        let resolver_called = install_reentrant_parent_resolver(&arena, store.kv.arc_clone());
+        let loading = Arc::new(AtomicBool::new(false));
+        let resolver_called = install_parent_resolver_guard(&arena, loading.clone());
         let (child_id, value) = mergeable_child_entry();
         let child_id_for_depth = child_id.clone();
-        let arena_for_depth = arena.clone();
         let bytes = kv_bytes_with_entry(child_id, value);
 
-        assert_completes_without_deadlock("decode_twice", move || {
-            store.decode_twice(bytes, Bytes::new()).unwrap();
-            let child_idx = arena_for_depth.id_to_idx(&child_id_for_depth).unwrap();
-            let _ = arena_for_depth.get_depth(child_idx);
-            assert!(
-                resolver_called.load(Ordering::SeqCst),
-                "lazy parent resolver should still work after decode_twice returns"
-            );
-        });
+        loading.store(true, Ordering::SeqCst);
+        store.decode_twice(bytes, Bytes::new()).unwrap();
+        loading.store(false, Ordering::SeqCst);
+        assert!(!resolver_called.load(Ordering::SeqCst));
+
+        let child_idx = arena.id_to_idx(&child_id_for_depth).unwrap();
+        let _ = arena.get_depth(child_idx);
+        assert!(
+            resolver_called.load(Ordering::SeqCst),
+            "lazy parent resolver should still work after decode_twice returns"
+        );
     }
 }

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -250,7 +250,7 @@ impl InnerStore {
         for cid in deleted_roots {
             self.kv.remove(&cid);
         }
-        self.kv.set_all(updates.into_iter());
+        self.kv.set_all(updates);
     }
 
     pub(crate) fn get_kv_clone(&self) -> KvWrapper {
@@ -402,5 +402,140 @@ impl InnerStore {
         let mut new_store = Self::new(arena, config.clone());
         new_store.decode(bytes).unwrap();
         new_store
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loro_common::{ContainerType, ID};
+    use std::{
+        panic::{catch_unwind, AssertUnwindSafe},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            mpsc, Arc,
+        },
+        time::Duration,
+    };
+
+    fn assert_completes_without_deadlock(name: &'static str, f: impl FnOnce() + Send + 'static) {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = catch_unwind(AssertUnwindSafe(f));
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(Ok(())) => {}
+            Ok(Err(payload)) => std::panic::resume_unwind(payload),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                panic!("{name} did not complete; possible recursive KV lock deadlock")
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("{name} thread disconnected without a result")
+            }
+        }
+    }
+
+    fn encoded_container_header(kind: ContainerType, parent: Option<ContainerID>) -> Bytes {
+        let mut output = Vec::new();
+        output.push(kind.to_u8());
+        leb128::write::unsigned(&mut output, 2).unwrap();
+        postcard::to_io(&parent, &mut output).unwrap();
+        output.into()
+    }
+
+    fn mergeable_child_entry() -> (ContainerID, Bytes) {
+        let parent_id = ContainerID::new_normal(ID::new(1, 0), ContainerType::Map);
+        let child_id = ContainerID::new_mergeable(&parent_id, "field", ContainerType::Text);
+        let value = encoded_container_header(ContainerType::Text, Some(parent_id));
+        (child_id, value)
+    }
+
+    fn install_reentrant_parent_resolver(arena: &SharedArena, kv: KvWrapper) -> Arc<AtomicBool> {
+        let resolver_called = Arc::new(AtomicBool::new(false));
+        let called = resolver_called.clone();
+        arena.set_parent_resolver(Some(move |child_id: ContainerID| {
+            called.store(true, Ordering::SeqCst);
+            let value = kv.get(&child_id.to_bytes())?;
+            let container = ContainerWrapper::new_from_bytes(value);
+            container.parent().cloned()
+        }));
+        resolver_called
+    }
+
+    fn kv_bytes_with_entry(cid: ContainerID, value: Bytes) -> Bytes {
+        let kv = KvWrapper::new_mem();
+        kv.set_all(vec![(Bytes::from(cid.to_bytes()), value)]);
+        kv.export()
+    }
+
+    #[test]
+    fn load_all_does_not_resolve_parent_while_kv_lock_is_held() {
+        let arena = SharedArena::new();
+        let mut store = InnerStore::new(arena.clone(), Configure::default());
+        let resolver_called = install_reentrant_parent_resolver(&arena, store.kv.arc_clone());
+        let (child_id, value) = mergeable_child_entry();
+        let child_id_for_depth = child_id.clone();
+        let arena_for_depth = arena.clone();
+        store.load_state = LoadState::Lazy;
+        store
+            .kv
+            .set_all(vec![(Bytes::from(child_id.to_bytes()), value)]);
+
+        assert_completes_without_deadlock("load_all", move || {
+            store.load_all();
+            let child_idx = arena_for_depth.id_to_idx(&child_id_for_depth).unwrap();
+            let _ = arena_for_depth.get_depth(child_idx);
+            assert!(
+                resolver_called.load(Ordering::SeqCst),
+                "lazy parent resolver should still work after load_all returns"
+            );
+        });
+    }
+
+    #[test]
+    fn load_roots_does_not_resolve_parent_while_kv_lock_is_held() {
+        let arena = SharedArena::new();
+        let mut store = InnerStore::new(arena.clone(), Configure::default());
+        let resolver_called = install_reentrant_parent_resolver(&arena, store.kv.arc_clone());
+        let (child_id, value) = mergeable_child_entry();
+        let child_id_for_depth = child_id.clone();
+        let arena_for_depth = arena.clone();
+        store.load_state = LoadState::Lazy;
+        store
+            .kv
+            .set_all(vec![(Bytes::from(child_id.to_bytes()), value)]);
+
+        assert_completes_without_deadlock("load_roots", move || {
+            store.load_roots();
+            let child_idx = arena_for_depth.id_to_idx(&child_id_for_depth).unwrap();
+            let _ = arena_for_depth.get_depth(child_idx);
+            assert!(
+                resolver_called.load(Ordering::SeqCst),
+                "lazy parent resolver should still work after load_roots returns"
+            );
+        });
+    }
+
+    #[test]
+    fn decode_twice_does_not_resolve_parent_while_kv_lock_is_held() {
+        let arena = SharedArena::new();
+        let mut store = InnerStore::new(arena.clone(), Configure::default());
+        let resolver_called = install_reentrant_parent_resolver(&arena, store.kv.arc_clone());
+        let (child_id, value) = mergeable_child_entry();
+        let child_id_for_depth = child_id.clone();
+        let arena_for_depth = arena.clone();
+        let bytes = kv_bytes_with_entry(child_id, value);
+
+        assert_completes_without_deadlock("decode_twice", move || {
+            store.decode_twice(bytes, Bytes::new()).unwrap();
+            let child_idx = arena_for_depth.id_to_idx(&child_id_for_depth).unwrap();
+            let _ = arena_for_depth.get_depth(child_idx);
+            assert!(
+                resolver_called.load(Ordering::SeqCst),
+                "lazy parent resolver should still work after decode_twice returns"
+            );
+        });
     }
 }

--- a/crates/loro-internal/src/utils/kv_wrapper.rs
+++ b/crates/loro-internal/src/utils/kv_wrapper.rs
@@ -64,9 +64,9 @@ impl KvWrapper {
             .collect()
     }
 
-    pub fn set_all(&self, iter: impl Iterator<Item = (Bytes, Bytes)>) {
+    pub fn set_all(&self, updates: Vec<(Bytes, Bytes)>) {
         let mut kv = self.kv.lock();
-        for (k, v) in iter {
+        for (k, v) in updates {
             kv.set(&k, v);
         }
     }
@@ -77,9 +77,14 @@ impl KvWrapper {
     }
 
     pub(crate) fn remove_same(&self, old_kv: &KvWrapper) {
-        let other = old_kv.kv.lock();
+        let old_entries = {
+            let other = old_kv.kv.lock();
+            other
+                .scan(Bound::Unbounded, Bound::Unbounded)
+                .collect::<Vec<_>>()
+        };
         let mut this = self.kv.lock();
-        for (k, v) in other.scan(Bound::Unbounded, Bound::Unbounded) {
+        for (k, v) in old_entries {
             if this.get(&k) == Some(v) {
                 this.remove(&k);
             }
@@ -111,5 +116,58 @@ impl KvWrapper {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.kv.lock().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        panic::{catch_unwind, AssertUnwindSafe},
+        sync::mpsc,
+        time::Duration,
+    };
+
+    fn assert_completes_without_deadlock(name: &'static str, f: impl FnOnce() + Send + 'static) {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = catch_unwind(AssertUnwindSafe(f));
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(Ok(())) => {}
+            Ok(Err(payload)) => std::panic::resume_unwind(payload),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                panic!("{name} did not complete; possible recursive KV lock deadlock")
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("{name} thread disconnected without a result")
+            }
+        }
+    }
+
+    #[test]
+    fn set_all_applies_precollected_updates() {
+        let kv = KvWrapper::new_mem();
+
+        assert_completes_without_deadlock("set_all", move || {
+            kv.set_all(vec![(
+                Bytes::from_static(b"key"),
+                Bytes::from_static(b"value"),
+            )]);
+            assert_eq!(kv.get(b"key"), Some(Bytes::from_static(b"value")));
+        });
+    }
+
+    #[test]
+    fn remove_same_can_compare_a_store_with_itself() {
+        let kv = KvWrapper::new_mem();
+        kv.insert(b"key", Bytes::from_static(b"value"));
+
+        assert_completes_without_deadlock("remove_same", move || {
+            kv.remove_same(&kv);
+            assert_eq!(kv.get(b"key"), None);
+        });
     }
 }

--- a/crates/loro-internal/src/utils/kv_wrapper.rs
+++ b/crates/loro-internal/src/utils/kv_wrapper.rs
@@ -52,15 +52,26 @@ impl KvWrapper {
         kv.get(key)
     }
 
-    pub fn with_kv<R>(&self, f: impl FnOnce(&dyn KvStore) -> R) -> R {
-        let kv = self.kv.lock();
-        f(&*kv)
-    }
-
     pub(crate) fn keys(&self) -> BTreeSet<Vec<u8>> {
         let kv = self.kv.lock();
         kv.scan(Bound::Unbounded, Bound::Unbounded)
             .map(|(k, _)| k.to_vec())
+            .collect()
+    }
+
+    /// Snapshot all entries while holding only the KV lock.
+    ///
+    /// Callers that also need the arena lock must use this instead of entering arena code from
+    /// inside a KV-locked closure. Lazy arena parent resolution can acquire this same KV lock.
+    pub(crate) fn scan_all_entries(&self) -> Vec<(Bytes, Bytes)> {
+        let kv = self.kv.lock();
+        kv.scan(Bound::Unbounded, Bound::Unbounded).collect()
+    }
+
+    pub(crate) fn scan_all_keys(&self) -> Vec<Bytes> {
+        let kv = self.kv.lock();
+        kv.scan(Bound::Unbounded, Bound::Unbounded)
+            .map(|(k, _)| k)
             .collect()
     }
 
@@ -77,14 +88,21 @@ impl KvWrapper {
     }
 
     pub(crate) fn remove_same(&self, old_kv: &KvWrapper) {
-        let old_entries = {
-            let other = old_kv.kv.lock();
-            other
+        if Arc::ptr_eq(&self.kv, &old_kv.kv) {
+            let mut this = self.kv.lock();
+            let keys = this
                 .scan(Bound::Unbounded, Bound::Unbounded)
-                .collect::<Vec<_>>()
-        };
+                .map(|(k, _)| k)
+                .collect::<Vec<_>>();
+            for k in keys {
+                this.remove(&k);
+            }
+            return;
+        }
+
+        let other = old_kv.kv.lock();
         let mut this = self.kv.lock();
-        for (k, v) in old_entries {
+        for (k, v) in other.scan(Bound::Unbounded, Bound::Unbounded) {
             if this.get(&k) == Some(v) {
                 this.remove(&k);
             }
@@ -122,52 +140,30 @@ impl KvWrapper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        panic::{catch_unwind, AssertUnwindSafe},
-        sync::mpsc,
-        time::Duration,
-    };
-
-    fn assert_completes_without_deadlock(name: &'static str, f: impl FnOnce() + Send + 'static) {
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let result = catch_unwind(AssertUnwindSafe(f));
-            let _ = tx.send(result);
-        });
-
-        match rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(Ok(())) => {}
-            Ok(Err(payload)) => std::panic::resume_unwind(payload),
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                panic!("{name} did not complete; possible recursive KV lock deadlock")
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("{name} thread disconnected without a result")
-            }
-        }
-    }
 
     #[test]
     fn set_all_applies_precollected_updates() {
         let kv = KvWrapper::new_mem();
 
-        assert_completes_without_deadlock("set_all", move || {
-            kv.set_all(vec![(
-                Bytes::from_static(b"key"),
-                Bytes::from_static(b"value"),
-            )]);
-            assert_eq!(kv.get(b"key"), Some(Bytes::from_static(b"value")));
-        });
+        kv.set_all(vec![(
+            Bytes::from_static(b"key"),
+            Bytes::from_static(b"value"),
+        )]);
+        assert_eq!(kv.get(b"key"), Some(Bytes::from_static(b"value")));
     }
 
     #[test]
-    fn remove_same_can_compare_a_store_with_itself() {
+    fn remove_same_streams_different_stores() {
         let kv = KvWrapper::new_mem();
-        kv.insert(b"key", Bytes::from_static(b"value"));
+        let old_kv = KvWrapper::new_mem();
+        kv.insert(b"same", Bytes::from_static(b"value"));
+        kv.insert(b"changed", Bytes::from_static(b"new"));
+        old_kv.insert(b"same", Bytes::from_static(b"value"));
+        old_kv.insert(b"changed", Bytes::from_static(b"old"));
 
-        assert_completes_without_deadlock("remove_same", move || {
-            kv.remove_same(&kv);
-            assert_eq!(kv.get(b"key"), None);
-        });
+        kv.remove_same(&old_kv);
+
+        assert_eq!(kv.get(b"same"), None);
+        assert_eq!(kv.get(b"changed"), Some(Bytes::from_static(b"new")));
     }
 }


### PR DESCRIPTION
## Summary
- avoid KV -> arena lock inversion in `decode_twice`, `load_all`, and `load_roots` by snapshotting KV scan results before taking arena guards
- keep `set_parent` side-effect free when parent depth is unknown, so it does not invoke the lazy parent resolver while wiring parent edges
- remove the arbitrary `KvWrapper::with_kv` closure API and document the resolver/KV lock-order constraint
- keep `remove_same` streaming for normal shallow-snapshot callers; only special-case identical KV stores
- replace timeout-based deadlock tests with deterministic resolver-guard regression tests
- add a patch changeset for `loro-crdt` and `loro-crdt-map`

Fixes #1026.

## Validation
- `rustfmt --check crates/loro-internal/src/arena.rs crates/loro-internal/src/state/container_store/inner_store.rs crates/loro-internal/src/utils/kv_wrapper.rs`
- `git diff --check`
- `cargo check -p loro-internal`
- `cargo test -p loro-internal loading_from_kv -- --nocapture`
- `cargo test -p loro-internal set_parent_does_not_resolve_missing_parent_depth -- --nocapture`
- `cargo test -p loro-internal utils::kv_wrapper::tests -- --nocapture`
- `cargo test -p loro-internal --test mergeable_container`
- `cargo test -p loro --test loro_rust_test shallow_snapshot -- --nocapture`
- `pnpm changeset status`

## Benchmarks
- Full Criterion bench suite was run for baseline and current; logs are under `/tmp/loro-bench-1026/`.
- Full-suite results had broad machine noise in unrelated benchmarks, so the affected load path was rechecked back-to-back after the final lock-order changes.
- Final targeted result for `text/B4 load`: `origin/main` `[561.35 us 563.37 us 565.53 us]`; this branch `[568.43 us 575.91 us 586.59 us]`; change `[+0.8566% +1.8032% +2.8877%]`, reported by Criterion as within noise threshold.