### PR TITLE
perf: reduce snapshot round memory usage

### DIFF
--- a/.changeset/calm-snapshots-breathe.md
+++ b/.changeset/calm-snapshots-breathe.md
@@ -1,0 +1,10 @@
+---
+"loro-crdt": patch
+---
+
+Reduce peak memory across large snapshot import, `toJSON`, update import, and
+snapshot export by preserving lazy state, bounding the decompressed SSTable
+block cache by bytes, and preallocating the snapshot output exactly. Snapshot
+export now also rejects inconsistent alive-container parent metadata instead of
+persisting it. Snapshot import now validates every embedded SSTable block
+checksum before accepting external bytes.

--- a/.changeset/calm-snapshots-breathe.md
+++ b/.changeset/calm-snapshots-breathe.md
@@ -5,6 +5,16 @@
 Reduce peak memory across large snapshot import, `toJSON`, update import, and
 snapshot export by preserving lazy state, bounding the decompressed SSTable
 block cache by bytes, and preallocating the snapshot output exactly. Snapshot
-export now also rejects inconsistent alive-container parent metadata instead of
-persisting it. Snapshot import now validates every embedded SSTable block
-checksum before accepting external bytes.
+import now validates every embedded SSTable block checksum before accepting
+external bytes.
+
+Full snapshot export no longer walks the alive-container graph: store entries
+for referenced containers are created when the creating op or imported diff is
+applied, so a cold export after a large import is a flush plus KV export
+instead of re-reading every container from compressed blocks. As part of this,
+full export round-trips imported state bytes faithfully (inconsistent
+alive-container parent metadata is now rejected by shallow export, which still
+walks, rather than by full export), and an ensured-but-empty mergeable child is
+no longer materialized into the KV store by a full export — importers resolve
+it from its parent map marker. First `toJSON` after import also avoids decoding
+each lazy container twice.

--- a/context/internal-encoding.md
+++ b/context/internal-encoding.md
@@ -1,6 +1,6 @@
 # Internal Encoding Context
 
-Verified against code 2026-07-20.
+Verified against code 2026-07-21.
 
 Loro has one binary blob envelope, two current binary body formats, two
 recognized-but-unsupported legacy top-level modes, and a separate JSON updates
@@ -84,30 +84,37 @@ document. If a snapshot is imported into a non-empty document,
 `LoroDoc::_import_with` routes through decoded oplog changes instead. Failed
 direct snapshot import must reset both state and oplog.
 
-Default snapshot export must still persist alive empty child containers, but it
-must not materialize the full lazy state store to find them. The alive walk in
-`DocState::get_all_alive_containers` registers root keys, reads snapshot-backed
-values ephemerally (via `try_get_value_ephemeral`, which never caches the
-decoded value or retains a probe-only wrapper), and only inserts a wrapper when
-an alive container has no KV entry. Shallow snapshot retention reuses the same
-complete alive set of arena indices. Do not replace this with
-`InnerStore::load_all` or cache every decoded value: documents with many
-small/deleted containers retain that memory for the rest of the WASM instance.
-`DocState::ensure_all_alive_containers` may retain only the resulting set of
-arena indices after a successful walk, capped at an estimated 4 MiB. It reuses
-that set while both the state frontiers and the existing retention-root list
-are unchanged, bypasses the cache during a transaction, and drops an obsolete
-set before constructing its replacement. The root-list part is required
-because obtaining a new empty top-level root does not advance the CRDT version.
-The walk also reads an uncached container's encoded parent and value through one
-temporary wrapper, so a single export does not probe the same lazy KV entry
-twice. Neither cache retains decoded container values.
-Decompressed SSTable blocks are bounded separately by the kv-store's
-byte-weighted block cache (`BLOCK_CACHE_MAX_BYTES` in `sstable.rs`), so the walk
-uses plain cached reads. The walk reads each present wrapper's parent header
-and checks it against the reachable edge (or a mergeable ID's intrinsic edge).
-Conflicting external state must return an export error; an alive empty child
-with no wrapper may inherit the edge that made it reachable.
+Default snapshot export does not walk the alive-container graph. It relies on a
+write-time invariant: every container brought alive by an applied op or diff
+gets a store entry when the reference is applied
+(`DocState::ensure_containers_created_by_op` for local ops,
+`DocState::ensure_containers_created_by_internal_diff` for imported/checkout
+diffs — this covers empty children that have no ops of their own and therefore
+no diff, plus tree `Create` meta maps). Full export is then `flush` + KV export:
+byte-faithful, never decodes lazy wrappers, and never materializes state, so a
+malformed imported entry round-trips instead of erroring (validation happens
+where the wrapper is actually read). Ensured-but-empty mergeable children are
+deliberately NOT materialized — the parent map's marker is their single source
+of truth and `has_container` must stop resolving them when the marker is
+removed (`loro_get_container_for_deleted_mergeable_children`).
+
+Shallow snapshot export still needs the complete alive set for its
+`retain_keys` filter. The alive walk in `DocState::ensure_all_alive_containers`
+registers root keys, reads snapshot-backed values ephemerally (via
+`try_get_value_ephemeral`, which never caches the decoded value or retains a
+probe-only wrapper), and only inserts a wrapper when an alive container has no
+KV entry. Do not replace this with `InnerStore::load_all` or cache every
+decoded value: documents with many small/deleted containers retain that memory
+for the rest of the WASM instance. The walk may retain only the resulting set
+of arena indices, capped at an estimated 4 MiB, reused while both the state
+frontiers and the existing retention-root list are unchanged (an empty
+top-level root does not advance the CRDT version), bypassed during a
+transaction. The walk reads an uncached container's encoded parent and value
+through one temporary wrapper, checks the parent header against the reachable
+edge (or a mergeable ID's intrinsic edge), and returns an export error on
+conflicting external state. Decompressed SSTable blocks are bounded separately
+by the kv-store's byte-weighted block cache (`BLOCK_CACHE_MAX_BYTES` in
+`sstable.rs`).
 
 `Snapshot::encoded_len` is available after the three section `Bytes` values are
 created. The default exporter uses it to reserve the final envelope once; keep

--- a/context/internal-encoding.md
+++ b/context/internal-encoding.md
@@ -1,7 +1,6 @@
 # Internal Encoding Context
 
-Verified against code 2026-07-17 at commit
-`fd5a1fdab79142302f0c0fbceb8807128ec6d9cd`.
+Verified against code 2026-07-20.
 
 Loro has one binary blob envelope, two current binary body formats, two
 recognized-but-unsupported legacy top-level modes, and a separate JSON updates
@@ -85,6 +84,27 @@ document. If a snapshot is imported into a non-empty document,
 `LoroDoc::_import_with` routes through decoded oplog changes instead. Failed
 direct snapshot import must reset both state and oplog.
 
+Default snapshot export must still persist alive empty child containers, but it
+must not materialize the full lazy state store to find them. The alive walk in
+`DocState::get_all_alive_containers` registers root keys, reads snapshot-backed
+values ephemerally (via `try_get_value_ephemeral`, which never caches the
+decoded value or retains a probe-only wrapper), and only inserts a wrapper when
+an alive container has no KV entry. Shallow snapshot retention reuses the same
+complete alive set of arena indices. Do not replace this with
+`InnerStore::load_all` or cache every decoded value: documents with many
+small/deleted containers retain that memory for the rest of the WASM instance.
+Decompressed SSTable blocks are bounded separately by the kv-store's
+byte-weighted block cache (`BLOCK_CACHE_MAX_BYTES` in `sstable.rs`), so the walk
+uses plain cached reads. The walk reads each present wrapper's parent header
+and checks it against the reachable edge (or a mergeable ID's intrinsic edge).
+Conflicting external state must return an export error; an alive empty child
+with no wrapper may inherit the edge that made it reachable.
+
+`Snapshot::encoded_len` is available after the three section `Bytes` values are
+created. The default exporter uses it to reserve the final envelope once; keep
+the checksum offset and the `EMPTY_MARK` length in that calculation aligned with
+`_encode_snapshot`.
+
 ## FastUpdates
 
 `FastUpdates` is a sequence of LEB128 length-prefixed change blocks.
@@ -93,6 +113,41 @@ overflow, and truncated block payloads, then sorts decoded changes by lamport.
 `encoding.rs:apply_decoded_changes_to_oplog` imports changes, separates pending
 changes, applies newly-unlocked pending changes, and rejects dependencies before
 a shallow root.
+
+`loro.rs:isolated_scalar_root_batch` is a conservative import optimization for
+a causally closed batch of brand-new peers whose operations are scalar Map
+writes on top-level root names absent from old history and current state. It is
+checked against the decoded changes *before* they are applied to the oplog,
+while the store still holds only old history: every batch peer must be absent
+from the current vv and contiguously covered from counter 0, every dependency
+must point inside the batch, and every op must be a scalar Map write on a root
+Map (no container values, no mergeable markers). After apply, the candidate is
+kept only if the vv delta equals exactly the batch spans (pending changes may
+have been unlocked). The fast path then calculates the state diff from the
+empty version to that batch, avoiding replay of an unrelated large history.
+`ChangeStore::old_history_may_touch_root_names` answers the "absent from old
+history" part with a size-capped set of every root name in the store, built
+once by scanning encoded block container arenas (no op parsing, no
+parsed-change cache fill) and updated incrementally on each inserted change.
+Because the set is only ever conservative, a rollback needs no invalidation —
+stale names just force the general diff path. Decode failures or exceeding the
+name-byte cap permanently disable the optimization for that store.
+
+For a large snapshot regression check, first build the Node package, then run:
+
+```sh
+pnpm -C crates/loro-wasm test:snapshot-memory -- /path/to/input.procloud 100
+```
+
+The budget argument is in MiB. Use `95` when the requirement is a strict
+100,000,000-byte ceiling; 95 MiB is about 99.6 MB.
+
+The gate keeps the `toJSON()` result alive through update import and snapshot
+export. It measures the memory directly attributable to this API round: input
+snapshot/update buffers, the WASM linear-memory high-water mark, the returned
+snapshot `Uint8Array`, retained JS heap growth, and unique binary backing stores
+reachable from the retained JSON value. It reports process RSS separately; RSS
+also includes the Node/V8 runtime and executable/code pages.
 
 ## Shallow, State-Only, And SnapshotAt
 

--- a/context/internal-encoding.md
+++ b/context/internal-encoding.md
@@ -93,6 +93,15 @@ an alive container has no KV entry. Shallow snapshot retention reuses the same
 complete alive set of arena indices. Do not replace this with
 `InnerStore::load_all` or cache every decoded value: documents with many
 small/deleted containers retain that memory for the rest of the WASM instance.
+`DocState::ensure_all_alive_containers` may retain only the resulting set of
+arena indices after a successful walk, capped at an estimated 4 MiB. It reuses
+that set while both the state frontiers and the existing retention-root list
+are unchanged, bypasses the cache during a transaction, and drops an obsolete
+set before constructing its replacement. The root-list part is required
+because obtaining a new empty top-level root does not advance the CRDT version.
+The walk also reads an uncached container's encoded parent and value through one
+temporary wrapper, so a single export does not probe the same lazy KV entry
+twice. Neither cache retains decoded container values.
 Decompressed SSTable blocks are bounded separately by the kv-store's
 byte-weighted block cache (`BLOCK_CACHE_MAX_BYTES` in `sstable.rs`), so the walk
 uses plain cached reads. The walk reads each present wrapper's parent header

--- a/context/mergeable-containers.md
+++ b/context/mergeable-containers.md
@@ -1,6 +1,6 @@
 # Mergeable Container Context
 
-Verified against code 2026-06-16.
+Verified against code 2026-07-21.
 
 Mergeable containers let two peers independently create the same child container
 under a map key and converge to one deterministic container id. The source of
@@ -81,10 +81,13 @@ rewrites the marker.
 
 ## Snapshot And Retention Rules
 
-Snapshot and shallow snapshot alive-container walks must preserve mergeable child
-state even when that child is hidden by a different winning marker. This is
-covered by `tests/mergeable_container/snapshot.rs`, including shallow snapshot
-tests for losing-kind state.
+Snapshot and shallow snapshot export must preserve mergeable child state even
+when that child is hidden by a different winning marker (full export keeps every
+flushed KV entry; the shallow alive walk retains them explicitly). An
+ensured-but-empty mergeable child has no KV entry of its own: full export omits
+it and importers resolve it from the parent map's marker. This is covered by
+`tests/mergeable_container/snapshot.rs`, including shallow snapshot tests for
+losing-kind state.
 
 Raw marker bytes are the wire/storage representation. Public read and diff
 surfaces should translate an active marker to a container value. APIs that expose

--- a/crates/examples/examples/b4_bench.rs
+++ b/crates/examples/examples/b4_bench.rs
@@ -69,7 +69,10 @@ fn report() {
         let d = apply(&actions, 1);
         d.export(ExportMode::Snapshot).unwrap()
     });
-    println!("  export(+apply,nocache):{:>8.2?}  (includes a fresh apply)", t_export_nc);
+    println!(
+        "  export(+apply,nocache):{:>8.2?}  (includes a fresh apply)",
+        t_export_nc
+    );
 
     // ---- Snapshot import ----
     let mem_before = get_mem_usage();
@@ -89,7 +92,10 @@ fn report() {
         let v = d.get_deep_value();
         std::hint::black_box(v);
     });
-    println!("  import + toJSON:     {:>10.2?}  (forces full state materialization)", t_import_val);
+    println!(
+        "  import + toJSON:     {:>10.2?}  (forces full state materialization)",
+        t_import_val
+    );
     std::hint::black_box(&imported);
 
     // ---- B4 x100 ----

--- a/crates/examples/examples/mergeable_notes.rs
+++ b/crates/examples/examples/mergeable_notes.rs
@@ -150,7 +150,10 @@ fn print_report(r: &Report) {
     println!("  import snapshot:           {:?}", r.import_time);
     println!("  resident after import:     {}", r.imported_resident);
     println!("  get_deep_value:            {:?}", r.deep_value_time);
-    println!("  resident after deep_value: {}", r.after_deep_value_resident);
+    println!(
+        "  resident after deep_value: {}",
+        r.after_deep_value_resident
+    );
 }
 
 fn main() {

--- a/crates/fuzz/fuzz/Cargo.lock
+++ b/crates/fuzz/fuzz/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
  "enum_dispatch",
  "itertools 0.12.1",
  "loro 0.16.12",
- "loro 1.13.6",
+ "loro 1.13.7",
  "loro 1.8.1",
  "num_cpus",
  "pretty_assertions",
@@ -359,7 +359,7 @@ version = "0.0.0"
 dependencies = [
  "fuzz",
  "libfuzzer-sys",
- "loro 1.13.6",
+ "loro 1.13.7",
 ]
 
 [[package]]
@@ -668,14 +668,14 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "enum-as-inner 0.6.0",
  "generic-btree",
  "loro-common 1.13.1",
  "loro-delta 1.13.0",
- "loro-internal 1.13.6",
- "loro-kv-store 1.13.1",
+ "loro-internal 1.13.7",
+ "loro-kv-store 1.13.7",
  "rustc-hash",
  "tracing",
 ]
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -869,7 +869,7 @@ dependencies = [
  "loom",
  "loro-common 1.13.1",
  "loro-delta 1.13.0",
- "loro-kv-store 1.13.1",
+ "loro-kv-store 1.13.7",
  "loro-rle 1.6.0",
  "loro_fractional_index 1.13.0",
  "md5",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.13.1"
+version = "1.13.7"
 dependencies = [
  "bytes",
  "ensure-cov",

--- a/crates/fuzz/src/container/map.rs
+++ b/crates/fuzz/src/container/map.rs
@@ -209,7 +209,9 @@ impl Actionable for MapAction {
                 // Type-conflict rejection (`ArgErr`) is an expected outcome — swallow it
                 // here rather than via `unwrap` so unrelated `ArgErr` sources still panic.
                 let result = match kind {
-                    ContainerType::Map => handler.ensure_mergeable_map(key).map(|m| m.to_container()),
+                    ContainerType::Map => {
+                        handler.ensure_mergeable_map(key).map(|m| m.to_container())
+                    }
                     ContainerType::List => {
                         handler.ensure_mergeable_list(key).map(|l| l.to_container())
                     }
@@ -222,9 +224,9 @@ impl Actionable for MapAction {
                     ContainerType::Tree => {
                         handler.ensure_mergeable_tree(key).map(|t| t.to_container())
                     }
-                    ContainerType::Counter => {
-                        handler.ensure_mergeable_counter(key).map(|c| c.to_container())
-                    }
+                    ContainerType::Counter => handler
+                        .ensure_mergeable_counter(key)
+                        .map(|c| c.to_container()),
                     ContainerType::Unknown(_) => return None,
                 };
                 match result {

--- a/crates/generic-btree/src/generic_impl/rope.rs
+++ b/crates/generic-btree/src/generic_impl/rope.rs
@@ -96,10 +96,10 @@ impl Rope {
         let (q, f) = self.tree.query_with_finder_return::<LengthFinder>(&index);
         self.cursor = q.and_then(|q| {
             if q.offset() == 0 {
-                if f.slot == 0 || f.parent.is_none() {
+                if f.slot == 0 {
                     None
                 } else {
-                    let node = self.tree.in_nodes.get(f.parent.unwrap()).unwrap();
+                    let node = self.tree.in_nodes.get(f.parent?).unwrap();
                     let child = &node.children[f.slot as usize - 1];
                     Some(Cursor {
                         pos: index - child.cache as usize,

--- a/crates/generic-btree/src/iter.rs
+++ b/crates/generic-btree/src/iter.rs
@@ -84,7 +84,7 @@ impl<'a, B: BTreeTrait> Drain<'a, B> {
         }
     }
 
-    fn none(tree: &'a mut BTree<B>) -> Drain<B> {
+    fn none(tree: &'a mut BTree<B>) -> Drain<'a, B> {
         Self {
             current_path: Default::default(),
             done: true,

--- a/crates/generic-btree/src/lib.rs
+++ b/crates/generic-btree/src/lib.rs
@@ -1319,16 +1319,15 @@ impl<B: BTreeTrait> BTree<B> {
             (false, splitted)
         } else if new_insert_1.is_none() {
             debug_assert!(new_insert_2.is_none());
-            return (true, splitted);
+            (true, splitted)
         } else {
-            if new_insert_1.is_some() && new_insert_2.is_none() {
+            if let (Some(new), None) = (&new_insert_1, &new_insert_2) {
                 // try merge new insert to next element
                 let parent = self.in_nodes.get_mut(parent_idx.unwrap()).unwrap();
                 let slot = Self::get_leaf_slot(node_idx.0, parent);
                 if slot + 1 < parent.children.len() {
                     let next_idx = parent.children[slot + 1].arena.unwrap().into();
                     let next = self.get_elem_mut(next_idx).unwrap();
-                    let new = new_insert_1.as_ref().unwrap();
                     if new.can_merge(next) {
                         next.merge_left(new);
                         self.recursive_update_cache(next_idx.into(), B::USE_DIFF, None);
@@ -1609,11 +1608,11 @@ impl<B: BTreeTrait> BTree<B> {
         })
     }
 
-    pub fn drain(&mut self, range: Range<QueryResult>) -> iter::Drain<B> {
+    pub fn drain(&mut self, range: Range<QueryResult>) -> iter::Drain<'_, B> {
         iter::Drain::new(self, Some(range.start), Some(range.end))
     }
 
-    pub fn drain_by_query<Q: Query<B>>(&mut self, range: Range<Q::QueryArg>) -> iter::Drain<B> {
+    pub fn drain_by_query<Q: Query<B>>(&mut self, range: Range<Q::QueryArg>) -> iter::Drain<'_, B> {
         let start = self.query::<Q>(&range.start);
         let end = self.query::<Q>(&range.end);
         iter::Drain::new(self, start, end)
@@ -2245,16 +2244,14 @@ impl<B: BTreeTrait> BTree<B> {
         let mut node = self.get_internal_mut(node_idx);
         let mut this_arr = node.parent_slot;
         if can_use_diff {
-            if node.parent.is_some() {
-                let parent_idx = node.parent.unwrap();
+            if let Some(parent_idx) = node.parent {
                 let (parent, this) = self.get2_mut(parent_idx, this_idx);
                 let diff =
                     this.calc_cache(&mut parent.children[this_arr as usize].cache, cache_diff);
                 return self.recursive_update_cache_with_diff(parent_idx, diff);
             }
         } else {
-            while node.parent.is_some() {
-                let parent_idx = node.parent.unwrap();
+            while let Some(parent_idx) = node.parent {
                 let (parent, this) = self.get2_mut(parent_idx, this_idx);
                 this.calc_cache(&mut parent.children[this_arr as usize].cache, None);
                 this_idx = parent_idx;
@@ -2650,7 +2647,7 @@ impl<B: BTreeTrait> BTree<B> {
     pub fn iter_with_filter<'a, R: Default + Copy + AddAssign + 'a>(
         &'a self,
         mut f: impl FnMut(&B::Cache) -> (bool, R) + 'a,
-    ) -> impl Iterator<Item = (R, &'_ B::Elem)> + '_ {
+    ) -> impl Iterator<Item = (R, &'a B::Elem)> + 'a {
         let mut queue = VecDeque::new();
         queue.push_back((self.root, R::default()));
         std::iter::from_fn(move || {
@@ -2866,7 +2863,7 @@ impl<B: BTreeTrait, T: Into<B::Elem>> FromIterator<T> for BTree<B> {
             arena_index: RawArenaIndex,
         }
 
-        let parent_num = (min_size + max_child_size - 1) / max_child_size;
+        let parent_num = min_size.div_ceil(max_child_size);
         let mut internal_nodes: Vec<TempInternalNode<B>> = Vec::with_capacity(parent_num);
         let index = tree.in_nodes.insert(Default::default());
         internal_nodes.push(TempInternalNode {
@@ -2911,7 +2908,7 @@ impl<B: BTreeTrait, T: Into<B::Elem>> FromIterator<T> for BTree<B> {
 
         // recursively create the internal nodes in higher level, until we reach root
         while internal_nodes.len() > 1 {
-            let parent_num = (internal_nodes.len() + max_child_size - 1) / max_child_size;
+            let parent_num = internal_nodes.len().div_ceil(max_child_size);
             let children = std::mem::replace(&mut internal_nodes, Vec::with_capacity(parent_num));
             let index = tree.in_nodes.insert(Default::default());
             internal_nodes.push(TempInternalNode {

--- a/crates/kv-store/src/mem_store.rs
+++ b/crates/kv-store/src/mem_store.rs
@@ -62,6 +62,8 @@ impl MemKvConfig {
 
 impl MemKvStore {
     pub const DEFAULT_BLOCK_SIZE: usize = 4 * 1024;
+    const EXPORT_ENTRY_OVERHEAD: usize = 8;
+
     pub fn new(config: MemKvConfig) -> Self {
         Self {
             mem_table: BTreeMap::new(),
@@ -81,18 +83,8 @@ impl MemKvStore {
         }
 
         for table in self.ss_table.iter().rev() {
-            if table.first_key > key || table.last_key < key {
-                continue;
-            }
-            // table.
-            let idx = table.find_block_idx(key);
-            let block = table.read_block_cached(idx);
-            let block_iter = BlockIter::new_seek_to_key(block, key);
-            if let Some(k) = block_iter.peek_next_curr_key() {
-                let v = block_iter.peek_next_curr_value().unwrap();
-                if k == key {
-                    return if v.is_empty() { None } else { Some(v) };
-                }
+            if let Some(value) = table.get(key) {
+                return if value.is_empty() { None } else { Some(value) };
             }
         }
         None
@@ -186,6 +178,11 @@ impl MemKvStore {
         ))
     }
 
+    #[cfg(test)]
+    fn cached_block_bytes(&self) -> u64 {
+        self.ss_table.iter().map(SsTable::cached_block_bytes).sum()
+    }
+
     /// The number of valid keys in the mem table and sstable, it's expensive to call
     pub fn len(&self) -> usize {
         // TODO: PERF
@@ -207,6 +204,34 @@ impl MemKvStore {
                 .sum::<usize>()
     }
 
+    fn export_capacity_hint(&self) -> usize {
+        debug_assert_eq!(self.ss_table.len(), 1);
+        let existing_bytes = self.ss_table[0].data_size();
+        let pending_bytes = self.mem_table.iter().fold(0_usize, |size, (key, value)| {
+            size.saturating_add(key.len())
+                .saturating_add(value.len())
+                // Account for entry prefixes, offsets, checksums, and new block metadata.
+                .saturating_add(Self::EXPORT_ENTRY_OVERHEAD)
+        });
+        // Raw memtable values can be far larger than their compressed representation. Bound the
+        // hint so a large, highly compressible delta cannot reserve an arbitrary amount up front.
+        let pending_headroom = pending_bytes.min((existing_bytes / 4).max(self.block_size));
+        existing_bytes
+            .saturating_add(pending_headroom)
+            // Leave room for a partially filled block and its metadata so a small delta does not
+            // push a nearly complete imported SSTable into Vec's geometric growth path.
+            .saturating_add(self.block_size)
+    }
+
+    fn new_export_builder(&self) -> SsTableBuilder {
+        SsTableBuilder::with_capacity(
+            self.block_size,
+            self.compression_type,
+            self.should_encode_none,
+            self.export_capacity_hint(),
+        )
+    }
+
     pub fn export_all(&mut self) -> Bytes {
         if self.mem_table.is_empty() && self.ss_table.len() == 1 {
             return self.ss_table[0].export_all();
@@ -216,6 +241,8 @@ impl MemKvStore {
             return self.export_with_encoded_block();
         }
 
+        // Pure memtables may contain highly compressible values, while multiple imported SSTables
+        // can overlap heavily. In both cases their resident size is a poor capacity hint.
         let mut builder = SsTableBuilder::new(
             self.block_size,
             self.compression_type,
@@ -264,9 +291,10 @@ impl MemKvStore {
 
     /// Like [`Self::import_all`] but skips per-block checksum verification.
     ///
-    /// Only use this when the blob's integrity is already guaranteed by an outer
-    /// checksum (e.g. Loro's document-level snapshot checksum, verified before
-    /// the snapshot body is handed to the KV store).
+    /// Only use this for trusted bytes produced by this crate, or after the
+    /// embedded block checksums have already been validated. An outer envelope
+    /// checksum alone is insufficient because it can be recomputed over malformed
+    /// inner blocks.
     pub fn import_all_unchecked(&mut self, bytes: Bytes) -> Result<(), String> {
         if bytes.is_empty() {
             return Ok(());
@@ -280,13 +308,10 @@ impl MemKvStore {
     #[tracing::instrument(level = "debug", skip(self))]
     fn export_with_encoded_block(&mut self) -> Bytes {
         ensure_cov::notify_cov("kv-store::mem_store::export_with_encoded_block");
+        let mut builder = self.new_export_builder();
         let mut mem_iter = self.mem_table.iter().peekable();
-        let mut sstable_iter = self.ss_table[0].iter();
-        let mut builder = SsTableBuilder::new(
-            self.block_size,
-            self.compression_type,
-            self.should_encode_none,
-        );
+        let mut sstable_iter =
+            SsTableIter::new_scan(&self.ss_table[0], Bound::Unbounded, Bound::Unbounded);
         'outer: while let Some(next_mem_pair) = mem_iter.peek() {
             let block = loop {
                 let Some(block) = sstable_iter.peek_next_block() else {
@@ -508,7 +533,7 @@ where
 mod tests {
     use std::vec;
 
-    use crate::{mem_store::MemKvConfig, MemKvStore};
+    use crate::{compress::CompressionType, mem_store::MemKvConfig, MemKvStore};
     use bytes::Bytes;
     #[test]
     fn test_mem_kv_store() {
@@ -615,6 +640,97 @@ mod tests {
 
         store.compare_and_swap(key, Some(value.clone()), large_value.clone());
         assert!(store.contains_key(key));
+    }
+
+    #[test]
+    fn block_cache_stays_bounded_during_full_scan() {
+        // More decompressed bytes than the block cache budget, so an unbounded cache would
+        // exceed it after one full scan.
+        const VALUE_SIZE: usize = 4 * 1024;
+        const ENTRIES: usize = 2048;
+        let mut source = MemKvStore::new(MemKvConfig::default().should_encode_none(true));
+        for i in 0..ENTRIES as u16 {
+            source.set(&i.to_be_bytes(), Bytes::from(vec![i as u8; VALUE_SIZE]));
+        }
+        let bytes = source.export_all();
+        let mut imported = MemKvStore::new(MemKvConfig::default().should_encode_none(true));
+        imported.import_all(bytes).unwrap();
+
+        assert_eq!(
+            imported.get(&0_u16.to_be_bytes()),
+            Some(Bytes::from(vec![0; VALUE_SIZE]))
+        );
+        let entries = imported
+            .scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+            .collect::<Vec<_>>();
+        assert_eq!(entries.len(), ENTRIES);
+        let cached = imported.cached_block_bytes();
+        assert!(cached > 0);
+        assert!(
+            cached <= 4 * 1024 * 1024,
+            "block cache exceeded its byte budget: {cached}"
+        );
+    }
+
+    #[test]
+    fn export_capacity_hint_covers_a_small_delta() {
+        let config = MemKvConfig::default()
+            .block_size(64)
+            .compression_type(CompressionType::None)
+            .should_encode_none(true);
+        let mut source = MemKvStore::new(config);
+        for i in 0..128_u16 {
+            source.set(&i.to_be_bytes(), Bytes::from(vec![i as u8; 32]));
+        }
+        let bytes = source.export_all();
+
+        let mut imported = MemKvStore::new(
+            MemKvConfig::default()
+                .block_size(64)
+                .compression_type(CompressionType::None)
+                .should_encode_none(true),
+        );
+        imported.import_all(bytes).unwrap();
+        imported.set(&64_u16.to_be_bytes(), Bytes::from(vec![7; 48]));
+        imported.set(&256_u16.to_be_bytes(), Bytes::from(vec![8; 48]));
+
+        let capacity_hint = imported.export_capacity_hint();
+        let exported = imported.export_all();
+        assert!(exported.len() <= capacity_hint);
+
+        let mut round_tripped = MemKvStore::new(
+            MemKvConfig::default()
+                .block_size(64)
+                .compression_type(CompressionType::None)
+                .should_encode_none(true),
+        );
+        round_tripped.import_all(exported).unwrap();
+        assert_eq!(
+            round_tripped.get(&64_u16.to_be_bytes()),
+            Some(Bytes::from(vec![7; 48]))
+        );
+        assert_eq!(
+            round_tripped.get(&256_u16.to_be_bytes()),
+            Some(Bytes::from(vec![8; 48]))
+        );
+    }
+
+    #[test]
+    fn export_capacity_hint_is_bounded_for_a_compressible_delta() {
+        let mut source = new_store();
+        source.set(b"base", Bytes::from_static(b"value"));
+        let bytes = source.export_all();
+
+        let mut imported = new_store();
+        imported.import_all(bytes).unwrap();
+        let large_value = Bytes::from(vec![0; 1024 * 1024]);
+        imported.set(b"large", large_value.clone());
+
+        assert!(imported.export_capacity_hint() < large_value.len());
+        let exported = imported.export_all();
+        let mut round_tripped = new_store();
+        round_tripped.import_all(exported).unwrap();
+        assert_eq!(round_tripped.get(b"large"), Some(large_value));
     }
 
     #[test]

--- a/crates/kv-store/src/sstable.rs
+++ b/crates/kv-store/src/sstable.rs
@@ -16,8 +16,10 @@ const CURRENT_SCHEMA_VERSION: u8 = 0;
 pub const SIZE_OF_U8: usize = std::mem::size_of::<u8>();
 pub const SIZE_OF_U16: usize = std::mem::size_of::<u16>();
 pub const SIZE_OF_U32: usize = std::mem::size_of::<u32>();
-// TODO: cache size
-const DEFAULT_CACHE_SIZE: usize = 1 << 20;
+/// Upper bound, in decompressed bytes, for each table's block cache. This keeps hot reads
+/// cheap while guaranteeing that neither a long-lived document nor a one-shot import/export
+/// walk can retain its entire store decompressed.
+const BLOCK_CACHE_MAX_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_BLOCK_NUM: u32 = 10_000_000;
 
 /// ```log
@@ -162,7 +164,17 @@ pub(crate) struct SsTableBuilder {
 
 impl SsTableBuilder {
     pub fn new(block_size: usize, compression_type: CompressionType, include_none: bool) -> Self {
-        let mut data = Vec::with_capacity(5);
+        Self::with_capacity(block_size, compression_type, include_none, 0)
+    }
+
+    pub fn with_capacity(
+        block_size: usize,
+        compression_type: CompressionType,
+        include_none: bool,
+        data_capacity: usize,
+    ) -> Self {
+        let header_size = MAGIC_BYTES.len() + SIZE_OF_U8;
+        let mut data = Vec::with_capacity(data_capacity.max(header_size));
         data.put_u32_le(u32::from_le_bytes(MAGIC_BYTES));
         data.put_u8(CURRENT_SCHEMA_VERSION);
         Self {
@@ -301,12 +313,28 @@ impl SsTableBuilder {
             last_key,
             meta: self.meta,
             meta_offset: meta_offset as usize,
-            block_cache: BlockCache::new(DEFAULT_CACHE_SIZE),
+            block_cache: new_block_cache(),
         }
     }
 }
 
-type BlockCache = quick_cache::sync::Cache<usize, Arc<Block>>;
+type BlockCache = quick_cache::sync::Cache<usize, Arc<Block>, BlockDataWeighter>;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct BlockDataWeighter;
+
+impl quick_cache::Weighter<usize, Arc<Block>> for BlockDataWeighter {
+    fn weight(&self, _idx: &usize, block: &Arc<Block>) -> u64 {
+        // Zero-weight entries are never evicted; clamp so empty blocks cannot pin themselves.
+        (block.data().len() as u64).max(1)
+    }
+}
+
+fn new_block_cache() -> BlockCache {
+    let estimated_blocks =
+        (BLOCK_CACHE_MAX_BYTES / crate::MemKvStore::DEFAULT_BLOCK_SIZE as u64) as usize;
+    BlockCache::with_weighter(estimated_blocks, BLOCK_CACHE_MAX_BYTES, BlockDataWeighter)
+}
 
 #[derive(Debug)]
 pub struct SsTable {
@@ -327,7 +355,7 @@ impl Clone for SsTable {
             last_key: self.last_key.clone(),
             meta: self.meta.clone(),
             meta_offset: self.meta_offset,
-            block_cache: BlockCache::new(DEFAULT_CACHE_SIZE),
+            block_cache: new_block_cache(),
         }
     }
 }
@@ -360,11 +388,10 @@ impl SsTable {
     /// Import without per-block checksum verification (and without eager block
     /// validation).
     ///
-    /// Only use this when the blob's integrity is already guaranteed by an outer
-    /// checksum — e.g. Loro verifies a document-wide checksum over the whole
-    /// snapshot body in `parse_header_and_body` before reaching here, so
-    /// re-hashing every block would redundantly cover bytes the outer checksum
-    /// already protects (this was ~38% of B4 snapshot-import time).
+    /// Only use this for trusted bytes produced by this crate, or after the
+    /// embedded block checksums have already been validated. An outer envelope
+    /// checksum alone is insufficient because it can be recomputed over malformed
+    /// inner blocks.
     pub fn import_all_unchecked(bytes: Bytes) -> LoroResult<Self> {
         Self::import_all_with(bytes, false, false)
     }
@@ -426,7 +453,7 @@ impl SsTable {
             last_key,
             meta,
             meta_offset,
-            block_cache: BlockCache::new(DEFAULT_CACHE_SIZE),
+            block_cache: new_block_cache(),
         };
         Ok(ans)
     }
@@ -582,6 +609,11 @@ impl SsTable {
     pub fn meta_len(&self) -> usize {
         self.meta.len()
     }
+
+    #[cfg(test)]
+    pub(crate) fn cached_block_bytes(&self) -> u64 {
+        self.block_cache.weight()
+    }
 }
 
 #[derive(Clone)]
@@ -608,24 +640,25 @@ impl<'a> SsTableIter<'a> {
     }
 
     pub fn new_scan(table: &'a SsTable, start: Bound<&[u8]>, end: Bound<&[u8]>) -> Self {
+        let read_block = |idx| table.read_block_cached(idx);
         let (table_idx, mut iter, excluded) = match start {
             Bound::Included(start) => {
                 notify_cov("kv-store::SstableIter::new_scan::start included");
                 let idx = table.find_block_idx(start);
-                let block = table.read_block_cached(idx);
+                let block = read_block(idx);
                 let iter = BlockIter::new_seek_to_key(block, start);
                 (idx, iter, None)
             }
             Bound::Excluded(start) => {
                 notify_cov("kv-store::SstableIter::new_scan::start excluded");
                 let idx = table.find_block_idx(start);
-                let block = table.read_block_cached(idx);
+                let block = read_block(idx);
                 let iter = BlockIter::new_seek_to_key(block, start);
                 (idx, iter, Some(start))
             }
             Bound::Unbounded => {
                 notify_cov("kv-store::SstableIter::new_scan::start unbounded");
-                let block = table.read_block_cached(0);
+                let block = read_block(0);
                 let iter = BlockIter::new(block);
                 (0, iter, None)
             }
@@ -642,7 +675,7 @@ impl<'a> SsTableIter<'a> {
                     }
                     (end_idx, None, None)
                 } else {
-                    let block = table.read_block_cached(end_idx);
+                    let block = read_block(end_idx);
                     let iter = BlockIter::new_back_to_key(block, end);
                     (end_idx, Some(iter), None)
                 }
@@ -658,7 +691,7 @@ impl<'a> SsTableIter<'a> {
                     }
                     (end_idx, None, Some(end))
                 } else {
-                    let block = table.read_block_cached(end_idx);
+                    let block = read_block(end_idx);
                     let iter = BlockIter::new_back_to_key(block, end);
                     (end_idx, Some(iter), Some(end))
                 }
@@ -670,7 +703,7 @@ impl<'a> SsTableIter<'a> {
                     notify_cov("kv-store::SstableIter::new_scan::unbounded equal");
                     (end_idx, None, None)
                 } else {
-                    let block = table.read_block_cached(end_idx);
+                    let block = read_block(end_idx);
                     let iter = BlockIter::new(block);
                     (end_idx, Some(iter), None)
                 }
@@ -1197,6 +1230,15 @@ mod test {
     }
 
     #[test]
+    fn sstable_builder_reserves_capacity_hint() {
+        let builder = SsTableBuilder::with_capacity(10, CompressionType::LZ4, true, 4096);
+        assert!(builder.data.capacity() >= 4096);
+
+        let builder = SsTableBuilder::with_capacity(10, CompressionType::LZ4, true, 0);
+        assert!(builder.data.capacity() >= MAGIC_BYTES.len() + SIZE_OF_U8);
+    }
+
+    #[test]
     fn sstable_iter_with_delete() {
         let mut builder = SsTableBuilder::new(10, CompressionType::LZ4, true);
         builder.add(Bytes::from_static(b"key1"), Bytes::from_static(b"value1"));
@@ -1403,8 +1445,7 @@ mod test {
         // The public `import_all` always verifies per-block checksums (with or
         // without the heavier `validate_blocks` decode). Only the explicit
         // `import_all_unchecked` fast path skips them, and its caller is then
-        // responsible for integrity via an outer checksum — that is the
-        // redundant-checksum skip that makes full snapshot import faster.
+        // responsible for accepting only trusted or previously validated bytes.
         let first_key = Bytes::from_static(b"key");
         let mut block_bytes = normal_block_bytes(b"key", b"value");
         *block_bytes.last_mut().unwrap() ^= 0xff;

--- a/crates/loro-internal/src/arena.rs
+++ b/crates/loro-internal/src/arena.rs
@@ -462,6 +462,16 @@ impl SharedArena {
         panic!("InternalError: Parent is not registered")
     }
 
+    /// Return the parent edge already stored in the arena without invoking the lazy resolver.
+    ///
+    /// The outer `Option` distinguishes an unregistered edge from a registered root edge.
+    pub(crate) fn get_registered_parent(
+        &self,
+        child: ContainerIdx,
+    ) -> Option<Option<ContainerIdx>> {
+        self.inner.containers.read().parents.get(&child).copied()
+    }
+
     /// Call `f` on each ancestor of `container`, including `container` itself.
     ///
     /// f(ContainerIdx, is_first)

--- a/crates/loro-internal/src/container/richtext/richtext_state.rs
+++ b/crates/loro-internal/src/container/richtext/richtext_state.rs
@@ -7,6 +7,7 @@ use loro_common::{Counter, IdFull, IdSpan, LoroError, LoroResult, LoroValue, ID}
 use query::{ByteQuery, ByteQueryT};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{ser::SerializeStruct, Serialize};
+use smallvec::SmallVec;
 use std::{
     fmt::{Display, Formatter},
     ops::{Bound, RangeBounds},
@@ -16,7 +17,6 @@ use std::{
     str::Utf8Error,
     sync::Arc,
 };
-use smallvec::SmallVec;
 use tracing::instrument;
 
 use crate::{

--- a/crates/loro-internal/src/encoding.rs
+++ b/crates/loro-internal/src/encoding.rs
@@ -372,12 +372,18 @@ pub(crate) fn parse_header_and_body(
     Ok(ans)
 }
 
-pub(crate) fn export_fast_snapshot(doc: &LoroDoc) -> Vec<u8> {
-    encode_with(EncodeMode::FastSnapshot, &mut |ans| {
-        fast_snapshot::encode_snapshot(doc, ans);
+pub(crate) fn export_fast_snapshot(doc: &LoroDoc) -> Result<Vec<u8>, LoroEncodeError> {
+    let snapshot = fast_snapshot::encode_snapshot_inner(doc)?;
+    let expected_len = snapshot
+        .encoded_len()
+        .and_then(|len| MIN_HEADER_SIZE.checked_add(len))
+        .ok_or_else(|| LoroEncodeError::internal("snapshot length overflow"))?;
+    let encoded = encode_with_capacity(EncodeMode::FastSnapshot, expected_len, &mut |ans| {
+        fast_snapshot::_encode_snapshot(&snapshot, ans);
         Ok(())
-    })
-    .unwrap()
+    })?;
+    debug_assert_eq!(encoded.len(), expected_len);
+    Ok(encoded)
 }
 
 pub(crate) fn export_snapshot_at(
@@ -441,8 +447,16 @@ fn encode_with(
     mode: EncodeMode,
     f: &mut dyn FnMut(&mut Vec<u8>) -> Result<(), LoroEncodeError>,
 ) -> Result<Vec<u8>, LoroEncodeError> {
+    encode_with_capacity(mode, MIN_HEADER_SIZE, f)
+}
+
+fn encode_with_capacity(
+    mode: EncodeMode,
+    capacity: usize,
+    f: &mut dyn FnMut(&mut Vec<u8>) -> Result<(), LoroEncodeError>,
+) -> Result<Vec<u8>, LoroEncodeError> {
     // HEADER
-    let mut ans = Vec::with_capacity(MIN_HEADER_SIZE);
+    let mut ans = Vec::with_capacity(capacity);
     ans.extend(MAGIC_BYTES);
     let checksum = [0; 16];
     ans.extend(checksum);
@@ -556,8 +570,27 @@ impl LoroDoc {
 
 #[cfg(test)]
 mod test {
-
+    use super::*;
     use loro_common::{loro_value, ContainerID, ContainerType, LoroValue, ID};
+
+    #[test]
+    fn fast_snapshot_envelope_has_exact_length_and_valid_checksum() {
+        let doc = LoroDoc::new_auto_commit();
+        doc.get_map("root").insert("key", "value").unwrap();
+        let encoded = doc.export(ExportMode::Snapshot).unwrap();
+        assert_eq!(&encoded[..4], &MAGIC_BYTES);
+        assert_eq!(&encoded[20..22], &EncodeMode::FastSnapshot.to_bytes());
+        let parsed = parse_header_and_body(&encoded, true).unwrap();
+        assert_eq!(parsed.mode, EncodeMode::FastSnapshot);
+        assert_eq!(encoded.len(), MIN_HEADER_SIZE + parsed.body.len());
+
+        let mut corrupted = encoded;
+        *corrupted.last_mut().unwrap() ^= 1;
+        assert!(matches!(
+            parse_header_and_body(&corrupted, true),
+            Err(LoroError::DecodeChecksumMismatchError)
+        ));
+    }
 
     #[test]
     fn test_value_encode_size() {

--- a/crates/loro-internal/src/encoding/fast_snapshot.rs
+++ b/crates/loro-internal/src/encoding/fast_snapshot.rs
@@ -20,7 +20,7 @@ use crate::{
     OpLog, VersionVector,
 };
 use bytes::{Buf, Bytes};
-use loro_common::{HasCounterSpan, IdSpan, InternalString, LoroError, LoroResult};
+use loro_common::{HasCounterSpan, IdSpan, InternalString, LoroEncodeError, LoroError, LoroResult};
 
 use super::{EncodedBlobMode, ImportBlobMetadata, ParsedHeaderAndBody};
 pub(crate) const EMPTY_MARK: &[u8] = b"E";
@@ -30,16 +30,30 @@ pub(crate) struct Snapshot {
     pub shallow_root_state_bytes: Bytes,
 }
 
-pub(super) fn _encode_snapshot<W: Write>(s: Snapshot, w: &mut W) {
+impl Snapshot {
+    pub(super) fn encoded_len(&self) -> Option<usize> {
+        let state_len = self
+            .state_bytes
+            .as_ref()
+            .map_or(EMPTY_MARK.len(), Bytes::len);
+        u32::try_from(self.oplog_bytes.len()).ok()?;
+        u32::try_from(state_len).ok()?;
+        u32::try_from(self.shallow_root_state_bytes.len()).ok()?;
+        (3 * std::mem::size_of::<u32>())
+            .checked_add(self.oplog_bytes.len())?
+            .checked_add(state_len)?
+            .checked_add(self.shallow_root_state_bytes.len())
+    }
+}
+
+pub(super) fn _encode_snapshot<W: Write>(s: &Snapshot, w: &mut W) {
     w.write_all(&(s.oplog_bytes.len() as u32).to_le_bytes())
         .unwrap();
     w.write_all(&s.oplog_bytes).unwrap();
-    let state_bytes = s
-        .state_bytes
-        .unwrap_or_else(|| Bytes::from_static(EMPTY_MARK));
+    let state_bytes = s.state_bytes.as_deref().unwrap_or(EMPTY_MARK);
     w.write_all(&(state_bytes.len() as u32).to_le_bytes())
         .unwrap();
-    w.write_all(&state_bytes).unwrap();
+    w.write_all(state_bytes).unwrap();
     w.write_all(&(s.shallow_root_state_bytes.len() as u32).to_le_bytes())
         .unwrap();
     w.write_all(&s.shallow_root_state_bytes).unwrap();
@@ -269,12 +283,7 @@ impl OpLog {
     }
 }
 
-pub(crate) fn encode_snapshot<W: std::io::Write>(doc: &LoroDoc, w: &mut W) {
-    let snapshot = encode_snapshot_inner(doc);
-    _encode_snapshot(snapshot, w);
-}
-
-pub(crate) fn encode_snapshot_inner(doc: &LoroDoc) -> Snapshot {
+pub(crate) fn encode_snapshot_inner(doc: &LoroDoc) -> Result<Snapshot, LoroEncodeError> {
     assert!(doc.drop_pending_events().is_empty());
     let old_state_frontiers = doc.state_frontiers();
     let was_detached = doc.is_detached();
@@ -286,8 +295,8 @@ pub(crate) fn encode_snapshot_inner(doc: &LoroDoc) -> Snapshot {
         let f = oplog.shallow_since_frontiers().clone();
         drop(state);
         drop(oplog);
-        let (snapshot, _) = shallow_snapshot::export_shallow_snapshot_inner(doc, &f).unwrap();
-        return snapshot;
+        let (snapshot, _) = shallow_snapshot::export_shallow_snapshot_inner(doc, &f)?;
+        return Ok(snapshot);
     }
 
     assert!(!state.is_in_txn());
@@ -306,12 +315,13 @@ pub(crate) fn encode_snapshot_inner(doc: &LoroDoc) -> Snapshot {
             .unwrap();
         state = doc.app_state().lock();
     }
-    state.ensure_all_alive_containers();
-    let state_bytes = state.store.encode();
-    let snapshot = Snapshot {
-        oplog_bytes,
-        state_bytes: Some(state_bytes),
-        shallow_root_state_bytes: Bytes::new(),
+    let snapshot = match state.ensure_all_alive_containers() {
+        Ok(_) => Ok(Snapshot {
+            oplog_bytes,
+            state_bytes: Some(state.store.encode()),
+            shallow_root_state_bytes: Bytes::new(),
+        }),
+        Err(err) => Err(LoroEncodeError::from(err)),
     };
     if was_detached {
         drop(state);
@@ -390,6 +400,36 @@ pub(crate) fn decode_updates(oplog: &mut OpLog, body: Bytes) -> Result<Vec<Chang
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        encoding::ExportMode, handler::HandlerTrait, utils::kv_wrapper::KvWrapper, MapHandler,
+    };
+
+    fn snapshot_sections(doc: &LoroDoc) -> Snapshot {
+        let encoded = doc.export(ExportMode::Snapshot).unwrap();
+        let parsed = crate::encoding::parse_header_and_body(&encoded, true).unwrap();
+        _decode_snapshot_bytes(Bytes::copy_from_slice(parsed.body)).unwrap()
+    }
+
+    #[test]
+    fn snapshot_encoded_len_matches_written_len() {
+        for snapshot in [
+            Snapshot {
+                oplog_bytes: Bytes::from_static(b"oplog"),
+                state_bytes: Some(Bytes::from_static(b"state")),
+                shallow_root_state_bytes: Bytes::new(),
+            },
+            Snapshot {
+                oplog_bytes: Bytes::new(),
+                state_bytes: None,
+                shallow_root_state_bytes: Bytes::from_static(b"shallow"),
+            },
+        ] {
+            let expected_len = snapshot.encoded_len().unwrap();
+            let mut encoded = Vec::new();
+            _encode_snapshot(&snapshot, &mut encoded);
+            assert_eq!(encoded.len(), expected_len);
+        }
+    }
 
     #[test]
     fn decode_updates_rejects_truncated_block() {
@@ -398,6 +438,84 @@ mod tests {
         let err = decode_updates(&mut oplog, Bytes::from_static(&[0x02, 0x01]))
             .expect_err("truncated update block should be rejected");
         assert!(matches!(err, LoroError::DecodeError(_)));
+    }
+
+    #[test]
+    fn snapshot_export_rejects_lazy_child_parent_conflict() {
+        fn doc_with_child(root: &str) -> (LoroDoc, loro_common::ContainerID) {
+            let doc = LoroDoc::new_auto_commit();
+            doc.set_peer_id(42).unwrap();
+            let child = doc
+                .get_map(root)
+                .insert_container("child", MapHandler::new_detached())
+                .unwrap();
+            child.insert("value", root).unwrap();
+            let child_id = child.id();
+            (doc, child_id)
+        }
+
+        let (parent_a, child_a) = doc_with_child("parent-a");
+        let (parent_b, child_b) = doc_with_child("parent-b");
+        assert_eq!(child_a, child_b, "test setup needs the same child id");
+
+        let mut sections_a = snapshot_sections(&parent_a);
+        let sections_b = snapshot_sections(&parent_b);
+        let state_a = KvWrapper::new_mem();
+        state_a
+            .import(sections_a.state_bytes.take().unwrap())
+            .unwrap();
+        let state_b = KvWrapper::new_mem();
+        state_b.import(sections_b.state_bytes.unwrap()).unwrap();
+        let child_key = child_a.to_bytes();
+        state_a.insert(&child_key, state_b.get(&child_key).unwrap());
+
+        let target = LoroDoc::new();
+        decode_snapshot_inner(
+            Snapshot {
+                oplog_bytes: sections_a.oplog_bytes,
+                state_bytes: Some(state_a.export()),
+                shallow_root_state_bytes: sections_a.shallow_root_state_bytes,
+            },
+            &target,
+            Default::default(),
+        )
+        .unwrap();
+
+        let err = target
+            .export(ExportMode::Snapshot)
+            .expect_err("conflicting lazy parent metadata must not be exported");
+        assert!(err.to_string().contains("snapshot state encodes parent"));
+    }
+
+    #[test]
+    fn snapshot_export_rejects_malformed_lazy_container_wrapper() {
+        let source = LoroDoc::new_auto_commit();
+        source.get_map("root").insert("value", 1).unwrap();
+        let mut sections = snapshot_sections(&source);
+        let state = KvWrapper::new_mem();
+        state.import(sections.state_bytes.take().unwrap()).unwrap();
+        let root = loro_common::ContainerID::new_root("root", crate::ContainerType::Map);
+        state.insert(
+            &root.to_bytes(),
+            Bytes::from(vec![crate::ContainerType::Map.to_u8()]),
+        );
+
+        let target = LoroDoc::new();
+        decode_snapshot_inner(
+            Snapshot {
+                oplog_bytes: sections.oplog_bytes,
+                state_bytes: Some(state.export()),
+                shallow_root_state_bytes: sections.shallow_root_state_bytes,
+            },
+            &target,
+            Default::default(),
+        )
+        .unwrap();
+
+        let err = target
+            .export(ExportMode::Snapshot)
+            .expect_err("malformed lazy state must return an export error");
+        assert!(err.to_string().contains("Decode container state failed"));
     }
 }
 

--- a/crates/loro-internal/src/encoding/fast_snapshot.rs
+++ b/crates/loro-internal/src/encoding/fast_snapshot.rs
@@ -315,14 +315,16 @@ pub(crate) fn encode_snapshot_inner(doc: &LoroDoc) -> Result<Snapshot, LoroEncod
             .unwrap();
         state = doc.app_state().lock();
     }
-    let snapshot = match state.ensure_all_alive_containers() {
-        Ok(_) => Ok(Snapshot {
-            oplog_bytes,
-            state_bytes: Some(state.store.encode()),
-            shallow_root_state_bytes: Bytes::new(),
-        }),
-        Err(err) => Err(LoroEncodeError::from(err)),
-    };
+    // Every container referenced by applied ops/diffs already has a store entry
+    // (`ensure_containers_created_by_op` / `ensure_containers_created_by_internal_diff`), so a
+    // full snapshot does not need to walk the alive-container graph: flushing the store and
+    // exporting the kv bytes is sufficient, and it keeps snapshot-backed state lazy. Only
+    // shallow snapshot export still derives the alive set (to filter retained keys).
+    let snapshot: Result<Snapshot, LoroEncodeError> = Ok(Snapshot {
+        oplog_bytes,
+        state_bytes: Some(state.store.encode()),
+        shallow_root_state_bytes: Bytes::new(),
+    });
     if was_detached {
         drop(state);
         doc._checkout_without_emitting(&old_state_frontiers, false, true)
@@ -441,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_export_rejects_lazy_child_parent_conflict() {
+    fn full_export_round_trips_lazy_child_parent_conflict_but_shallow_rejects() {
         fn doc_with_child(root: &str) -> (LoroDoc, loro_common::ContainerID) {
             let doc = LoroDoc::new_auto_commit();
             doc.set_peer_id(42).unwrap();
@@ -481,14 +483,24 @@ mod tests {
         )
         .unwrap();
 
-        let err = target
+        // Full snapshot export is a byte-faithful round-trip of the imported kv and does not
+        // re-derive the container graph, so it must succeed even with conflicting lazy parent
+        // metadata. The alive-container walk (and its validation) now only runs for shallow
+        // exports, which must still reject the conflict.
+        let reexported = target
             .export(ExportMode::Snapshot)
-            .expect_err("conflicting lazy parent metadata must not be exported");
+            .expect("full export round-trips lazy state without walking it");
+        let reimported = LoroDoc::new();
+        reimported.import(&reexported).unwrap();
+
+        let err = target
+            .export(ExportMode::StateOnly(None))
+            .expect_err("shallow export walks the graph and must reject the conflict");
         assert!(err.to_string().contains("snapshot state encodes parent"));
     }
 
     #[test]
-    fn snapshot_export_rejects_malformed_lazy_container_wrapper() {
+    fn full_export_round_trips_malformed_lazy_wrapper_but_shallow_rejects() {
         let source = LoroDoc::new_auto_commit();
         source.get_map("root").insert("value", 1).unwrap();
         let mut sections = snapshot_sections(&source);
@@ -512,9 +524,16 @@ mod tests {
         )
         .unwrap();
 
-        let err = target
+        // Full snapshot export no longer decodes lazy wrappers, so the malformed entry is
+        // round-tripped as-is; the error surfaces where the wrapper is actually read, e.g. the
+        // shallow-export walk.
+        target
             .export(ExportMode::Snapshot)
-            .expect_err("malformed lazy state must return an export error");
+            .expect("full export round-trips lazy state without decoding it");
+
+        let err = target
+            .export(ExportMode::StateOnly(None))
+            .expect_err("shallow export decodes the wrapper and must return an error");
         assert!(err.to_string().contains("Decode container state failed"));
     }
 }

--- a/crates/loro-internal/src/encoding/shallow_snapshot.rs
+++ b/crates/loro-internal/src/encoding/shallow_snapshot.rs
@@ -5,10 +5,10 @@ use std::collections::BTreeSet;
 use loro_common::{ContainerID, ContainerType, LoroEncodeError, LoroError, ID};
 
 use crate::{
-    container::list::list_op::InnerListOp,
+    container::{idx::ContainerIdx, list::list_op::InnerListOp},
     dag::DagUtils,
     encoding::fast_snapshot::{_encode_snapshot, Snapshot},
-    state::container_store::FRONTIERS_KEY,
+    state::{container_store::FRONTIERS_KEY, DocState},
     version::{Frontiers, VersionVector},
     LoroDoc,
 };
@@ -25,7 +25,7 @@ pub(crate) fn export_shallow_snapshot<W: std::io::Write>(
     w: &mut W,
 ) -> Result<Frontiers, LoroEncodeError> {
     let (snapshot, start_from) = export_shallow_snapshot_inner(doc, start_from)?;
-    _encode_snapshot(snapshot, w);
+    _encode_snapshot(&snapshot, w);
     Ok(start_from)
 }
 
@@ -102,7 +102,7 @@ pub(crate) fn export_shallow_snapshot_inner(
                 return Err(LoroEncodeError::UnknownContainer);
             }
 
-            state.ensure_all_alive_containers();
+            state.ensure_all_alive_containers()?;
             state.store.flush();
 
             // All the containers that are created after start_from need to be encoded.
@@ -136,12 +136,11 @@ pub(crate) fn export_shallow_snapshot_inner(
         doc._checkout_without_emitting(&start_from, false, false)
             .map_err(LoroEncodeError::from)?;
         let mut state = doc.app_state().lock();
-        let alive_containers = state.ensure_all_alive_containers();
-        if has_unknown_container(alive_containers.iter()) {
+        let alive_containers = state.ensure_all_alive_containers()?;
+        if has_unknown_container(alive_containers.iter().copied()) {
             return Err(LoroEncodeError::UnknownContainer);
         }
-        let mut alive_c_bytes: BTreeSet<Vec<u8>> =
-            alive_containers.iter().map(|x| x.to_bytes()).collect();
+        let mut alive_c_bytes = alive_indices_to_bytes(&state, &alive_containers);
         state.store.flush();
         let shallow_root_state_kv = state.store.get_kv_clone();
         drop(state);
@@ -149,7 +148,7 @@ pub(crate) fn export_shallow_snapshot_inner(
             .map_err(LoroEncodeError::from)?;
         let state_bytes = if ops_num > MAX_OPS_NUM_TO_ENCODE_WITHOUT_LATEST_STATE {
             let mut state = doc.app_state().lock();
-            state.ensure_all_alive_containers();
+            state.ensure_all_alive_containers()?;
             state.store.encode();
             // All the containers that are created after start_from need to be encoded
             for cid in state.store.iter_all_container_ids() {
@@ -187,8 +186,8 @@ pub(crate) fn export_shallow_snapshot_inner(
     Ok((result?, start_from))
 }
 
-fn has_unknown_container<'a>(mut cids: impl Iterator<Item = &'a ContainerID>) -> bool {
-    cids.any(|cid| matches!(cid.container_type(), ContainerType::Unknown(_)))
+fn has_unknown_container(mut idxs: impl Iterator<Item = ContainerIdx>) -> bool {
+    idxs.any(|idx| matches!(idx.get_type(), ContainerType::Unknown(_)))
 }
 
 fn has_unknown_container_key<'a>(mut keys: impl Iterator<Item = &'a Vec<u8>>) -> bool {
@@ -225,11 +224,11 @@ pub(crate) fn export_state_only_snapshot<W: std::io::Write>(
         doc._checkout_without_emitting(&start_from, false, false)
             .map_err(LoroEncodeError::from)?;
         let mut state = doc.app_state().lock();
-        let alive_containers = state.ensure_all_alive_containers();
-        if has_unknown_container(alive_containers.iter()) {
+        let alive_containers = state.ensure_all_alive_containers()?;
+        if has_unknown_container(alive_containers.iter().copied()) {
             return Err(LoroEncodeError::UnknownContainer);
         }
-        let mut alive_c_bytes = cids_to_bytes(alive_containers);
+        let mut alive_c_bytes = alive_indices_to_bytes(&state, &alive_containers);
         state.store.flush();
         let shallow_state_kv = state.store.get_kv_clone();
         drop(state);
@@ -237,7 +236,7 @@ pub(crate) fn export_state_only_snapshot<W: std::io::Write>(
         doc._checkout_without_emitting(target_frontiers, false, false)
             .map_err(LoroEncodeError::from)?;
         let mut state = doc.app_state().lock();
-        state.ensure_all_alive_containers();
+        state.ensure_all_alive_containers()?;
         state.store.encode();
         for cid in state.store.iter_all_container_ids() {
             if let ContainerID::Normal { peer, counter, .. } = cid {
@@ -263,7 +262,7 @@ pub(crate) fn export_state_only_snapshot<W: std::io::Write>(
             state_bytes: Some(target_state_kv.export()),
             shallow_root_state_bytes: shallow_state_bytes,
         };
-        _encode_snapshot(snapshot, w);
+        _encode_snapshot(&snapshot, w);
         Ok(())
     })();
 
@@ -273,11 +272,14 @@ pub(crate) fn export_state_only_snapshot<W: std::io::Write>(
     Ok(start_from)
 }
 
-fn cids_to_bytes(
-    alive_containers: std::collections::HashSet<ContainerID, rustc_hash::FxBuildHasher>,
+fn alive_indices_to_bytes(
+    state: &DocState,
+    alive_containers: &rustc_hash::FxHashSet<ContainerIdx>,
 ) -> BTreeSet<Vec<u8>> {
-    let alive_c_bytes: BTreeSet<Vec<u8>> = alive_containers.iter().map(|x| x.to_bytes()).collect();
-    alive_c_bytes
+    alive_containers
+        .iter()
+        .map(|idx| state.arena.get_container_id(*idx).unwrap().to_bytes())
+        .collect()
 }
 
 fn frontiers_to_vv_for_export(
@@ -426,18 +428,18 @@ pub(crate) fn encode_snapshot_at<W: std::io::Write>(
             }
         }
 
-        let alive_containers = state.ensure_all_alive_containers();
-        if has_unknown_container(alive_containers.iter()) {
+        let alive_containers = state.ensure_all_alive_containers()?;
+        if has_unknown_container(alive_containers.iter().copied()) {
             break 'block Err(LoroEncodeError::UnknownContainer);
         }
 
-        let alive_c_bytes = cids_to_bytes(alive_containers);
+        let alive_c_bytes = alive_indices_to_bytes(&state, &alive_containers);
         state.store.flush();
         let state_kv = state.store.get_kv_clone();
         state_kv.retain_keys(&alive_c_bytes);
         let bytes = state_kv.export();
         _encode_snapshot(
-            Snapshot {
+            &Snapshot {
                 oplog_bytes,
                 state_bytes: Some(bytes),
                 shallow_root_state_bytes: Bytes::new(),

--- a/crates/loro-internal/src/handler.rs
+++ b/crates/loro-internal/src/handler.rs
@@ -1854,12 +1854,9 @@ impl TextHandler {
     ///
     /// This method requires auto_commit to be enabled.
     pub fn splice(&self, pos: usize, len: usize, s: &str, pos_type: PosType) -> LoroResult<String> {
-        let end = checked_range_end(
-            pos,
-            len,
-            self.len(pos_type),
-            || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-        )?;
+        let end = checked_range_end(pos, len, self.len(pos_type), || {
+            format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+        })?;
         let x = self.slice(pos, end, pos_type)?;
         self.delete(pos, len, pos_type)?;
         self.insert(pos, s, pos_type)?;
@@ -1968,12 +1965,9 @@ impl TextHandler {
         }
 
         let text_len = self.len(pos_type);
-        let end = checked_range_end(
-            pos,
-            len,
-            text_len,
-            || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-        )?;
+        let end = checked_range_end(pos, len, text_len, || {
+            format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+        })?;
         self.validate_text_boundary(pos, pos_type)?;
         self.validate_text_boundary(end, pos_type)?;
 
@@ -2236,12 +2230,9 @@ impl TextHandler {
         }
 
         let text_len = self.len(pos_type);
-        let end = checked_range_end(
-            pos,
-            len,
-            text_len,
-            || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-        )
+        let end = checked_range_end(pos, len, text_len, || {
+            format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+        })
         .inspect_err(|_| error!("pos={} len={} len={}", pos, len, text_len))?;
         self.validate_text_boundary(pos, pos_type)?;
         self.validate_text_boundary(end, pos_type)?;
@@ -3245,12 +3236,9 @@ impl ListHandler {
         match &self.inner {
             MaybeDetached::Detached(l) => {
                 let mut list = l.lock();
-                let end = checked_range_end(
-                    pos,
-                    len,
-                    list.value.len(),
-                    || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-                )?;
+                let end = checked_range_end(pos, len, list.value.len(), || {
+                    format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+                })?;
                 list.value.drain(pos..end);
                 Ok(())
             }
@@ -3264,12 +3252,9 @@ impl ListHandler {
         }
 
         let list_len = self.len();
-        let end = checked_range_end(
-            pos,
-            len,
-            list_len,
-            || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-        )?;
+        let end = checked_range_end(pos, len, list_len, || {
+            format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+        })?;
 
         let inner = self.inner.try_attached_state()?;
         let ids: Vec<_> = inner.with_state(|state| {
@@ -3919,12 +3904,9 @@ impl MovableListHandler {
         match &self.inner {
             MaybeDetached::Detached(d) => {
                 let mut d = d.lock();
-                let end = checked_range_end(
-                    pos,
-                    len,
-                    d.value.len(),
-                    || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-                )?;
+                let end = checked_range_end(pos, len, d.value.len(), || {
+                    format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+                })?;
                 d.value.drain(pos..end);
                 Ok(())
             }
@@ -3939,12 +3921,9 @@ impl MovableListHandler {
         }
 
         let list_len = self.len();
-        let end = checked_range_end(
-            pos,
-            len,
-            list_len,
-            || format!("Position: {}:{}", file!(), line!()).into_boxed_str(),
-        )?;
+        let end = checked_range_end(pos, len, list_len, || {
+            format!("Position: {}:{}", file!(), line!()).into_boxed_str()
+        })?;
 
         let (ids, new_poses) = self.with_state(|state| {
             let list = state.as_movable_list_state().unwrap();

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     cursor::{AbsolutePosition, CannotFindRelativePosition, Cursor, PosQueryResult},
     dag::{Dag, DagUtils},
-    diff_calc::DiffCalculator,
+    diff_calc::{DiffCalculator, DiffMode},
     encoding::{
         self, decode_snapshot, export_fast_snapshot, export_fast_updates,
         export_fast_updates_in_range, export_shallow_snapshot, export_snapshot_at,
@@ -135,7 +135,9 @@ impl LoroDoc {
                 .expect("fork_at on detached doc should not fail");
         }
 
-        let snapshot = self.with_barrier(|| encoding::fast_snapshot::encode_snapshot_inner(self));
+        let snapshot = self
+            .with_barrier(|| encoding::fast_snapshot::encode_snapshot_inner(self))
+            .expect("forking a valid document should encode a snapshot");
         let doc = Self::new();
         doc.with_barrier(|| {
             encoding::fast_snapshot::decode_snapshot_inner(snapshot, &doc, Default::default())
@@ -767,6 +769,14 @@ impl LoroDoc {
 
         let old_vv = oplog.vv().clone();
         let old_frontiers = oplog.frontiers().clone();
+        // Checked before the changes are applied, while the store still holds only old history.
+        let isolated_batch = isolated_scalar_root_batch(&oplog, &changes).filter(|(_, names)| {
+            let mut state = self.state.lock();
+            names.iter().all(|name| {
+                let id = ContainerID::new_root(name, ContainerType::Map);
+                !state.store.contains_id(&id)
+            })
+        });
         let rollback_enabled = preflight.needs_state_apply_rollback;
         if rollback_enabled {
             oplog.begin_import_rollback_with_arena(arena_checkpoint);
@@ -775,14 +785,39 @@ impl LoroDoc {
         let result = encoding::apply_decoded_changes_to_oplog(&mut oplog, changes);
         if &old_vv != oplog.vv() {
             let mut diff = DiffCalculator::new(false);
-            let (diff, diff_mode) = diff.calc_diff_internal(
-                &oplog,
-                &old_vv,
-                &old_frontiers,
-                oplog.vv(),
-                oplog.dag.get_frontiers(),
-                None,
-            );
+            // Applying may have unlocked pending changes; the isolated fast path is only valid
+            // when exactly the candidate batch was appended on top of the old version.
+            let isolated_batch = isolated_batch.filter(|(component_vv, _)| {
+                component_vv
+                    .iter()
+                    .all(|(peer, end)| oplog.vv().get(peer) == Some(end))
+                    && oplog.vv().iter().all(|(peer, end)| {
+                        let old_end = old_vv.get(peer).copied().unwrap_or(0);
+                        let component_end = component_vv.get(peer).copied().unwrap_or(0);
+                        *end == old_end.max(component_end)
+                    })
+            });
+            let (diff, diff_mode) = if let Some((component_vv, _)) = isolated_batch {
+                let component_frontiers = oplog.dag.vv_to_frontiers(&component_vv);
+                let (diff, _) = diff.calc_diff_internal(
+                    &oplog,
+                    &VersionVector::default(),
+                    &Frontiers::default(),
+                    &component_vv,
+                    &component_frontiers,
+                    None,
+                );
+                (diff, DiffMode::Import)
+            } else {
+                diff.calc_diff_internal(
+                    &oplog,
+                    &old_vv,
+                    &old_frontiers,
+                    oplog.vv(),
+                    oplog.dag.get_frontiers(),
+                    None,
+                )
+            };
             let mut state = self.state.lock();
             if let Err(e) = state.apply_diff(
                 InternalDocDiff {
@@ -2061,7 +2096,7 @@ impl LoroDoc {
     pub fn export(&self, mode: ExportMode) -> Result<Vec<u8>, LoroEncodeError> {
         self.with_barrier(|| {
             let ans = match mode {
-                ExportMode::Snapshot => export_fast_snapshot(self),
+                ExportMode::Snapshot => export_fast_snapshot(self)?,
                 ExportMode::Updates { from } => export_fast_updates(self, &from),
                 ExportMode::UpdatesInRange { spans } => {
                     export_fast_updates_in_range(&self.oplog.lock(), spans.as_ref())
@@ -2176,6 +2211,82 @@ fn pending_root_containers_to_materialize(oplog: &OpLog, changes: &[Change]) -> 
     }
 
     roots.into_iter().collect()
+}
+
+/// Identify a causally closed update component that can be applied without replaying unrelated
+/// history. The first version is deliberately narrow: it accepts only scalar Map operations on
+/// top-level roots that never appeared in the existing history.
+fn isolated_scalar_root_batch(
+    oplog: &OpLog,
+    changes: &[Change],
+) -> Option<(VersionVector, FxHashSet<InternalString>)> {
+    if changes.is_empty() || !oplog.shallow_since_vv().is_empty() {
+        return None;
+    }
+
+    // Every peer in the batch must be brand new and contiguously covered from counter 0.
+    // (`changes` is sorted by lamport, so one peer's changes appear in counter order.)
+    let mut component_vv = VersionVector::new();
+    let mut root_names = FxHashSet::default();
+    for change in changes {
+        let peer = change.id.peer;
+        if oplog.vv().get(&peer).copied().unwrap_or(0) != 0 {
+            return None;
+        }
+        let end = component_vv.entry(peer).or_insert(0);
+        if change.id.counter != *end {
+            return None;
+        }
+        *end = change.ctr_end();
+
+        for op in change.ops.iter() {
+            let cid = oplog.arena.idx_to_id(op.container)?;
+            if cid.is_mergeable() {
+                return None;
+            }
+            let ContainerID::Root {
+                name,
+                container_type: ContainerType::Map,
+            } = cid
+            else {
+                return None;
+            };
+            let InnerContent::Map(map) = &op.content else {
+                return None;
+            };
+            if let Some(value) = &map.value {
+                if value.is_container()
+                    || loro_common::parse_mergeable_marker(
+                        &ContainerID::new_root(&name, ContainerType::Map),
+                        &map.key,
+                        value,
+                    )
+                    .is_some()
+                {
+                    return None;
+                }
+            }
+            root_names.insert(name);
+        }
+    }
+
+    // The batch must be causally closed: every dependency points inside the batch itself.
+    for change in changes {
+        for dep in change.deps.iter() {
+            if dep.counter >= component_vv.get(&dep.peer).copied().unwrap_or(0) {
+                return None;
+            }
+        }
+    }
+
+    if oplog
+        .change_store()
+        .old_history_may_touch_root_names(&root_names)
+    {
+        return None;
+    }
+
+    Some((component_vv, root_names))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -2472,7 +2583,7 @@ mod test {
         LoroDoc, ToJson, TreeParentId,
     };
     use bytes::{BufMut, Bytes};
-    use loro_common::ID;
+    use loro_common::{ContainerID, ContainerType, ID};
     use loro_kv_store::{mem_store::MemKvConfig, MemKvStore};
 
     const XXH_SEED: u32 = u32::from_le_bytes(*b"LORO");
@@ -2972,5 +3083,183 @@ mod test {
             String::new()
         };
         assert!(msg.contains("poisoned LoroMutex"), "{msg}");
+    }
+
+    #[test]
+    fn repeated_independent_scalar_root_imports_scan_history_once() {
+        let base = LoroDoc::new_auto_commit();
+        base.set_peer_id(1).unwrap();
+        for i in 0..64 {
+            base.get_map("existing")
+                .insert(&format!("key-{i}"), i)
+                .unwrap();
+            base.commit_then_renew();
+        }
+
+        let target = LoroDoc::new();
+        target
+            .import(&base.export(ExportMode::Snapshot).unwrap())
+            .unwrap();
+        assert!(!target.has_history_cache());
+
+        for i in 0_u64..8 {
+            let remote = LoroDoc::new_auto_commit();
+            remote.set_peer_id(2 + i).unwrap();
+            remote
+                .get_map(format!("isolated-{i}"))
+                .insert("value", i as i32)
+                .unwrap();
+            let update = remote.export(ExportMode::all_updates()).unwrap();
+            target.import(&update).unwrap();
+            assert_eq!(
+                target.get_map(format!("isolated-{i}")).get("value"),
+                Some((i as i32).into())
+            );
+        }
+
+        assert!(!target.has_history_cache());
+        assert_eq!(
+            target
+                .oplog
+                .lock()
+                .change_store()
+                .root_history_scan_count_for_test(),
+            1
+        );
+    }
+
+    #[test]
+    fn independent_fast_path_rejects_root_present_only_in_snapshot_state() {
+        fn snapshot_sections(doc: &LoroDoc) -> crate::encoding::fast_snapshot::Snapshot {
+            let (_, txn_guard) = doc.implicit_commit_then_stop();
+            drop(txn_guard);
+            crate::encoding::fast_snapshot::encode_snapshot_inner(doc).unwrap()
+        }
+
+        let base = LoroDoc::new_auto_commit();
+        base.set_peer_id(1).unwrap();
+        base.get_map("existing").insert("value", "base").unwrap();
+        let base_sections = snapshot_sections(&base);
+
+        let state_donor = LoroDoc::new_auto_commit();
+        state_donor.set_peer_id(999).unwrap();
+        state_donor
+            .get_map("isolated")
+            .insert("value", "stale")
+            .unwrap();
+        let donor_sections = snapshot_sections(&state_donor);
+
+        let target = LoroDoc::new();
+        crate::encoding::fast_snapshot::decode_snapshot_inner(
+            crate::encoding::fast_snapshot::Snapshot {
+                oplog_bytes: base_sections.oplog_bytes,
+                state_bytes: donor_sections.state_bytes,
+                shallow_root_state_bytes: Bytes::new(),
+            },
+            &target,
+            Default::default(),
+        )
+        .unwrap();
+        assert!(!target.has_history_cache());
+
+        let left = LoroDoc::new_auto_commit();
+        left.set_peer_id(2).unwrap();
+        left.get_map("isolated").insert("value", "left").unwrap();
+        let right = LoroDoc::new_auto_commit();
+        right.set_peer_id(3).unwrap();
+        right.get_map("isolated").insert("value", "winner").unwrap();
+        let aggregate = LoroDoc::new();
+        aggregate
+            .import(&left.export(ExportMode::all_updates()).unwrap())
+            .unwrap();
+        aggregate
+            .import(&right.export(ExportMode::all_updates()).unwrap())
+            .unwrap();
+
+        target
+            .import(&aggregate.export(ExportMode::all_updates()).unwrap())
+            .unwrap();
+
+        assert_eq!(
+            target.get_map("isolated").get("value"),
+            Some("winner".into())
+        );
+        assert!(target.has_history_cache());
+    }
+
+    #[test]
+    fn independent_scalar_root_import_rolls_back_after_state_failure() {
+        let base = LoroDoc::new_auto_commit();
+        base.set_peer_id(1).unwrap();
+        base.get_map("existing").insert("value", "base").unwrap();
+
+        let target = LoroDoc::new();
+        target
+            .import(&base.export(ExportMode::Snapshot).unwrap())
+            .unwrap();
+        let vv_before = target.oplog_vv();
+        let state_before = target.get_deep_value();
+
+        let remote = LoroDoc::new_auto_commit();
+        remote.set_peer_id(2).unwrap();
+        remote.get_map("isolated").insert("value", 7).unwrap();
+        let update = remote.export(ExportMode::all_updates()).unwrap();
+
+        crate::state::fail_next_import_state_apply_for_test();
+        let err = target.import(&update).unwrap_err();
+        assert!(err.to_string().contains("state apply failpoint"));
+        assert_eq!(target.oplog_vv(), vv_before);
+        assert_eq!(target.get_deep_value(), state_before);
+        assert!(!target.has_history_cache());
+
+        target.import(&update).unwrap();
+        assert_eq!(target.get_map("isolated").get("value"), Some(7.into()));
+    }
+
+    #[test]
+    fn independent_fast_path_rejects_root_name_seen_in_history() {
+        let base = LoroDoc::new_auto_commit();
+        base.set_peer_id(1).unwrap();
+        base.get_map("shared").insert("value", "base").unwrap();
+
+        let target = LoroDoc::new();
+        target
+            .import(&base.export(ExportMode::Snapshot).unwrap())
+            .unwrap();
+        assert!(!target.has_history_cache());
+
+        let remote = LoroDoc::new_auto_commit();
+        remote.set_peer_id(999).unwrap();
+        remote.get_map("shared").insert("value", "remote").unwrap();
+        target
+            .import(&remote.export(ExportMode::all_updates()).unwrap())
+            .unwrap();
+
+        assert_eq!(target.get_map("shared").get("value"), Some("remote".into()));
+        assert!(target.has_history_cache());
+    }
+
+    #[test]
+    fn independent_fast_path_rejects_deleted_root_name() {
+        let base = LoroDoc::new_auto_commit();
+        base.set_peer_id(1).unwrap();
+        let root_id = ContainerID::new_root("deleted", ContainerType::Map);
+        base.get_map("deleted").insert("value", "base").unwrap();
+        base.delete_root_container(root_id);
+
+        let target = LoroDoc::new();
+        target
+            .import(&base.export(ExportMode::Snapshot).unwrap())
+            .unwrap();
+        assert!(!target.has_history_cache());
+
+        let remote = LoroDoc::new_auto_commit();
+        remote.set_peer_id(2).unwrap();
+        remote.get_map("deleted").insert("value", "remote").unwrap();
+        target
+            .import(&remote.export(ExportMode::all_updates()).unwrap())
+            .unwrap();
+
+        assert!(target.has_history_cache());
     }
 }

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1000,8 +1000,8 @@ impl LoroDoc {
     #[inline]
     fn ensure_root_container(&self, id: &ContainerID) {
         // Mergeable roots stay lazily materialized: their existence is derived from the
-        // parent map's child ref, and their state is only created on first op (or at
-        // export via the alive-container walk).
+        // parent map's child ref, and a store entry only appears once the child gets its
+        // own ops (or via the shallow-export alive walk).
         if id.is_root() && !id.is_mergeable() {
             self.state.lock().ensure_container(id);
         }

--- a/crates/loro-internal/src/oplog/change_store.rs
+++ b/crates/loro-internal/src/oplog/change_store.rs
@@ -1,4 +1,6 @@
-use self::block_encode::{decode_block, decode_header, encode_block, ChangesBlockHeader};
+use self::block_encode::{
+    decode_block, decode_cids, decode_header, encode_block, ChangesBlockHeader,
+};
 use super::{loro_dag::AppDagNodeInner, AppDagNode};
 use crate::sync::Mutex;
 use crate::{
@@ -9,19 +11,22 @@ use crate::{
     op::Op,
     parent::register_container_and_parent_link,
     version::{Frontiers, ImVersionVector},
-    VersionVector,
+    InternalString, VersionVector,
 };
 use block_encode::decode_block_range;
 use bytes::Bytes;
 use itertools::Itertools;
 use loro_common::{
-    Counter, HasCounterSpan, HasId, HasIdSpan, HasLamportSpan, IdLp, IdSpan, Lamport, LoroError,
-    LoroResult, PeerID, ID,
+    ContainerID, Counter, HasCounterSpan, HasId, HasIdSpan, HasLamportSpan, IdLp, IdSpan, Lamport,
+    LoroError, LoroResult, PeerID, ID,
 };
 use loro_kv_store::{mem_store::MemKvConfig, MemKvStore};
 use once_cell::sync::OnceCell;
 use rle::{HasLength, Mergable, RlePush, RleVec, Sliceable};
+use rustc_hash::FxHashSet;
 use std::sync::atomic::AtomicI64;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, VecDeque},
@@ -37,6 +42,7 @@ pub(super) mod iter;
 const MAX_BLOCK_SIZE: usize = 1024 * 4;
 #[cfg(test)]
 const MAX_BLOCK_SIZE: usize = 128;
+const MAX_ROOT_HISTORY_NAME_BYTES: usize = 256 * 1024;
 
 /// # Invariance
 ///
@@ -69,6 +75,48 @@ pub struct ChangeStore {
     /// The version vector of the external kv store.
     external_vv: Arc<Mutex<VersionVector>>,
     merge_interval: Arc<AtomicI64>,
+    root_history_names: Arc<Mutex<RootHistoryNamesState>>,
+    #[cfg(test)]
+    root_history_scan_count: Arc<AtomicUsize>,
+}
+
+/// A conservative, size-capped set of every top-level root name that appears in the store's
+/// history. It only answers "may history have touched this root?", so retaining stale names
+/// (e.g. from a rolled-back import) is harmless — it just forces the general diff path.
+#[derive(Debug, Default)]
+enum RootHistoryNamesState {
+    #[default]
+    Uninitialized,
+    Valid {
+        names: FxHashSet<InternalString>,
+        name_bytes: usize,
+    },
+    Invalid,
+}
+
+/// Return false when retaining the name would exceed the fixed memory bound.
+fn record_root_name(
+    names: &mut FxHashSet<InternalString>,
+    name_bytes: &mut usize,
+    cid: &ContainerID,
+) -> bool {
+    let ContainerID::Root { name, .. } = cid else {
+        return true;
+    };
+    if cid.is_mergeable() || names.contains(name) {
+        return true;
+    }
+
+    let Some(new_bytes) = name_bytes.checked_add(name.len()) else {
+        return false;
+    };
+    if new_bytes > MAX_ROOT_HISTORY_NAME_BYTES {
+        return false;
+    }
+
+    names.insert(name.clone());
+    *name_bytes = new_bytes;
+    true
 }
 
 #[derive(Debug, Clone)]
@@ -149,6 +197,9 @@ impl ChangeStore {
             external_kv: Arc::new(Mutex::new(MemKvStore::new(MemKvConfig::default()))),
             // external_kv: Arc::new(Mutex::new(BTreeMap::default())),
             merge_interval,
+            root_history_names: Arc::new(Mutex::new(RootHistoryNamesState::Uninitialized)),
+            #[cfg(test)]
+            root_history_scan_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -301,6 +352,8 @@ impl ChangeStore {
     }
 
     pub(crate) fn rollback_import(&self, rollback: ChangeStoreRollback) {
+        // The name set may already include names from changes this rollback removes. That is
+        // fine: stale names only make `old_history_may_touch_root_names` conservatively true.
         let mut inner = self.inner.lock();
         inner.mem_parsed_kv.retain(|id, _| {
             let old_end = rollback.old_vv.get(&id.peer).copied().unwrap_or(0);
@@ -334,6 +387,125 @@ impl ChangeStore {
                 f(c);
             }
         }
+    }
+
+    fn build_root_history_names(&self) -> RootHistoryNamesState {
+        let mut names = FxHashSet::default();
+        let mut name_bytes = 0;
+
+        {
+            let external = self.external_kv.lock();
+            for (key, bytes) in external.scan(Bound::Unbounded, Bound::Unbounded) {
+                if key.len() != 12 {
+                    continue;
+                }
+                let header = match decode_header(&bytes)
+                    .and_then(|header| decode_cids(&bytes, Some(header)))
+                {
+                    Ok(header) => header,
+                    Err(_) => return RootHistoryNamesState::Invalid,
+                };
+                let Some(cids) = header.cids.get() else {
+                    return RootHistoryNamesState::Invalid;
+                };
+                for cid in cids.iter() {
+                    if !record_root_name(&mut names, &mut name_bytes, cid) {
+                        return RootHistoryNamesState::Invalid;
+                    }
+                }
+            }
+        }
+
+        let inner = self.inner.lock();
+        for block in inner.mem_parsed_kv.values() {
+            match &block.content {
+                ChangesBlockContent::Changes(changes) | ChangesBlockContent::Both(changes, _) => {
+                    for change in changes.iter() {
+                        for op in change.ops.iter() {
+                            let Some(cid) = self.arena.idx_to_id(op.container) else {
+                                return RootHistoryNamesState::Invalid;
+                            };
+                            if !record_root_name(&mut names, &mut name_bytes, &cid) {
+                                return RootHistoryNamesState::Invalid;
+                            }
+                        }
+                    }
+                }
+                ChangesBlockContent::Bytes(bytes) => {
+                    let header = bytes.header.get().map(|header| header.as_ref().clone());
+                    let header = match decode_cids(&bytes.bytes, header) {
+                        Ok(header) => header,
+                        Err(_) => return RootHistoryNamesState::Invalid,
+                    };
+                    let Some(cids) = header.cids.get() else {
+                        return RootHistoryNamesState::Invalid;
+                    };
+                    for cid in cids.iter() {
+                        if !record_root_name(&mut names, &mut name_bytes, cid) {
+                            return RootHistoryNamesState::Invalid;
+                        }
+                    }
+                }
+            }
+        }
+
+        RootHistoryNamesState::Valid { names, name_bytes }
+    }
+
+    fn record_change_in_root_history_names(&self, change: &Change) {
+        let mut cached = self.root_history_names.lock();
+        let RootHistoryNamesState::Valid { names, name_bytes } = &mut *cached else {
+            return;
+        };
+
+        for op in change.ops.iter() {
+            let recorded = self
+                .arena
+                .idx_to_id(op.container)
+                .is_some_and(|cid| record_root_name(names, name_bytes, &cid));
+            if !recorded {
+                *cached = RootHistoryNamesState::Invalid;
+                return;
+            }
+        }
+    }
+
+    /// Return whether the history already in this store may have touched any top-level root in
+    /// `names`. Must be called before the candidate changes are inserted.
+    ///
+    /// The first call scans encoded block container arenas without parsing operations or
+    /// populating the parsed-change cache; later inserts update the cached name set, so repeated
+    /// independent imports do not rescan the old history. Decode failures or exceeding the size
+    /// cap permanently disable this optimization for the store.
+    pub(crate) fn old_history_may_touch_root_names(
+        &self,
+        names: &FxHashSet<InternalString>,
+    ) -> bool {
+        if names.is_empty() {
+            return false;
+        }
+
+        let mut cached = self.root_history_names.lock();
+        if matches!(*cached, RootHistoryNamesState::Uninitialized) {
+            #[cfg(test)]
+            self.root_history_scan_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            *cached = self.build_root_history_names();
+        }
+
+        match &*cached {
+            RootHistoryNamesState::Valid {
+                names: history_names,
+                ..
+            } => names.iter().any(|name| history_names.contains(name)),
+            RootHistoryNamesState::Invalid | RootHistoryNamesState::Uninitialized => true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn root_history_scan_count_for_test(&self) -> usize {
+        self.root_history_scan_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub(crate) fn iter_blocks(&self, id_span: IdSpan) -> Vec<(Arc<ChangesBlock>, usize, usize)> {
@@ -529,6 +701,9 @@ impl ChangeStore {
             external_vv: Arc::new(Mutex::new(self.external_vv.lock().clone())),
             external_kv: self.external_kv.lock().clone_store(),
             merge_interval,
+            root_history_names: Arc::new(Mutex::new(RootHistoryNamesState::Uninitialized)),
+            #[cfg(test)]
+            root_history_scan_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -638,13 +813,14 @@ mod mut_external_kv {
                 kv_store.len() <= 2,
                 "kv store should be empty when using decode_all"
             );
-            // The snapshot/update body is already integrity-checked by the
-            // document-level checksum in `parse_header_and_body(.., true)` before
-            // we reach here, so skip the redundant per-block checksum.
+            // Snapshot/update bytes are external input. Validate the checksums embedded in each
+            // SSTable block as well as the document envelope so malformed lazy blocks are rejected
+            // during import instead of surfacing from a later read.
             kv_store
-                .import_all_unchecked(bytes)
+                .import_all(bytes)
                 .map_err(|e| LoroError::DecodeError(e.into_boxed_str()))?;
             drop(kv_store);
+            *self.root_history_names.lock() = RootHistoryNamesState::Uninitialized;
             let vv_bytes = self.external_kv.lock().get(VV_KEY).unwrap_or_default();
             let vv = VersionVector::decode(&vv_bytes)
                 .map_err(|_| LoroError::DecodeDataCorruptionError)?;
@@ -798,6 +974,8 @@ mod mut_inner_kv {
             is_local: bool,
             mut rollback: Option<&mut ChangeStoreRollback>,
         ) {
+            self.record_change_in_root_history_names(&change);
+
             #[cfg(debug_assertions)]
             {
                 let vv = self.external_vv.lock();
@@ -1894,6 +2072,18 @@ mod test {
         assert_eq!(change.id.peer, 1);
         assert!(change.lamport <= 700);
         assert_eq!(change.id.counter + change.atom_len() as Counter, 500);
+    }
+
+    #[test]
+    fn root_history_names_reject_oversized_name_without_retaining_it() {
+        let mut names = FxHashSet::default();
+        let mut name_bytes = 0;
+        let oversized_name = "x".repeat(MAX_ROOT_HISTORY_NAME_BYTES + 1);
+        let oversized = ContainerID::new_root(&oversized_name, crate::ContainerType::Map);
+
+        assert!(!record_root_name(&mut names, &mut name_bytes, &oversized));
+        assert!(names.is_empty());
+        assert_eq!(name_bytes, 0);
     }
 
     #[test]

--- a/crates/loro-internal/src/parent.rs
+++ b/crates/loro-internal/src/parent.rs
@@ -4,13 +4,14 @@
 //!
 //!
 
-use loro_common::LoroValue;
+use loro_common::{ContainerID, LoroValue};
+use smallvec::SmallVec;
 
 use crate::{
     arena::SharedArena,
     change::Change,
     container::{list::list_op::ListOp, map::MapSet},
-    op::{ListSlice, RawOp, RawOpContent},
+    op::{ListSlice, Op, RawOp, RawOpContent},
     DocState, OpLog,
 };
 
@@ -83,6 +84,27 @@ impl DocState {
             #[cfg(feature = "counter")]
             RawOpContent::Counter(_) => {}
             RawOpContent::Unknown { .. } => {}
+        }
+    }
+
+    /// Create store entries for the containers this local op brings alive.
+    ///
+    /// Full snapshot export no longer walks the alive-container graph, so "every referenced
+    /// container has a store entry" must hold by construction: an empty child inserted via
+    /// `insert_container` would otherwise only exist inside its parent's value and be skipped
+    /// by `flush`.
+    ///
+    /// Mergeable markers are deliberately NOT handled here: an ensured-but-empty mergeable
+    /// child has no independent existence — the parent map's marker is its single source of
+    /// truth, and materializing a store entry for it would keep `has_container` true after the
+    /// marker is removed (see `loro_get_container_for_deleted_mergeable_children`).
+    pub(super) fn ensure_containers_created_by_op(&mut self, op: &Op) {
+        let mut to_ensure: SmallVec<[ContainerID; 2]> = SmallVec::new();
+        op.content
+            .visit_created_children(&self.arena, &mut |c| to_ensure.push(c.clone()));
+
+        for id in to_ensure {
+            self.ensure_container(&id);
         }
     }
 }

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -911,16 +911,22 @@ impl DocState {
         self.store.ensure_container(id);
     }
 
-    /// Ensure all alive containers are created in DocState and will be encoded in the next `encode` call
-    pub(crate) fn ensure_all_alive_containers(&mut self) -> FxHashSet<ContainerID> {
-        // TODO: PERF This can be optimized because we shouldn't need to call get_value for
-        // all the containers every time we export
-        let ans = self.get_all_alive_containers();
-        for id in ans.iter() {
-            self.ensure_container(id);
+    /// Ensure all alive containers are created in DocState and will be encoded in the next
+    /// `encode` call.
+    ///
+    /// Returns arena indices rather than IDs so the full-snapshot export path does not have to
+    /// hold a second set of cloned container IDs; callers that need IDs map them through the
+    /// arena.
+    pub(crate) fn ensure_all_alive_containers(&mut self) -> LoroResult<FxHashSet<ContainerIdx>> {
+        let indices = self.get_all_alive_container_indices()?;
+        for idx in indices.iter() {
+            let id = self.arena.get_container_id(*idx).unwrap();
+            if !self.store.contains_id(&id) {
+                self.store.ensure_container(&id);
+            }
         }
 
-        ans
+        Ok(indices)
     }
 
     pub(crate) fn get_value_by_idx(&mut self, container_idx: ContainerIdx) -> LoroValue {
@@ -1303,7 +1309,7 @@ impl DocState {
     fn root_container_is_empty(&mut self, idx: ContainerIdx) -> bool {
         let value = self
             .store
-            .get_value(idx)
+            .get_value_ephemeral(idx)
             .unwrap_or_else(|| idx.get_type().default_value());
         visible_container_value_is_empty(idx.get_type(), &value)
     }
@@ -1325,7 +1331,7 @@ impl DocState {
         id: Option<ContainerID>,
     ) -> LoroValue {
         let id = id.unwrap_or_else(|| self.arena.idx_to_id(container).unwrap());
-        let Some(value) = self.store.get_value(container) else {
+        let Some(value) = self.store.get_value_ephemeral(container) else {
             return container.get_type().default_value();
         };
         let cid_str = LoroValue::String(format!("idx:{}, id:{}", container.to_index(), id).into());
@@ -1413,7 +1419,7 @@ impl DocState {
     }
 
     pub fn get_container_deep_value(&mut self, container: ContainerIdx) -> LoroValue {
-        let Some(value) = self.store.get_value(container) else {
+        let Some(value) = self.store.get_value_ephemeral(container) else {
             return container.get_type().default_value();
         };
         match value {
@@ -1480,29 +1486,101 @@ impl DocState {
         }
     }
 
-    pub(crate) fn get_all_alive_containers(&mut self) -> FxHashSet<ContainerID> {
-        let flag = self.store.load_all();
+    pub(crate) fn get_all_alive_containers(&mut self) -> LoroResult<FxHashSet<ContainerID>> {
+        Ok(self
+            .get_all_alive_container_indices()?
+            .into_iter()
+            .map(|idx| self.arena.get_container_id(idx).unwrap())
+            .collect())
+    }
+
+    fn get_all_alive_container_indices(&mut self) -> LoroResult<FxHashSet<ContainerIdx>> {
+        let flag = self.store.load_root_containers();
         let mut ans = FxHashSet::default();
         let mut to_visit = self
             .arena
             .root_containers(flag)
             .iter()
-            .map(|x| self.arena.get_container_id(*x).unwrap())
-            .filter(|id| self.store.contains_id(id))
+            .copied()
+            .filter(|idx| {
+                let id = self.arena.get_container_id(*idx).unwrap();
+                self.store.contains_id(&id)
+            })
             .collect_vec();
 
-        while let Some(id) = to_visit.pop() {
-            self.get_alive_children_of(&id, &mut to_visit);
-            ans.insert(id);
+        while let Some(idx) = to_visit.pop() {
+            if !ans.insert(idx) {
+                continue;
+            }
+            self.get_alive_children_of(idx, &mut to_visit)?;
         }
 
-        ans
+        Ok(ans)
     }
 
-    pub(crate) fn get_alive_children_of(&mut self, id: &ContainerID, ans: &mut Vec<ContainerID>) {
-        let idx = self.arena.register_container(id);
-        let Some(value) = self.store.get_value(idx) else {
-            return;
+    fn validate_alive_parent(
+        &mut self,
+        child_idx: ContainerIdx,
+        expected_parent: Option<ContainerIdx>,
+    ) -> LoroResult<()> {
+        let child_id = self.arena.get_container_id(child_idx).unwrap();
+        let expected_parent_id = expected_parent.and_then(|idx| self.arena.get_container_id(idx));
+        if let Some(encoded_parent) = self.store.get_parent_ephemeral(child_idx)? {
+            if encoded_parent != expected_parent_id {
+                return Err(LoroError::DecodeError(
+                    format!(
+                        "container {child_id:?} expects parent {expected_parent_id:?}, but its snapshot state encodes parent {encoded_parent:?}"
+                    )
+                    .into_boxed_str(),
+                ));
+            }
+        }
+
+        match self.arena.get_registered_parent(child_idx) {
+            Some(registered_parent) if registered_parent == expected_parent => {}
+            Some(registered_parent) => {
+                let registered_parent =
+                    registered_parent.and_then(|idx| self.arena.get_container_id(idx));
+                return Err(LoroError::DecodeError(
+                    format!(
+                        "container {child_id:?} expects parent {expected_parent_id:?}, but its registered parent is {registered_parent:?}"
+                    )
+                    .into_boxed_str(),
+                ));
+            }
+            None => self.arena.set_parent(child_idx, expected_parent),
+        }
+
+        Ok(())
+    }
+
+    fn register_alive_child(
+        &mut self,
+        parent_idx: ContainerIdx,
+        child_id: &ContainerID,
+        ans: &mut Vec<ContainerIdx>,
+    ) -> LoroResult<()> {
+        let child_idx = self.arena.register_container(child_id);
+        self.validate_alive_parent(child_idx, Some(parent_idx))?;
+        ans.push(child_idx);
+        Ok(())
+    }
+
+    fn get_alive_children_of(
+        &mut self,
+        idx: ContainerIdx,
+        ans: &mut Vec<ContainerIdx>,
+    ) -> LoroResult<()> {
+        let id = self.arena.get_container_id(idx).unwrap();
+        if let Some((parent_id, _key, _kind)) = id.parse_mergeable() {
+            let parent_idx = self.arena.register_container(&parent_id);
+            self.validate_alive_parent(idx, Some(parent_idx))?;
+        } else if id.is_root() {
+            self.validate_alive_parent(idx, None)?;
+        }
+
+        let Some(value) = self.store.try_get_value_ephemeral(idx)? else {
+            return Ok(());
         };
 
         match value {
@@ -1518,7 +1596,7 @@ impl DocState {
                         let map = node.as_map().unwrap();
                         let meta = map.get("meta").unwrap();
                         let id = meta.as_container().unwrap();
-                        ans.push(id.clone());
+                        self.register_alive_child(idx, id, ans)?;
                         let children = map.get("children").unwrap();
                         let children = children.as_list().unwrap();
                         for child in children.iter() {
@@ -1528,7 +1606,7 @@ impl DocState {
                 } else {
                     for item in list.iter() {
                         if let LoroValue::Container(id) = item {
-                            ans.push(id.clone());
+                            self.register_alive_child(idx, id, ans)?;
                         }
                     }
                 }
@@ -1536,7 +1614,7 @@ impl DocState {
             LoroValue::Map(map) => {
                 for (_key, value) in map.iter() {
                     if let LoroValue::Container(id) = value {
-                        ans.push(id.clone());
+                        self.register_alive_child(idx, id, ans)?;
                     }
                 }
                 // Mergeable children are resolved from compact binary markers stored in this
@@ -1557,12 +1635,13 @@ impl DocState {
                     })
                     .unwrap_or_default();
                 for cid in mergeable_cids {
-                    self.arena.register_container(&cid);
-                    ans.push(cid);
+                    self.register_alive_child(idx, &cid, ans)?;
                 }
             }
             _ => {}
         }
+
+        Ok(())
     }
 
     // Because we need to calculate path based on [DocState], so we cannot extract

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -8,7 +8,6 @@ use container_store::ContainerStore;
 use dead_containers_cache::DeadContainersCache;
 use enum_as_inner::EnumAsInner;
 use enum_dispatch::enum_dispatch;
-use itertools::Itertools;
 use loro_common::{ContainerID, Lamport, LoroError, LoroResult, TreeID};
 use loro_delta::DeltaItem;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -171,6 +170,31 @@ pub struct DocState {
     event_recorder: EventRecorder,
 
     dead_containers_cache: DeadContainersCache,
+    alive_containers_cache: Option<AliveContainersCache>,
+}
+
+struct AliveContainersCache {
+    frontiers: Frontiers,
+    roots: Vec<ContainerIdx>,
+    indices: Arc<FxHashSet<ContainerIdx>>,
+}
+
+const ALIVE_CONTAINERS_CACHE_MAX_BYTES: usize = 4 * 1024 * 1024;
+
+fn estimated_alive_containers_cache_bytes(
+    roots_capacity: usize,
+    indices: &FxHashSet<ContainerIdx>,
+) -> usize {
+    // Hash-table control bytes and alignment are implementation details. A pointer of overhead per
+    // entry is deliberately conservative, so retaining the cache cannot silently become another
+    // form of full-state materialization on documents with very many small containers.
+    roots_capacity
+        .saturating_mul(std::mem::size_of::<ContainerIdx>())
+        .saturating_add(
+            indices
+                .capacity()
+                .saturating_mul(std::mem::size_of::<ContainerIdx>() + std::mem::size_of::<usize>()),
+        )
 }
 
 impl std::fmt::Debug for DocState {
@@ -453,6 +477,7 @@ impl DocState {
                 changed_idx_in_txn: FxHashSet::default(),
                 event_recorder: Default::default(),
                 dead_containers_cache: Default::default(),
+                alive_containers_cache: None,
             },
             crate::lock::LockKind::DocState,
         ))
@@ -477,6 +502,7 @@ impl DocState {
             changed_idx_in_txn: FxHashSet::default(),
             event_recorder: Default::default(),
             dead_containers_cache: Default::default(),
+            alive_containers_cache: None,
         }))
     }
 
@@ -917,12 +943,41 @@ impl DocState {
     /// Returns arena indices rather than IDs so the full-snapshot export path does not have to
     /// hold a second set of cloned container IDs; callers that need IDs map them through the
     /// arena.
-    pub(crate) fn ensure_all_alive_containers(&mut self) -> LoroResult<FxHashSet<ContainerIdx>> {
-        let indices = self.get_all_alive_container_indices()?;
+    pub(crate) fn ensure_all_alive_containers(
+        &mut self,
+    ) -> LoroResult<Arc<FxHashSet<ContainerIdx>>> {
+        let roots = self.existing_retention_roots();
+        if !self.in_txn {
+            if let Some(cache) = &self.alive_containers_cache {
+                if cache.frontiers == self.frontiers && cache.roots == roots {
+                    return Ok(cache.indices.clone());
+                }
+            }
+        }
+        // Do not hold the previous version's set while constructing its replacement.
+        self.alive_containers_cache = None;
+
+        let indices = Arc::new(self.get_all_alive_container_indices_from_roots(&roots)?);
         for idx in indices.iter() {
             let id = self.arena.get_container_id(*idx).unwrap();
             if !self.store.contains_id(&id) {
                 self.store.ensure_container(&id);
+            }
+        }
+
+        if !self.in_txn {
+            // The walk can discover and ensure an empty mergeable child, which registers another
+            // retention root without advancing the document version. Store the post-walk roots so
+            // the next unchanged export can use the cache immediately.
+            let roots = self.existing_retention_roots();
+            if estimated_alive_containers_cache_bytes(roots.capacity(), &indices)
+                <= ALIVE_CONTAINERS_CACHE_MAX_BYTES
+            {
+                self.alive_containers_cache = Some(AliveContainersCache {
+                    frontiers: self.frontiers.clone(),
+                    roots,
+                    indices: indices.clone(),
+                });
             }
         }
 
@@ -1141,6 +1196,7 @@ impl DocState {
             self.start_recording();
         }
         self.dead_containers_cache = Default::default();
+        self.alive_containers_cache = None;
     }
 
     pub fn get_value(&mut self) -> LoroValue {
@@ -1495,24 +1551,45 @@ impl DocState {
     }
 
     fn get_all_alive_container_indices(&mut self) -> LoroResult<FxHashSet<ContainerIdx>> {
+        let roots = self.existing_retention_roots();
+        self.get_all_alive_container_indices_from_roots(&roots)
+    }
+
+    fn existing_retention_roots(&mut self) -> Vec<ContainerIdx> {
         let flag = self.store.load_root_containers();
-        let mut ans = FxHashSet::default();
-        let mut to_visit = self
-            .arena
+        self.arena
             .root_containers(flag)
-            .iter()
-            .copied()
+            .into_iter()
             .filter(|idx| {
                 let id = self.arena.get_container_id(*idx).unwrap();
                 self.store.contains_id(&id)
             })
-            .collect_vec();
+            .collect()
+    }
 
-        while let Some(idx) = to_visit.pop() {
+    fn get_all_alive_container_indices_from_roots(
+        &mut self,
+        roots: &[ContainerIdx],
+    ) -> LoroResult<FxHashSet<ContainerIdx>> {
+        let mut ans = FxHashSet::default();
+        let mut to_visit = Vec::new();
+        for &idx in roots {
+            let id = self.arena.get_container_id(idx).unwrap();
+            let expected_parent = id
+                .parse_mergeable()
+                .map(|(parent_id, _, _)| self.arena.register_container(&parent_id));
+            to_visit.push((idx, expected_parent));
+        }
+
+        while let Some((idx, expected_parent)) = to_visit.pop() {
             if !ans.insert(idx) {
+                // The same child may be referenced by multiple parents. Even though its value was
+                // already traversed, every additional edge still has to agree with the encoded and
+                // registered parent.
+                self.validate_alive_parent(idx, expected_parent)?;
                 continue;
             }
-            self.get_alive_children_of(idx, &mut to_visit)?;
+            self.get_alive_children_of(idx, expected_parent, &mut to_visit)?;
         }
 
         Ok(ans)
@@ -1523,9 +1600,19 @@ impl DocState {
         child_idx: ContainerIdx,
         expected_parent: Option<ContainerIdx>,
     ) -> LoroResult<()> {
+        let encoded_parent = self.store.get_parent_ephemeral(child_idx)?;
+        self.validate_alive_parent_with_encoded(child_idx, expected_parent, encoded_parent)
+    }
+
+    fn validate_alive_parent_with_encoded(
+        &mut self,
+        child_idx: ContainerIdx,
+        expected_parent: Option<ContainerIdx>,
+        encoded_parent: Option<Option<ContainerID>>,
+    ) -> LoroResult<()> {
         let child_id = self.arena.get_container_id(child_idx).unwrap();
         let expected_parent_id = expected_parent.and_then(|idx| self.arena.get_container_id(idx));
-        if let Some(encoded_parent) = self.store.get_parent_ephemeral(child_idx)? {
+        if let Some(encoded_parent) = encoded_parent {
             if encoded_parent != expected_parent_id {
                 return Err(LoroError::DecodeError(
                     format!(
@@ -1558,30 +1645,24 @@ impl DocState {
         &mut self,
         parent_idx: ContainerIdx,
         child_id: &ContainerID,
-        ans: &mut Vec<ContainerIdx>,
-    ) -> LoroResult<()> {
+        ans: &mut Vec<(ContainerIdx, Option<ContainerIdx>)>,
+    ) {
         let child_idx = self.arena.register_container(child_id);
-        self.validate_alive_parent(child_idx, Some(parent_idx))?;
-        ans.push(child_idx);
-        Ok(())
+        ans.push((child_idx, Some(parent_idx)));
     }
 
     fn get_alive_children_of(
         &mut self,
         idx: ContainerIdx,
-        ans: &mut Vec<ContainerIdx>,
+        expected_parent: Option<ContainerIdx>,
+        ans: &mut Vec<(ContainerIdx, Option<ContainerIdx>)>,
     ) -> LoroResult<()> {
-        let id = self.arena.get_container_id(idx).unwrap();
-        if let Some((parent_id, _key, _kind)) = id.parse_mergeable() {
-            let parent_idx = self.arena.register_container(&parent_id);
-            self.validate_alive_parent(idx, Some(parent_idx))?;
-        } else if id.is_root() {
-            self.validate_alive_parent(idx, None)?;
-        }
-
-        let Some(value) = self.store.try_get_value_ephemeral(idx)? else {
+        let Some((encoded_parent, value)) = self.store.try_get_parent_and_value_ephemeral(idx)?
+        else {
+            self.validate_alive_parent_with_encoded(idx, expected_parent, None)?;
             return Ok(());
         };
+        self.validate_alive_parent_with_encoded(idx, expected_parent, Some(encoded_parent))?;
 
         match value {
             LoroValue::Container(_) => unreachable!(),
@@ -1596,7 +1677,7 @@ impl DocState {
                         let map = node.as_map().unwrap();
                         let meta = map.get("meta").unwrap();
                         let id = meta.as_container().unwrap();
-                        self.register_alive_child(idx, id, ans)?;
+                        self.register_alive_child(idx, id, ans);
                         let children = map.get("children").unwrap();
                         let children = children.as_list().unwrap();
                         for child in children.iter() {
@@ -1606,7 +1687,7 @@ impl DocState {
                 } else {
                     for item in list.iter() {
                         if let LoroValue::Container(id) = item {
-                            self.register_alive_child(idx, id, ans)?;
+                            self.register_alive_child(idx, id, ans);
                         }
                     }
                 }
@@ -1614,7 +1695,7 @@ impl DocState {
             LoroValue::Map(map) => {
                 for (_key, value) in map.iter() {
                     if let LoroValue::Container(id) = value {
-                        self.register_alive_child(idx, id, ans)?;
+                        self.register_alive_child(idx, id, ans);
                     }
                 }
                 // Mergeable children are resolved from compact binary markers stored in this
@@ -1635,7 +1716,7 @@ impl DocState {
                     })
                     .unwrap_or_default();
                 for cid in mergeable_cids {
-                    self.register_alive_child(idx, &cid, ans)?;
+                    self.register_alive_child(idx, &cid, ans);
                 }
             }
             _ => {}

--- a/crates/loro-internal/src/state.rs
+++ b/crates/loro-internal/src/state.rs
@@ -11,6 +11,7 @@ use enum_dispatch::enum_dispatch;
 use loro_common::{ContainerID, Lamport, LoroError, LoroResult, TreeID};
 use loro_delta::DeltaItem;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use tracing::{info_span, instrument, warn};
 
 use crate::{
@@ -747,7 +748,8 @@ impl DocState {
                         diff.diff = extern_diff.into();
                     }
                 }
-                crate::event::DiffVariant::Internal(_) => {
+                crate::event::DiffVariant::Internal(inner_diff) => {
+                    self.ensure_containers_created_by_internal_diff(inner_diff);
                     let cid = self.arena.idx_to_id(idx).unwrap();
                     info_span!("apply diff on", container_id = ?cid).in_scope(
                         || -> LoroResult<()> {
@@ -846,6 +848,72 @@ impl DocState {
         Ok(())
     }
 
+    /// Create store entries for every container this diff brings alive.
+    ///
+    /// Full snapshot export no longer walks the alive-container graph to discover containers
+    /// that exist only as references inside another container's value (e.g. an empty child
+    /// created by a remote peer, whose own container has no ops and therefore no diff). Such
+    /// entries must be created when the reference is applied so the next flush persists them.
+    fn ensure_containers_created_by_internal_diff(&mut self, diff: &InternalDiff) {
+        let mut to_ensure: SmallVec<[ContainerID; 2]> = SmallVec::new();
+        match diff {
+            InternalDiff::ListRaw(delta) => {
+                for item in delta.iter() {
+                    if let crate::delta::DeltaItem::Insert { insert, .. } = item {
+                        match &insert.values {
+                            either::Either::Left(range) => {
+                                for value in self.arena.iter_value_slice(range.to_range()) {
+                                    if let LoroValue::Container(c) = value {
+                                        to_ensure.push(c);
+                                    }
+                                }
+                            }
+                            either::Either::Right(LoroValue::Container(c)) => {
+                                to_ensure.push(c.clone())
+                            }
+                            either::Either::Right(_) => {}
+                        }
+                    }
+                }
+            }
+            InternalDiff::Map(delta) => {
+                // Mergeable markers are deliberately not materialized here: the parent map's
+                // marker is the single source of truth for an ensured-but-empty mergeable
+                // child, and it resolves lazily via `does_container_exist`/`get_reachable`.
+                for value in delta.updated.values() {
+                    let Some(Some(value)) = value.as_ref().map(|v| v.value.as_ref()) else {
+                        continue;
+                    };
+                    if let LoroValue::Container(c) = value {
+                        to_ensure.push(c.clone());
+                    }
+                }
+            }
+            InternalDiff::Tree(delta) => {
+                for item in delta.diff.iter() {
+                    if matches!(item.action, crate::delta::TreeInternalDiff::Create { .. }) {
+                        to_ensure.push(item.target.associated_meta_container());
+                    }
+                }
+            }
+            InternalDiff::MovableList(delta) => {
+                for elem in delta.elements.values() {
+                    if let LoroValue::Container(c) = &elem.value {
+                        to_ensure.push(c.clone());
+                    }
+                }
+            }
+            InternalDiff::RichtextRaw(_) => {}
+            #[cfg(feature = "counter")]
+            InternalDiff::Counter(_) => {}
+            InternalDiff::Unknown => {}
+        }
+
+        for id in to_ensure {
+            self.ensure_container(&id);
+        }
+    }
+
     fn validate_diff_batch(&mut self, diffs: &[InternalContainerDiff]) -> LoroResult<()> {
         for diff in diffs {
             let crate::event::DiffVariant::Internal(internal_diff) = &diff.diff else {
@@ -865,6 +933,7 @@ impl DocState {
     pub fn apply_local_op(&mut self, raw_op: &RawOp, op: &Op) -> LoroResult<()> {
         // set parent first, `MapContainer` will only be created for TreeID that does not contain
         self.set_container_parent_by_raw_op(raw_op);
+        self.ensure_containers_created_by_op(op);
         let state = self.store.get_or_create_mut(op.container);
         if self.in_txn {
             self.changed_idx_in_txn.insert(op.container);
@@ -938,11 +1007,15 @@ impl DocState {
     }
 
     /// Ensure all alive containers are created in DocState and will be encoded in the next
-    /// `encode` call.
+    /// `encode` call, and return the alive set.
     ///
-    /// Returns arena indices rather than IDs so the full-snapshot export path does not have to
-    /// hold a second set of cloned container IDs; callers that need IDs map them through the
-    /// arena.
+    /// Only shallow snapshot export needs this now (its `retain_keys` filter requires the alive
+    /// set). Full snapshot export relies on the write-time invariant maintained by
+    /// `ensure_containers_created_by_op` / `ensure_containers_created_by_internal_diff` instead
+    /// of walking the graph.
+    ///
+    /// Returns arena indices rather than IDs so callers do not have to hold a second set of
+    /// cloned container IDs; callers that need IDs map them through the arena.
     pub(crate) fn ensure_all_alive_containers(
         &mut self,
     ) -> LoroResult<Arc<FxHashSet<ContainerIdx>>> {

--- a/crates/loro-internal/src/state/analyzer.rs
+++ b/crates/loro-internal/src/state/analyzer.rs
@@ -39,7 +39,9 @@ impl DocAnalysis {
 
         let mut containers = FxHashMap::default();
         let mut state = doc.app_state().lock();
-        let alive_containers = state.get_all_alive_containers();
+        let alive_containers = state
+            .get_all_alive_containers()
+            .expect("analyzing a valid document should resolve its container hierarchy");
         for (idx, c) in state.iter_all_containers_mut() {
             let ops_num = ops_nums.get(&idx).unwrap_or(&0);
             let id = doc.arena().get_container_id(idx).unwrap();

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -120,11 +120,7 @@ impl ContainerStore {
         &mut self,
         idx: ContainerIdx,
     ) -> LoroResult<Option<LoroValue>> {
-        self.store
-            .try_with_container_for_ephemeral_read(idx, |c| {
-                c.try_get_value_ephemeral(idx, ctx!(self))
-            })
-            .and_then(|value| value.transpose())
+        self.store.try_get_value_ephemeral(idx, ctx!(self))
     }
 
     pub(crate) fn try_get_parent_and_value_ephemeral(
@@ -573,12 +569,11 @@ mod test {
 
         let mut state = imported.app_state().lock();
         let map_idx = state.store.arena.register_container(&map_id);
-        assert!(state.alive_containers_cache.is_some());
         assert!(!state.store.store.has_cached_value_for_test(map_idx));
     }
 
     #[test]
-    fn snapshot_export_alive_cache_tracks_empty_root_without_version_change() {
+    fn snapshot_export_includes_empty_root_without_version_change() {
         let doc = LoroDoc::new_auto_commit();
         doc.get_map("first");
         doc.export(crate::encoding::ExportMode::Snapshot).unwrap();
@@ -596,7 +591,7 @@ mod test {
     }
 
     #[test]
-    fn snapshot_export_alive_cache_tracks_new_empty_child() {
+    fn snapshot_export_includes_new_empty_child() {
         let doc = LoroDoc::new_auto_commit();
         let root = doc.get_map("root");
         root.insert("value", 1).unwrap();
@@ -611,6 +606,94 @@ mod test {
         round_tripped.import(&snapshot).unwrap();
         let mut state = round_tripped.app_state().lock();
         assert!(state.store.contains_id(&child_id));
+    }
+
+    /// An empty child created by a remote peer has no ops of its own, so the importer only
+    /// applies the parent's diff. The diff-apply hook must still create a store entry for the
+    /// child, or the importer's own full snapshot would silently drop it.
+    #[test]
+    fn snapshot_export_includes_remote_empty_child() {
+        let a = LoroDoc::new_auto_commit();
+        let map_child_id = a
+            .get_map("map")
+            .insert_container("child", MapHandler::new_detached())
+            .unwrap()
+            .id();
+        let list_child_id = a
+            .get_list("list")
+            .insert_container(0, ListHandler::new_detached())
+            .unwrap()
+            .id();
+        let movable_child_id = a
+            .get_movable_list("movable")
+            .insert_container(0, MovableListHandler::new_detached())
+            .unwrap()
+            .id();
+        let updates = a
+            .export(crate::encoding::ExportMode::all_updates())
+            .unwrap();
+
+        let b = LoroDoc::new_auto_commit();
+        b.import(&updates).unwrap();
+        let snapshot = b.export(crate::encoding::ExportMode::Snapshot).unwrap();
+
+        let c = LoroDoc::new();
+        c.import(&snapshot).unwrap();
+        assert_eq!(a.get_deep_value(), c.get_deep_value());
+        let mut state = c.app_state().lock();
+        for id in [&map_child_id, &list_child_id, &movable_child_id] {
+            assert!(state.store.contains_id(id), "missing {id:?}");
+        }
+    }
+
+    /// A remote tree node's associated meta map has no ops until someone writes metadata; the
+    /// tree diff's `Create` action must ensure its store entry on the importer.
+    #[test]
+    fn snapshot_export_includes_remote_tree_meta() {
+        let a = LoroDoc::new_auto_commit();
+        let node = a.get_tree("tree").create(TreeParentId::Root).unwrap();
+        let meta_id = node.associated_meta_container();
+        let updates = a
+            .export(crate::encoding::ExportMode::all_updates())
+            .unwrap();
+
+        let b = LoroDoc::new_auto_commit();
+        b.import(&updates).unwrap();
+        let snapshot = b.export(crate::encoding::ExportMode::Snapshot).unwrap();
+
+        let c = LoroDoc::new();
+        c.import(&snapshot).unwrap();
+        let mut state = c.app_state().lock();
+        assert!(state.store.contains_id(&meta_id));
+    }
+
+    /// An ensured-but-empty mergeable child has no store entry anywhere — the parent map's
+    /// marker is its single source of truth. A full snapshot round-trip through an importer
+    /// must keep the child resolvable by id without materializing an entry for it.
+    #[test]
+    fn snapshot_export_keeps_empty_marker_child_resolvable_without_entry() {
+        let a = LoroDoc::new_auto_commit();
+        let child_id = a
+            .get_map("state")
+            .ensure_mergeable_text("notes")
+            .unwrap()
+            .id();
+        let updates = a
+            .export(crate::encoding::ExportMode::all_updates())
+            .unwrap();
+
+        let b = LoroDoc::new_auto_commit();
+        b.import(&updates).unwrap();
+        let snapshot = b.export(crate::encoding::ExportMode::Snapshot).unwrap();
+
+        let c = LoroDoc::new();
+        c.import(&snapshot).unwrap();
+        let mut state = c.app_state().lock();
+        assert!(!state.store.contains_id(&child_id));
+        assert!(
+            state.does_container_exist(&child_id),
+            "empty mergeable child must resolve from the marker after round-trip"
+        );
     }
 
     #[test]
@@ -653,8 +736,10 @@ mod test {
         let target = LoroDoc::new();
         target.import(&updates).unwrap();
         {
+            // The diff-apply hook creates the empty child's store entry at import time; full
+            // snapshot export relies on this invariant instead of walking the alive graph.
             let mut state = target.app_state().lock();
-            assert!(!state.store.contains_id(&child_id));
+            assert!(state.store.contains_id(&child_id));
         }
 
         let snapshot = target

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -127,6 +127,14 @@ impl ContainerStore {
             .and_then(|value| value.transpose())
     }
 
+    pub(crate) fn try_get_parent_and_value_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+    ) -> LoroResult<Option<(Option<ContainerID>, LoroValue)>> {
+        self.store
+            .try_get_parent_and_value_ephemeral(idx, ctx!(self))
+    }
+
     pub(crate) fn get_parent_ephemeral(
         &mut self,
         idx: ContainerIdx,
@@ -488,6 +496,24 @@ mod test {
     }
 
     #[test]
+    fn combined_ephemeral_parent_and_value_read_does_not_cache_value() {
+        let doc = init_doc();
+        let bytes = export_container_store(&doc);
+        let mut store = decode_container_store(bytes);
+        let map_id = ContainerID::new_root("map", ContainerType::Map);
+        let map_idx = store.arena.register_container(&map_id);
+
+        assert!(!store.store.has_cached_value_for_test(map_idx));
+        let (parent, value) = store
+            .try_get_parent_and_value_ephemeral(map_idx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parent, None);
+        assert_eq!(value.as_map().map(|map| map.len()), Some(2));
+        assert!(!store.store.has_cached_value_for_test(map_idx));
+    }
+
+    #[test]
     fn snapshot_export_does_not_materialize_map_value_after_key_read() {
         let source = init_doc();
         let snapshot = source
@@ -540,10 +566,51 @@ mod test {
             .export(crate::encoding::ExportMode::Snapshot)
             .unwrap();
         assert!(!exported.is_empty());
+        let exported_again = imported
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+        assert_eq!(exported_again, exported);
 
         let mut state = imported.app_state().lock();
         let map_idx = state.store.arena.register_container(&map_id);
+        assert!(state.alive_containers_cache.is_some());
         assert!(!state.store.store.has_cached_value_for_test(map_idx));
+    }
+
+    #[test]
+    fn snapshot_export_alive_cache_tracks_empty_root_without_version_change() {
+        let doc = LoroDoc::new_auto_commit();
+        doc.get_map("first");
+        doc.export(crate::encoding::ExportMode::Snapshot).unwrap();
+        let version_before = doc.state_frontiers();
+
+        let second_id = ContainerID::new_root("second", ContainerType::Map);
+        doc.get_map("second");
+        assert_eq!(doc.state_frontiers(), version_before);
+
+        let snapshot = doc.export(crate::encoding::ExportMode::Snapshot).unwrap();
+        let round_tripped = LoroDoc::new();
+        round_tripped.import(&snapshot).unwrap();
+        let mut state = round_tripped.app_state().lock();
+        assert!(state.store.contains_id(&second_id));
+    }
+
+    #[test]
+    fn snapshot_export_alive_cache_tracks_new_empty_child() {
+        let doc = LoroDoc::new_auto_commit();
+        let root = doc.get_map("root");
+        root.insert("value", 1).unwrap();
+        doc.export(crate::encoding::ExportMode::Snapshot).unwrap();
+
+        let child = root
+            .insert_container("child", MapHandler::new_detached())
+            .unwrap();
+        let child_id = child.id();
+        let snapshot = doc.export(crate::encoding::ExportMode::Snapshot).unwrap();
+        let round_tripped = LoroDoc::new();
+        round_tripped.import(&snapshot).unwrap();
+        let mut state = round_tripped.app_state().lock();
+        assert!(state.store.contains_id(&child_id));
     }
 
     #[test]

--- a/crates/loro-internal/src/state/container_store.rs
+++ b/crates/loro-internal/src/state/container_store.rs
@@ -111,6 +111,29 @@ impl ContainerStore {
             .with_container_for_read(idx, |c| c.get_value(idx, ctx!(self)))
     }
 
+    pub(crate) fn get_value_ephemeral(&mut self, idx: ContainerIdx) -> Option<LoroValue> {
+        self.try_get_value_ephemeral(idx)
+            .expect("snapshot-backed container should decode")
+    }
+
+    pub(crate) fn try_get_value_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+    ) -> LoroResult<Option<LoroValue>> {
+        self.store
+            .try_with_container_for_ephemeral_read(idx, |c| {
+                c.try_get_value_ephemeral(idx, ctx!(self))
+            })
+            .and_then(|value| value.transpose())
+    }
+
+    pub(crate) fn get_parent_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+    ) -> LoroResult<Option<Option<ContainerID>>> {
+        self.store.get_parent_ephemeral(idx)
+    }
+
     pub fn map_get(&mut self, idx: ContainerIdx, key: &str) -> Option<LoroValue> {
         self.store
             .with_container_for_read(idx, |c| c.map_get(idx, ctx!(self), key))?
@@ -264,11 +287,6 @@ impl ContainerStore {
         self.store.iter_all_container_ids()
     }
 
-    pub fn load_all(&mut self) -> LoadAllFlag {
-        self.store.load_all();
-        LoadAllFlag
-    }
-
     pub fn load_root_containers(&mut self) -> LoadAllFlag {
         self.store.load_roots();
         LoadAllFlag
@@ -373,8 +391,8 @@ impl ContainerStore {
 mod test {
     use super::*;
     use crate::{
-        cursor::PosType, state::TreeParentId, ContainerType, ListHandler, LoroDoc, MapHandler,
-        MovableListHandler,
+        cursor::PosType, handler::HandlerTrait, state::TreeParentId, ContainerType, ListHandler,
+        LoroDoc, MapHandler, MovableListHandler,
     };
 
     fn decode_container_store(bytes: Bytes) -> ContainerStore {
@@ -425,7 +443,7 @@ mod test {
 
     fn export_container_store(doc: &LoroDoc) -> Bytes {
         let mut state = doc.app_state().lock();
-        state.ensure_all_alive_containers();
+        state.ensure_all_alive_containers().unwrap();
         state.store.encode()
     }
 
@@ -449,5 +467,136 @@ mod test {
         assert!(!store.store.has_cached_value_for_test(map_idx));
         assert_eq!(store.map_len(map_idx), 2);
         assert!(store.store.has_cached_value_for_test(map_idx));
+    }
+
+    #[test]
+    fn ephemeral_lazy_read_does_not_cache_value() {
+        let doc = init_doc();
+        let bytes = export_container_store(&doc);
+        let mut store = decode_container_store(bytes);
+        let map_id = ContainerID::new_root("map", ContainerType::Map);
+        let map_idx = store.arena.register_container(&map_id);
+
+        assert!(!store.store.has_cached_value_for_test(map_idx));
+        assert_eq!(
+            store
+                .get_value_ephemeral(map_idx)
+                .and_then(|value| value.as_map().map(|map| map.len())),
+            Some(2)
+        );
+        assert!(!store.store.has_cached_value_for_test(map_idx));
+    }
+
+    #[test]
+    fn snapshot_export_does_not_materialize_map_value_after_key_read() {
+        let source = init_doc();
+        let snapshot = source
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+        let imported = LoroDoc::new();
+        imported.import(&snapshot).unwrap();
+        let map_id = ContainerID::new_root("map", ContainerType::Map);
+
+        assert_eq!(imported.get_map("map").get("key"), Some("value".into()));
+        {
+            let mut state = imported.app_state().lock();
+            let map_idx = state.store.arena.register_container(&map_id);
+            assert!(state.store.store.has_cached_value_for_test(map_idx));
+            assert!(!state
+                .store
+                .store
+                .has_materialized_map_value_for_test(map_idx));
+        }
+
+        imported
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+
+        let mut state = imported.app_state().lock();
+        let map_idx = state.store.arena.register_container(&map_id);
+        assert!(!state
+            .store
+            .store
+            .has_materialized_map_value_for_test(map_idx));
+    }
+
+    #[test]
+    fn snapshot_export_keeps_imported_state_lazy() {
+        let source = init_doc();
+        let snapshot = source
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+        let imported = LoroDoc::new();
+        imported.import(&snapshot).unwrap();
+        let map_id = ContainerID::new_root("map", ContainerType::Map);
+
+        {
+            let mut state = imported.app_state().lock();
+            let map_idx = state.store.arena.register_container(&map_id);
+            assert!(!state.store.store.has_cached_value_for_test(map_idx));
+        }
+
+        let exported = imported
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+        assert!(!exported.is_empty());
+
+        let mut state = imported.app_state().lock();
+        let map_idx = state.store.arena.register_container(&map_id);
+        assert!(!state.store.store.has_cached_value_for_test(map_idx));
+    }
+
+    #[test]
+    fn deep_value_read_keeps_imported_state_lazy() {
+        let source = init_doc();
+        let expected = source.get_deep_value();
+        let child_map_id = source
+            .get_map("map")
+            .get("child_map")
+            .and_then(|value| value.as_container().cloned())
+            .unwrap();
+        let snapshot = source
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+        let imported = LoroDoc::new();
+        imported.import(&snapshot).unwrap();
+        let map_id = ContainerID::new_root("map", ContainerType::Map);
+
+        assert_eq!(imported.get_deep_value(), expected);
+        assert_eq!(imported.get_deep_value(), expected);
+
+        let mut state = imported.app_state().lock();
+        let map_idx = state.store.arena.register_container(&map_id);
+        let child_map_idx = state.store.arena.register_container(&child_map_id);
+        assert!(!state.store.store.has_cached_value_for_test(map_idx));
+        assert!(!state.store.store.has_cached_value_for_test(child_map_idx));
+    }
+
+    #[test]
+    fn snapshot_export_persists_empty_alive_child() {
+        let source = LoroDoc::new_auto_commit();
+        let child = source
+            .get_map("root")
+            .insert_container("empty", MapHandler::new_detached())
+            .unwrap();
+        let child_id = child.id();
+        let updates = source
+            .export(crate::encoding::ExportMode::all_updates())
+            .unwrap();
+        let target = LoroDoc::new();
+        target.import(&updates).unwrap();
+        {
+            let mut state = target.app_state().lock();
+            assert!(!state.store.contains_id(&child_id));
+        }
+
+        let snapshot = target
+            .export(crate::encoding::ExportMode::Snapshot)
+            .unwrap();
+        let round_tripped = LoroDoc::new();
+        round_tripped.import(&snapshot).unwrap();
+
+        let mut state = round_tripped.app_state().lock();
+        assert!(state.store.contains_id(&child_id));
     }
 }

--- a/crates/loro-internal/src/state/container_store/container_wrapper.rs
+++ b/crates/loro-internal/src/state/container_store/container_wrapper.rs
@@ -83,6 +83,20 @@ impl LazyDecodedValue {
         }
     }
 
+    fn to_loro_value_ephemeral(&self) -> LoroValue {
+        match self {
+            Self::Value(value) | Self::Text { value, .. } => value.clone(),
+            Self::Map { ordered, value } => value.get().cloned().unwrap_or_else(|| {
+                LoroValue::Map(
+                    ordered
+                        .iter()
+                        .map(|(key, value)| (key.clone(), value.clone()))
+                        .collect::<loro_common::LoroMapValue>(),
+                )
+            }),
+        }
+    }
+
     fn as_map(&self) -> Option<&BTreeMap<String, LoroValue>> {
         match self {
             Self::Map { ordered, .. } => Some(ordered),
@@ -197,6 +211,30 @@ impl ContainerWrapper {
 
     pub fn get_value(&mut self, idx: ContainerIdx, ctx: ContainerCreationContext) -> LoroValue {
         self.try_get_value(idx, ctx).unwrap()
+    }
+
+    /// Read the current value without populating the lazy-value cache.
+    ///
+    /// Snapshot export uses this while walking reachable containers. Keeping the decoded value
+    /// on every lazy wrapper would turn that walk into full state materialization.
+    pub(crate) fn try_get_value_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+        ctx: ContainerCreationContext,
+    ) -> LoroResult<LoroValue> {
+        match &mut self.data {
+            ContainerData::State(state) => Ok(state.get_value()),
+            ContainerData::Lazy(lazy) if lazy.value.is_some() => {
+                Ok(lazy.value.as_ref().unwrap().to_loro_value_ephemeral())
+            }
+            ContainerData::Lazy(lazy) => {
+                let Some(bytes) = lazy.bytes.clone() else {
+                    return Ok(self.kind.default_value());
+                };
+                let mut temporary = Self::try_new_from_bytes(bytes)?;
+                temporary.try_get_value(idx, ctx)
+            }
+        }
     }
 
     pub fn map_get(
@@ -522,6 +560,17 @@ impl ContainerWrapper {
     #[cfg(test)]
     pub(super) fn has_cached_value_for_test(&self) -> bool {
         self.has_cached_value()
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_materialized_map_value_for_test(&self) -> bool {
+        let ContainerData::Lazy(lazy) = &self.data else {
+            return false;
+        };
+        matches!(
+            lazy.value.as_ref(),
+            Some(LazyDecodedValue::Map { value, .. }) if value.get().is_some()
+        )
     }
 
     fn value_bytes_and_offset(&mut self) -> Option<(Bytes, usize)> {

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -3,7 +3,7 @@ use crate::{
     state::container_store::FRONTIERS_KEY, utils::kv_wrapper::KvWrapper, version::Frontiers,
 };
 use bytes::Bytes;
-use loro_common::ContainerID;
+use loro_common::{ContainerID, LoroResult};
 
 use super::ContainerWrapper;
 
@@ -163,6 +163,40 @@ impl InnerStore {
         }
 
         None
+    }
+
+    /// Read a container without retaining a wrapper loaded only for this read.
+    pub(crate) fn try_with_container_for_ephemeral_read<R>(
+        &mut self,
+        idx: ContainerIdx,
+        f: impl FnOnce(&mut ContainerWrapper) -> R,
+    ) -> LoroResult<Option<R>> {
+        if let Some(entry) = self.get_entry_mut(idx) {
+            return Ok(Some(f(entry)));
+        }
+
+        if self.load_state != LoadState::AllLoaded {
+            let id = self.arena.get_container_id(idx).unwrap();
+            let key = id.to_bytes();
+            if let Some(v) = self.kv.get(&key) {
+                let mut container = ContainerWrapper::try_new_from_bytes(v)?;
+                return Ok(Some(f(&mut container)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Read the parent encoded in a container wrapper without retaining a wrapper loaded only
+    /// for this probe.
+    ///
+    /// The outer `Option` distinguishes a missing wrapper from a wrapper whose encoded parent is
+    /// `None`.
+    pub(crate) fn get_parent_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+    ) -> LoroResult<Option<Option<ContainerID>>> {
+        self.try_with_container_for_ephemeral_read(idx, |container| container.parent().cloned())
     }
 
     pub(crate) fn has_decoded_state(&mut self, idx: ContainerIdx) -> bool {
@@ -375,6 +409,12 @@ impl InnerStore {
     pub(super) fn has_cached_value_for_test(&mut self, idx: ContainerIdx) -> bool {
         self.get_entry_mut(idx)
             .is_some_and(|entry| entry.has_cached_value_for_test())
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_materialized_map_value_for_test(&mut self, idx: ContainerIdx) -> bool {
+        self.get_entry_mut(idx)
+            .is_some_and(|entry| entry.has_materialized_map_value_for_test())
     }
 }
 

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -1,9 +1,13 @@
 use crate::{
-    arena::SharedArena, configure::Configure, container::idx::ContainerIdx,
-    state::container_store::FRONTIERS_KEY, utils::kv_wrapper::KvWrapper, version::Frontiers,
+    arena::SharedArena,
+    configure::Configure,
+    container::idx::ContainerIdx,
+    state::{container_store::FRONTIERS_KEY, ContainerCreationContext},
+    utils::kv_wrapper::KvWrapper,
+    version::Frontiers,
 };
 use bytes::Bytes;
-use loro_common::{ContainerID, LoroResult};
+use loro_common::{ContainerID, LoroResult, LoroValue};
 
 use super::ContainerWrapper;
 
@@ -181,6 +185,39 @@ impl InnerStore {
             if let Some(v) = self.kv.get(&key) {
                 let mut container = ContainerWrapper::try_new_from_bytes(v)?;
                 return Ok(Some(f(&mut container)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Read a container's encoded parent and current value together without retaining a wrapper
+    /// loaded only for this read.
+    ///
+    /// The alive-container walk needs both fields. Reading them through two independent probes can
+    /// evict the first SSTable block before the value is requested, and it constructs the same lazy
+    /// wrapper twice. Decode an uncached wrapper in place here and drop it after returning the value.
+    pub(crate) fn try_get_parent_and_value_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+        ctx: ContainerCreationContext<'_>,
+    ) -> LoroResult<Option<(Option<ContainerID>, LoroValue)>> {
+        if let Some(entry) = self.get_entry_mut(idx) {
+            let parent = entry.parent().cloned();
+            let value = entry.try_get_value_ephemeral(idx, ctx)?;
+            return Ok(Some((parent, value)));
+        }
+
+        if self.load_state != LoadState::AllLoaded {
+            let id = self.arena.get_container_id(idx).unwrap();
+            let key = id.to_bytes();
+            if let Some(value) = self.kv.get(&key) {
+                let mut container = ContainerWrapper::try_new_from_bytes(value)?;
+                let parent = container.parent().cloned();
+                // This wrapper is already temporary, so decoding into it does not retain state in
+                // the document and avoids constructing another temporary wrapper internally.
+                let value = container.try_get_value(idx, ctx)?;
+                return Ok(Some((parent, value)));
             }
         }
 

--- a/crates/loro-internal/src/state/container_store/inner_store.rs
+++ b/crates/loro-internal/src/state/container_store/inner_store.rs
@@ -191,6 +191,32 @@ impl InnerStore {
         Ok(None)
     }
 
+    /// Read a container's current value without retaining a wrapper loaded only for this read.
+    ///
+    /// Mirrors [`Self::try_get_parent_and_value_ephemeral`]: routing the kv branch through
+    /// `ContainerWrapper::try_get_value_ephemeral` would clone the bytes into a second temporary
+    /// wrapper, so decode the already-temporary wrapper in place instead.
+    pub(crate) fn try_get_value_ephemeral(
+        &mut self,
+        idx: ContainerIdx,
+        ctx: ContainerCreationContext<'_>,
+    ) -> LoroResult<Option<LoroValue>> {
+        if let Some(entry) = self.get_entry_mut(idx) {
+            return entry.try_get_value_ephemeral(idx, ctx).map(Some);
+        }
+
+        if self.load_state != LoadState::AllLoaded {
+            let id = self.arena.get_container_id(idx).unwrap();
+            let key = id.to_bytes();
+            if let Some(bytes) = self.kv.get(&key) {
+                let mut container = ContainerWrapper::try_new_from_bytes(bytes)?;
+                return container.try_get_value(idx, ctx).map(Some);
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Read a container's encoded parent and current value together without retaining a wrapper
     /// loaded only for this read.
     ///

--- a/crates/loro-internal/src/state/map_state.rs
+++ b/crates/loro-internal/src/state/map_state.rs
@@ -29,9 +29,7 @@ fn translate_with_parent(
     value: LoroValue,
 ) -> LoroValue {
     match parent_id {
-        Some(parent) => {
-            loro_common::translate_mergeable_marker_value(parent, key.as_ref(), value)
-        }
+        Some(parent) => loro_common::translate_mergeable_marker_value(parent, key.as_ref(), value),
         None => value,
     }
 }

--- a/crates/loro-internal/src/state/richtext_state.rs
+++ b/crates/loro-internal/src/state/richtext_state.rs
@@ -12,9 +12,7 @@ use crate::{
         list::list_op,
         richtext::{
             config::StyleConfigMap,
-            richtext_state::{
-                DrainInfo, EntityRanges, IterRangeItem, PosType, RichtextStateChunk,
-            },
+            richtext_state::{DrainInfo, EntityRanges, IterRangeItem, PosType, RichtextStateChunk},
             AnchorType, RichtextState as InnerState, StyleKey, StyleOp, Styles,
         },
     },

--- a/crates/loro-internal/src/tests/import_atomicity.rs
+++ b/crates/loro-internal/src/tests/import_atomicity.rs
@@ -30,6 +30,40 @@ fn corrupt_snapshot_state_bytes(snapshot: &mut [u8]) {
     let state_start = state_len_pos + 4;
     snapshot[state_start] ^= 0xff;
 
+    refresh_snapshot_checksum(snapshot);
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SnapshotKvSection {
+    OpLog,
+    State,
+}
+
+fn corrupt_snapshot_sstable_block(snapshot: &mut [u8], section: SnapshotKvSection) {
+    let body_start = 22;
+    let oplog_len =
+        u32::from_le_bytes(snapshot[body_start..body_start + 4].try_into().unwrap()) as usize;
+    let oplog_start = body_start + 4;
+    let state_len_pos = oplog_start + oplog_len;
+    let state_len = u32::from_le_bytes(
+        snapshot[state_len_pos..state_len_pos + 4]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let state_start = state_len_pos + 4;
+    let (section_start, section_len) = match section {
+        SnapshotKvSection::OpLog => (oplog_start, oplog_len),
+        SnapshotKvSection::State => (state_start, state_len),
+    };
+
+    // SSTable layout starts with four magic bytes and one schema byte. Corrupt the first block
+    // payload while leaving its embedded checksum stale, then refresh only the outer envelope.
+    assert!(section_len > 9);
+    snapshot[section_start + 5] ^= 0xff;
+    refresh_snapshot_checksum(snapshot);
+}
+
+fn refresh_snapshot_checksum(snapshot: &mut [u8]) {
     let checksum = xxhash_rust::xxh32::xxh32(&snapshot[20..], u32::from_le_bytes(*b"LORO"));
     snapshot[16..20].copy_from_slice(&checksum.to_le_bytes());
 }
@@ -301,4 +335,31 @@ fn corrupt_snapshot_import_rolls_back_empty_doc() {
 
     dst.import(&snapshot).unwrap();
     assert_eq!(dst.get_deep_value(), src.get_deep_value());
+}
+
+#[test]
+fn snapshot_import_rejects_corrupt_inner_sstable_with_valid_envelope_checksum() {
+    let src = LoroDoc::new_auto_commit();
+    src.set_peer_id(9).unwrap();
+    src.get_map("map").insert("key", "value").unwrap();
+    let snapshot = src.export(ExportMode::Snapshot).unwrap();
+
+    for section in [SnapshotKvSection::OpLog, SnapshotKvSection::State] {
+        let mut corrupted = snapshot.clone();
+        corrupt_snapshot_sstable_block(&mut corrupted, section);
+
+        let dst = LoroDoc::new();
+        let err = dst
+            .import(&corrupted)
+            .expect_err("invalid inner SSTable checksum must fail during import");
+        assert!(
+            err.to_string().contains("checksum") || err.to_string().contains("Checksum"),
+            "unexpected {section:?} import error: {err:?}"
+        );
+        assert!(dst.oplog().lock().is_empty());
+        assert!(dst
+            .get_deep_value()
+            .as_map()
+            .is_some_and(|value| value.is_empty()));
+    }
 }

--- a/crates/loro-internal/src/txn.rs
+++ b/crates/loro-internal/src/txn.rs
@@ -569,7 +569,12 @@ impl Transaction {
             let expected = self
                 .doc
                 .upgrade()
-                .map(|d| d.state.lock().peer.load(std::sync::atomic::Ordering::Relaxed))
+                .map(|d| {
+                    d.state
+                        .lock()
+                        .peer
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                })
                 .unwrap_or(found);
             return Err(LoroError::UnmatchedContext { expected, found });
         }

--- a/crates/loro-internal/src/utils/kv_wrapper.rs
+++ b/crates/loro-internal/src/utils/kv_wrapper.rs
@@ -39,11 +39,10 @@ impl KvWrapper {
 
     pub fn import(&self, bytes: Bytes) -> Result<(), String> {
         let mut kv = self.kv.lock();
-        // Only reached while decoding a snapshot/state blob whose integrity is
-        // already guaranteed by the document-level checksum in
-        // `parse_header_and_body(.., true)`, so skip the redundant per-block
-        // checksum.
-        kv.import_all_unchecked(bytes)
+        // Snapshot bytes are external input. The document-level checksum does not replace
+        // validation of the checksums embedded in each SSTable block: a producer can emit a
+        // self-consistent outer envelope containing an invalid inner table.
+        kv.import_all(bytes)
     }
 
     pub fn export(&self) -> Bytes {

--- a/crates/loro-internal/tests/mergeable_container/convergence.rs
+++ b/crates/loro-internal/tests/mergeable_container/convergence.rs
@@ -279,10 +279,7 @@ fn detached_map_ensure_mergeable_counter_rejects_misuse() {
         .ensure_mergeable_counter("revision")
         .expect_err("detached ensure_mergeable_* must error");
     assert!(
-        matches!(
-            err,
-            loro_common::LoroError::MisuseDetachedContainer { .. }
-        ),
+        matches!(err, loro_common::LoroError::MisuseDetachedContainer { .. }),
         "detached error must be MisuseDetachedContainer; got {err:?}"
     );
 }

--- a/crates/loro-internal/tests/mergeable_container/delete.rs
+++ b/crates/loro-internal/tests/mergeable_container/delete.rs
@@ -261,7 +261,10 @@ fn three_peer_delete_then_recreate_converges() {
     sync(&a, &c);
 
     // C recreates "revision" as a text with a post-delete IdLp.
-    let c_text = c.get_map("state").ensure_mergeable_text("revision").unwrap();
+    let c_text = c
+        .get_map("state")
+        .ensure_mergeable_text("revision")
+        .unwrap();
     c_text.insert(0, "after-delete", PosType::Unicode).unwrap();
     c.commit_then_renew();
 

--- a/crates/loro-internal/tests/mergeable_container/snapshot.rs
+++ b/crates/loro-internal/tests/mergeable_container/snapshot.rs
@@ -291,9 +291,7 @@ fn shallow_snapshot_preserves_losing_kind_state() {
     // The Map marker now wins LWW on A and is the visible kind; the Text child becomes the loser
     // whose state lives only at its deterministic cid.
     for i in 0..6 {
-        a.get_map("state")
-            .insert(&format!("noise_{i}"), i)
-            .unwrap();
+        a.get_map("state").insert(&format!("noise_{i}"), i).unwrap();
         a.commit_then_renew();
     }
     let a_map = a.get_map("state").ensure_mergeable_map("k").unwrap();

--- a/crates/loro-wasm/package.json
+++ b/crates/loro-wasm/package.json
@@ -77,7 +77,8 @@
   "scripts": {
     "build-dev": "deno run -A ./scripts/build.ts dev && rollup -c && deno run -A ./scripts/post-rollup.ts && npm run test",
     "build-release": "deno run -A ./scripts/build.ts release && rollup -c && deno run -A ./scripts/post-rollup.ts && npm run test",
-    "test": "node --expose-gc ./node_modules/vitest/vitest.mjs run && npx tsc --noEmit && cd ./deno_tests && deno test -A && cd ../bun_tests && bun test"
+    "test": "node --expose-gc ./node_modules/vitest/vitest.mjs run && npx tsc --noEmit && cd ./deno_tests && deno test -A && cd ../bun_tests && bun test",
+    "test:snapshot-memory": "node --expose-gc ./scripts/measure-snapshot-round-memory.cjs"
   },
   "homepage": "https://loro.dev",
   "author": "",

--- a/crates/loro-wasm/scripts/measure-snapshot-round-memory.cjs
+++ b/crates/loro-wasm/scripts/measure-snapshot-round-memory.cjs
@@ -1,0 +1,401 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { isDeepStrictEqual } = require("node:util");
+
+const MiB = 1024 * 1024;
+const packageDir = path.resolve(__dirname, "../nodejs");
+const defaultLocalUpdateRounds = 32;
+const defaultLocalPayloadBytes = 4 * 1024;
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function loadLoro() {
+  const packageEntry = path.join(packageDir, "index.js");
+  if (!fs.existsSync(packageEntry)) {
+    die(
+      "nodejs package is missing; run `pnpm -C crates/loro-wasm build-release` first",
+    );
+  }
+  return {
+    loro: require(packageEntry),
+    lowLevel: require(path.join(packageDir, "loro_wasm.js")),
+  };
+}
+
+function retainedBinaryBytes(root) {
+  const seenObjects = new WeakSet();
+  const seenBuffers = new Set();
+  let bytes = 0;
+
+  function countBuffer(buffer) {
+    if (!seenBuffers.has(buffer)) {
+      seenBuffers.add(buffer);
+      bytes += buffer.byteLength;
+    }
+  }
+
+  function visit(value) {
+    if (value === null || typeof value !== "object") return;
+    if (ArrayBuffer.isView(value)) {
+      countBuffer(value.buffer);
+      return;
+    }
+    if (
+      value instanceof ArrayBuffer ||
+      (typeof SharedArrayBuffer !== "undefined" &&
+        value instanceof SharedArrayBuffer)
+    ) {
+      countBuffer(value);
+      return;
+    }
+    if (seenObjects.has(value)) return;
+    seenObjects.add(value);
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    for (const item of Object.values(value)) visit(item);
+  }
+
+  visit(root);
+  return bytes;
+}
+
+function sampleMemory(lowLevel) {
+  const usage = process.memoryUsage();
+  return {
+    wasmMiB: lowLevel.__wasm.memory.buffer.byteLength / MiB,
+    rssMiB: usage.rss / MiB,
+    maxRssMiB: process.resourceUsage().maxRSS / 1024,
+    heapUsedMiB: usage.heapUsed / MiB,
+    externalMiB: usage.external / MiB,
+    arrayBuffersMiB: usage.arrayBuffers / MiB,
+  };
+}
+
+function recordPhase(phases, name, lowLevel) {
+  phases[name] = sampleMemory(lowLevel);
+}
+
+function makeLocalPayload(size, round) {
+  const chars = new Array(size);
+  let state = (round + 1) * 0x9e3779b1;
+  for (let i = 0; i < size; i += 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    chars[i] = String.fromCharCode(32 + ((state >>> 0) % 95));
+  }
+  return chars.join("");
+}
+
+function applyLocalUpdates(doc, scenario, rounds, payloadBytes) {
+  if (rounds === 0) {
+    return {
+      commitCount: 0,
+      mutationCount: 0,
+      insertedTextBytes: 0,
+    };
+  }
+
+  const rootName = `__snapshot_memory_bench_${scenario}`;
+  const text = doc.getText(`${rootName}_text`);
+  const map = doc.getMap(`${rootName}_map`);
+
+  for (let round = 0; round < rounds; round += 1) {
+    const payload = makeLocalPayload(payloadBytes, round);
+    text.insert(text.length, payload);
+    map.set(`round-${round}`, {
+      round,
+      payloadBytes,
+      marker: payload.slice(0, 16),
+    });
+    doc.commit();
+  }
+
+  return {
+    commitCount: rounds,
+    mutationCount: rounds * 2,
+    insertedTextBytes: rounds * payloadBytes,
+  };
+}
+
+function runWorker() {
+  const snapshotPath = process.argv[3];
+  const scenario = process.argv[4];
+  const update = Buffer.from(process.argv[5], "base64");
+  const budgetMiB = Number(process.argv[6]);
+  const localUpdateRounds = Number(process.argv[7]);
+  const localPayloadBytes = Number(process.argv[8]);
+  const localPeerId = Number(process.argv[9]);
+  const { loro, lowLevel } = loadLoro();
+  const snapshot = fs.readFileSync(snapshotPath);
+  const doc = new loro.LoroDoc();
+  global.gc?.();
+  const baselineHeapBytes = process.memoryUsage().heapUsed;
+  const phases = {};
+  recordPhase(phases, "module", lowLevel);
+
+  doc.import(snapshot);
+  recordPhase(phases, "afterSnapshotImport", lowLevel);
+  const retainedJson = doc.toJSON();
+  recordPhase(phases, "afterToJson", lowLevel);
+  doc.import(update);
+  recordPhase(phases, "afterRemoteUpdateImport", lowLevel);
+
+  const localUpdateStartVersion = doc.oplogVersion();
+  doc.setPeerId(localPeerId);
+  recordPhase(phases, "afterLocalVersionCapture", lowLevel);
+  const localWorkload = applyLocalUpdates(
+    doc,
+    scenario,
+    localUpdateRounds,
+    localPayloadBytes,
+  );
+  recordPhase(phases, "afterLocalUpdates", lowLevel);
+
+  const exportedLocalUpdate = doc.export({
+    mode: "update",
+    from: localUpdateStartVersion,
+  });
+  recordPhase(phases, "afterLocalUpdateExport", lowLevel);
+  localUpdateStartVersion.free();
+
+  const exportedSnapshot = doc.export({ mode: "snapshot" });
+  recordPhase(phases, "afterSnapshotExport", lowLevel);
+
+  // This is the memory directly attributable to the JS/WASM round: input buffers, the Wasm
+  // linear-memory high-water mark, both returned export buffers, and the retained JS heap growth
+  // from toJSON. RSS is reported separately because it also includes V8 and code pages.
+  const wasmBytes = lowLevel.__wasm.memory.buffer.byteLength;
+  const exportedLocalUpdateBytes = exportedLocalUpdate.byteLength;
+  const exportedSnapshotBytes = exportedSnapshot.byteLength;
+  global.gc?.();
+  const usageAfterExport = process.memoryUsage();
+  const processMaxRssMiB = process.resourceUsage().maxRSS / 1024;
+  const retainedHeapBytes = Math.max(
+    usageAfterExport.heapUsed - baselineHeapBytes,
+    0,
+  );
+  const retainedJsonExternalBytes = retainedBinaryBytes(retainedJson);
+  const controlledBytes =
+    snapshot.byteLength +
+    update.byteLength +
+    wasmBytes +
+    exportedLocalUpdateBytes +
+    exportedSnapshotBytes +
+    retainedHeapBytes +
+    retainedJsonExternalBytes;
+  const retainedJsonRootCount = Object.keys(retainedJson).length;
+
+  const expectedVersion = doc.version();
+  const expectedVersionBytes = Buffer.from(expectedVersion.encode());
+  const expectedJson = doc.toJSON();
+  const updateRoundTripped = new loro.LoroDoc();
+  updateRoundTripped.import(snapshot);
+  updateRoundTripped.import(update);
+  updateRoundTripped.import(exportedLocalUpdate);
+  const updateRoundTripVersion = updateRoundTripped.version();
+  const updateRoundTripVersionMatches =
+    expectedVersion.compare(updateRoundTripVersion) === 0;
+  const updateRoundTripVersionEncodingMatches = Buffer.from(
+    updateRoundTripVersion.encode(),
+  ).equals(expectedVersionBytes);
+  const updateRoundTripJsonMatches = isDeepStrictEqual(
+    updateRoundTripped.toJSON(),
+    expectedJson,
+  );
+  const snapshotRoundTripped = new loro.LoroDoc();
+  snapshotRoundTripped.import(exportedSnapshot);
+  const snapshotRoundTripVersion = snapshotRoundTripped.version();
+  const snapshotRoundTripVersionMatches =
+    expectedVersion.compare(snapshotRoundTripVersion) === 0;
+  const snapshotRoundTripVersionEncodingMatches = Buffer.from(
+    snapshotRoundTripVersion.encode(),
+  ).equals(expectedVersionBytes);
+  const snapshotRoundTripJsonMatches = isDeepStrictEqual(
+    snapshotRoundTripped.toJSON(),
+    expectedJson,
+  );
+  expectedVersion.free();
+  updateRoundTripVersion.free();
+  snapshotRoundTripVersion.free();
+  const underBudget = controlledBytes < budgetMiB * MiB;
+  const phaseValues = Object.values(phases);
+  const localUpdatesWasmGrowthMiB =
+    phases.afterLocalUpdates.wasmMiB - phases.afterRemoteUpdateImport.wasmMiB;
+  const localUpdateExportWasmGrowthMiB =
+    phases.afterLocalUpdateExport.wasmMiB - phases.afterLocalUpdates.wasmMiB;
+  const snapshotExportWasmGrowthMiB =
+    phases.afterSnapshotExport.wasmMiB - phases.afterLocalUpdateExport.wasmMiB;
+
+  const result = {
+    scenario,
+    inputSnapshotBytes: snapshot.byteLength,
+    remoteUpdateBytes: update.byteLength,
+    localWorkload,
+    exportedLocalUpdateBytes,
+    exportedSnapshotBytes,
+    wasmMiB: wasmBytes / MiB,
+    wasmPeakMiB: Math.max(...phaseValues.map((phase) => phase.wasmMiB)),
+    localUpdatesWasmGrowthMiB,
+    localUpdateExportWasmGrowthMiB,
+    snapshotExportWasmGrowthMiB,
+    exportedLocalUpdateMiB: exportedLocalUpdateBytes / MiB,
+    exportedSnapshotMiB: exportedSnapshotBytes / MiB,
+    retainedHeapMiB: retainedHeapBytes / MiB,
+    retainedJsonExternalMiB: retainedJsonExternalBytes / MiB,
+    retainedJsonRootCount,
+    controlledMiB: controlledBytes / MiB,
+    rssMiB: usageAfterExport.rss / MiB,
+    sampledRssPeakMiB: Math.max(...phaseValues.map((phase) => phase.rssMiB)),
+    processMaxRssMiB,
+    externalMiB: usageAfterExport.external / MiB,
+    budgetMiB,
+    underBudget,
+    updateRoundTripVersionMatches,
+    updateRoundTripVersionEncodingMatches,
+    updateRoundTripJsonMatches,
+    snapshotRoundTripVersionMatches,
+    snapshotRoundTripVersionEncodingMatches,
+    snapshotRoundTripJsonMatches,
+    phases,
+  };
+  console.log(JSON.stringify(result));
+  if (
+    !underBudget ||
+    !updateRoundTripVersionMatches ||
+    !updateRoundTripJsonMatches ||
+    !snapshotRoundTripVersionMatches ||
+    !snapshotRoundTripJsonMatches
+  ) {
+    process.exitCode = 1;
+  }
+}
+
+function makeUpdates(snapshotPath) {
+  const { loro } = loadLoro();
+  const snapshot = fs.readFileSync(snapshotPath);
+  const suffix = `${process.pid}-${Date.now()}`;
+  const peerBase = Number.MAX_SAFE_INTEGER - (Date.now() % 1_000_000);
+
+  const causal = new loro.LoroDoc();
+  causal.import(snapshot);
+  const baseVersion = causal.version();
+  causal.setPeerId(peerBase);
+  causal.getMap(`__memory_probe_causal_${suffix}`).set("value", "causal");
+
+  const independent = new loro.LoroDoc();
+  independent.setPeerId(peerBase - 1);
+  independent
+    .getMap(`__memory_probe_independent_${suffix}`)
+    .set("value", "independent");
+
+  return [
+    {
+      scenario: "to-json-then-causal-update",
+      update: causal.export({ mode: "update", from: baseVersion }),
+    },
+    {
+      scenario: "to-json-then-independent-update",
+      update: independent.export({ mode: "update" }),
+    },
+  ];
+}
+
+function runCoordinator() {
+  const firstArg = process.argv[2] === "--" ? 3 : 2;
+  const snapshotPath = process.argv[firstArg];
+  const budgetMiB = Number(process.argv[firstArg + 1] ?? 100);
+  const localUpdateRounds = Number(
+    process.argv[firstArg + 2] ?? defaultLocalUpdateRounds,
+  );
+  const localPayloadBytes = Number(
+    process.argv[firstArg + 3] ?? defaultLocalPayloadBytes,
+  );
+  if (!snapshotPath) {
+    die(
+      "usage: node --expose-gc scripts/measure-snapshot-round-memory.cjs SNAPSHOT [BUDGET_MIB] [LOCAL_UPDATE_ROUNDS] [LOCAL_PAYLOAD_BYTES]",
+    );
+  }
+  if (!fs.statSync(snapshotPath).isFile()) {
+    die(`snapshot is not a file: ${snapshotPath}`);
+  }
+  if (!Number.isFinite(budgetMiB) || budgetMiB <= 0) {
+    die(`invalid budget: ${process.argv[firstArg + 1]}`);
+  }
+  if (!Number.isSafeInteger(localUpdateRounds) || localUpdateRounds < 0) {
+    die(`invalid local update rounds: ${process.argv[firstArg + 2]}`);
+  }
+  if (!Number.isSafeInteger(localPayloadBytes) || localPayloadBytes <= 0) {
+    die(`invalid local payload bytes: ${process.argv[firstArg + 3]}`);
+  }
+
+  const results = [];
+  let failed = false;
+  let scenarioIndex = 0;
+  for (const { scenario, update } of makeUpdates(snapshotPath)) {
+    const localPeerId = Number.MAX_SAFE_INTEGER - 100_000 - scenarioIndex;
+    scenarioIndex += 1;
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--expose-gc",
+        __filename,
+        "--worker",
+        snapshotPath,
+        scenario,
+        Buffer.from(update).toString("base64"),
+        String(budgetMiB),
+        String(localUpdateRounds),
+        String(localPayloadBytes),
+        String(localPeerId),
+      ],
+      { encoding: "utf8", maxBuffer: 4 * MiB },
+    );
+    if (child.error) {
+      throw child.error;
+    }
+    if (child.stderr) {
+      process.stderr.write(child.stderr);
+    }
+    try {
+      results.push(JSON.parse(child.stdout));
+    } catch (error) {
+      process.stdout.write(child.stdout);
+      throw error;
+    }
+    failed ||= child.status !== 0;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        metric:
+          "input snapshot/remote update buffers + Wasm linear-memory high-water + returned local-update and snapshot Uint8Arrays + retained toJSON heap delta/backing stores",
+        budgetMiB,
+        localUpdateRounds,
+        localPayloadBytes,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[2] === "--worker") {
+  runWorker();
+} else {
+  runCoordinator();
+}

--- a/crates/loro/tests/mergeable_public_api.rs
+++ b/crates/loro/tests/mergeable_public_api.rs
@@ -215,8 +215,14 @@ fn loro_map_ensure_mergeable_tree_through_public_api() {
     let a = doc(1);
     let b = doc(2);
 
-    let a_tree = a.get_map("state").ensure_mergeable_tree("hierarchy").unwrap();
-    let b_tree = b.get_map("state").ensure_mergeable_tree("hierarchy").unwrap();
+    let a_tree = a
+        .get_map("state")
+        .ensure_mergeable_tree("hierarchy")
+        .unwrap();
+    let b_tree = b
+        .get_map("state")
+        .ensure_mergeable_tree("hierarchy")
+        .unwrap();
     assert_eq!(
         a_tree.id(),
         b_tree.id(),


### PR DESCRIPTION
## Summary

Reduces peak memory across the large-document round

`snapshot import → toJSON → remote update import → local updates → local update export → full snapshot export`

while preserving lazy state and making cold full-snapshot export substantially cheaper.

## What changed

- **Bounded SSTable block cache.** The old `1 << 20` entry limit could retain nearly every decompressed block touched by a large document. The cache is now byte-weighted and capped at 4 MiB of decompressed data per table.
- **Full snapshot export skips the alive-container walk.** Referenced containers are ensured when their creating op or imported internal diff is applied. A full export can therefore flush and export the KV state directly instead of decoding every lazy container and rebuilding the same state.
  - Shallow snapshot export still walks the reachable graph and validates parent metadata.
  - Full export preserves imported lazy state bytes faithfully.
  - Empty mergeable children represented by parent-map markers remain marker-only instead of being materialized just for export.
- **Cheaper lazy reads for `toJSON`.** Ephemeral reads no longer create a second temporary wrapper for each decoded lazy container.
- **Exact snapshot preallocation.** `Snapshot::encoded_len` reserves the final envelope once, avoiding geometric `Vec` growth while assembling the result.
- **Independent scalar-root import fast path.** A causally closed batch of new peers writing scalars to new root maps is validated before apply, then diffed from the empty version instead of replaying the full history. The conservative root-history summary is size-capped and incrementally maintained.
- **Per-block checksum validation.** External snapshot import validates embedded SSTable block checksums instead of allowing malformed inner blocks to fail later during lazy reads.

## Benchmark results

Measured with the 11,387,982-byte (10.86 MiB) `.procloud` fixture using release WASM builds. Timing values are medians of three adjacent, interleaved runs.

| Scenario | `main` (`68587bc5`) | Before final export change (`3b64511b`) | PR (`3ea96a86`) | PR vs `main` |
| --- | ---: | ---: | ---: | ---: |
| Cold import + first full snapshot | 131.5 ms | 400.1 ms | 57.2 ms | **56.5% faster** |
| First full snapshot phase only | 122.7 ms | 390.1 ms | 46.9 ms | **61.8% faster** |
| Full round with causal update | 241.1 ms | 588.6 ms | 264.1 ms | 9.5% slower |
| Snapshot phase in causal round | 65.6 ms | 359.4 ms | 38.4 ms | **41.5% faster** |
| Full round with independent update | 6,563.6 ms | 589.7 ms | 264.9 ms | **96.0% faster (24.8×)** |
| Second unchanged full snapshot | 17.0 ms | 5.51 ms | 5.60 ms | **67.1% faster (3.0×)** |

The B4 harness's cached snapshot export also improved from 151.04 µs on `main` to 106.61 µs on this PR (about 29% faster).

### Memory comparison against `main`

The committed memory bench performs 32 local commits with 4 KiB text payloads, exports the resulting local update, then exports and semantically round-trips a complete snapshot. Both revisions were measured with the same script, fixture, parameters, and fresh worker processes.

| Update scenario | `main` WASM peak | PR WASM peak | WASM reduction | `main` controlled total | PR controlled total | Total reduction | 100 MiB gate |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Causal update | 161.81 MiB | 65.94 MiB | **59.3%** | 188.16 MiB | 92.29 MiB | **51.0%** | Fail → **Pass** |
| Independent update | 310.56 MiB | 65.50 MiB | **78.9%** | 336.95 MiB | 91.85 MiB | **72.7%** | Fail → **Pass** |

`Controlled total` includes the input snapshot/update buffers, WASM linear-memory high-water, returned update and snapshot buffers, retained `toJSON` heap growth, and retained binary backing stores.

The phase samples show where the WASM reduction comes from:

| Phase | `main` | PR | Change |
| --- | ---: | ---: | ---: |
| After snapshot import | 23.56 MiB | 23.56 MiB | unchanged |
| After first `toJSON` | 82.00 MiB | 38.69 MiB | **−52.8%** |
| After causal update import | 86.56 MiB | 40.75 MiB | **−52.9%** |
| After independent update import | 252.06 MiB | 40.31 MiB | **−84.0%** |
| Full snapshot export growth, causal | +74.38 MiB | +22.31 MiB | **−70.0%** |
| Full snapshot export growth, independent | +58.50 MiB | +22.31 MiB | **−61.9%** |

Observed process max RSS also fell from 256.34 to 181.13 MiB in the causal scenario (−29.3%), and from 404.38 to 180.42 MiB in the independent scenario (−55.4%). RSS is not the gate because it also includes V8, code pages, and allocator behavior.

## Validation

- Release WASM build and package tests: 331 Vitest tests passed (2 skipped, 2 todo), plus 4 Deno and 4 Bun tests.
- `cargo test -p loro-internal --lib`: 318 passed, 4 ignored.
- Mergeable-container targeted tests: 36 internal tests and 14 public-API tests passed.
- Both memory scenarios pass the 100 MiB controlled-total gate.
- Local-update and full-snapshot round trips preserve semantic versions and JSON state.
- The fixture's byte encoding of the snapshot round-trip version vector differs on both `main` and this PR; semantic version comparison passes, so this is not introduced here.

## Reproduction

```bash
pnpm -C crates/loro-wasm build-release
pnpm -C crates/loro-wasm test:snapshot-memory -- /path/to/file.procloud 100 32 4096
cargo run --release -p examples --example b4_bench
```

## Behavior and review notes

- Full snapshot export now relies on the write/apply-time container-materialization invariant. It no longer uses export as a second validation pass over all lazy parent metadata; shallow export retains that validation.
- Per-block checksum validation adds mandatory import work for untrusted bytes. This is a deliberate correctness trade-off.
- The causal full-round result is 9.5% slower than `main` even though its snapshot phase is 41.5% faster; the table keeps that remaining non-export overhead visible.
- The changeset documents the observable `loro-crdt` behavior changes, and `context/internal-encoding.md` plus `context/mergeable-containers.md` document the maintained invariants.