### PR TITLE
test: shallow snapshot retains deleted rich-text style values (privacy leak)

### DIFF
--- a/crates/loro/tests/integration_test/shallow_snapshot_test.rs
+++ b/crates/loro/tests/integration_test/shallow_snapshot_test.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::gen_action;
-use loro::{cursor::CannotFindRelativePosition, ExportMode, Frontiers, LoroDoc, ID};
+use loro::{cursor::CannotFindRelativePosition, ExportMode, Frontiers, LoroDoc, LoroValue, ID};
 
 #[test]
 fn state_only_at_concurrent_frontiers_excludes_later_ops() -> anyhow::Result<()> {
@@ -510,6 +510,69 @@ fn shallow_doc_accepts_cross_peer_op_whose_deps_include_boundary() -> anyhow::Re
     let p2_updates = p2.export(ExportMode::all_updates())?;
     s.import(&p2_updates)
         .expect("shallow doc should accept cross-peer op whose deps include the shallow boundary");
+
+    Ok(())
+}
+
+/// Shallow snapshots are documented as a content-redaction mechanism: exporting at the
+/// current frontiers is supposed to drop the trimmed history, leaving only the live state.
+/// Deleted *character* content is indeed dropped, but the value of a rich-text style op
+/// whose whole range has been deleted is still shipped verbatim in the exported bytes,
+/// even though no API can read it back.
+#[test]
+fn shallow_snapshot_drops_deleted_text_but_retains_dead_style_values() -> anyhow::Result<()> {
+    const SECRET_STYLE_VALUE: &str = "SECRET-STYLE-VALUE-e5f1";
+    const SECRET_TEXT: &str = "SECRET-TEXT-a7b2";
+
+    fn contains(haystack: &[u8], needle: &str) -> bool {
+        haystack
+            .windows(needle.len())
+            .any(|w| w == needle.as_bytes())
+    }
+
+    let doc = LoroDoc::new();
+    doc.set_peer_id(1)?;
+    let text = doc.get_text("text");
+    text.insert(0, SECRET_TEXT)?;
+    let len = SECRET_TEXT.chars().count();
+    text.mark(
+        0..len,
+        "comment",
+        LoroValue::String(SECRET_STYLE_VALUE.into()),
+    )?;
+    doc.commit();
+
+    text.delete(0, len)?;
+    doc.commit();
+
+    // Both secrets are unreachable through every read API.
+    assert_eq!(text.to_string(), "");
+    let live_state = format!("{:?}", doc.get_deep_value());
+    assert!(!live_state.contains(SECRET_TEXT));
+    assert!(!live_state.contains(SECRET_STYLE_VALUE));
+
+    let shallow = doc.export(ExportMode::shallow_snapshot(&doc.oplog_frontiers()))?;
+
+    // Control: the deleted characters are gone from the export, which is what makes the
+    // style leak below an asymmetry rather than "shallow snapshots keep history".
+    assert!(
+        !contains(&shallow, SECRET_TEXT),
+        "deleted text content must not survive a shallow snapshot"
+    );
+    assert!(
+        !contains(&shallow, SECRET_STYLE_VALUE),
+        "style value of a fully deleted range must not survive a shallow snapshot"
+    );
+
+    // The leak also survives a re-export from the imported shallow doc, so it cannot be
+    // laundered by round-tripping.
+    let imported = LoroDoc::new();
+    imported.import(&shallow)?;
+    let reexported = imported.export(ExportMode::shallow_snapshot(&imported.oplog_frontiers()))?;
+    assert!(
+        !contains(&reexported, SECRET_STYLE_VALUE),
+        "style value must not survive re-export of an imported shallow snapshot"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR contains **only a failing test**. I can try to come up with a fix, but want to leave that up to you.

## Summary

A shallow-snapshot export retains the **value of a rich-text style op whose entire marked range has been deleted**. Deleted character content is correctly dropped from the same export, so this is an asymmetry rather than "shallow snapshots keep history".

Minimal repro (single peer, no concurrency needed):

```rust
let text = doc.get_text("text");
text.insert(0, "SECRET-TEXT-a7b2")?;
text.mark(0..16, "comment", LoroValue::String("SECRET-STYLE-VALUE-e5f1".into()))?;
doc.commit();
text.delete(0, 16)?;                  // whole marked range gone
doc.commit();

let shallow = doc.export(ExportMode::shallow_snapshot(&doc.oplog_frontiers()))?;
// "SECRET-TEXT-a7b2"        -> absent   (correct)
// "SECRET-STYLE-VALUE-e5f1" -> PRESENT  (the bug)
```

Every read API says the data is gone: `text.to_string()` is `""`, and neither secret appears in `get_deep_value()`. Only the raw exported bytes still carry the style value. It also survives `import` into a fresh doc followed by a re-export, so it cannot be laundered by round-tripping.

The shallow-snapshots concepts page has a **"Content Redaction"** section that presents this exact export as the way to sanitize a document (https://loro.dev/docs/concepts/shallow_snapshots, source: `loro-dev/loro-docs` `pages/docs/concepts/shallow_snapshots.mdx`). Its example is structurally identical to the repro:

  ```ts
  const redacted = doc.export({
    mode: "shallow-snapshot",
    frontiers: doc.frontiers(),
  });
  // Sensitive data permanently removed from history
  ```

  That promise holds for the plain-text case the docs show, and breaks the moment the secret is a mark value instead of characters.
- Issue #388 ("Feature request: redact(contentIds) and/or sanitize(minimumFrontier) API", closed) treats shallow-snapshot export as the supported sanitization path: https://github.com/loro-dev/loro/issues/388
- The `redact` API from #504 does null out `TextOp::Mark` values — but only on the JSON-updates path (`crates/loro-internal/src/encoding/json_schema.rs`). `crates/loro-internal/src/encoding/shallow_snapshot.rs` has no equivalent redaction pass: https://github.com/loro-dev/loro/pull/504

So the two documented sanitization routes disagree about whether a dead style value is sensitive.

## Suspected mechanism

`calc_shallow_doc_start` (`crates/loro-internal/src/encoding/shallow_snapshot.rs:318`) walks a multi-head frontier back to the LCA, and the retained op tail from that start is shipped unredacted. Ops *at* the start frontier are always re-included, and a start landing on a `StyleStart` is advanced so the Start/End pair stays together — which keeps the mark op, and with it its value, in the export. In the single-peer repro above the start is already the tip, and the style value still ships, so the retained-tail encoding path looks like the place to fix rather than the frontier calculation itself.

With a **two-peer concurrent** frontier (2 heads), the LCA regression is much broader. In my probing the deleted *character* content leaked too, because history gets retained back to the common ancestor. That is arguably expected given the frontier can't be trimmed to a multi-head point, but it means "export at current frontiers to sanitize" is unsafe in exactly the collaborative case.

## Red test output


```
running 1 test
The application panicked (crashed).
Message:  style value of a fully deleted range must not survive a shallow snapshot
Location: crates/loro/tests/integration_test/shallow_snapshot_test.rs:562

test integration_test::shallow_snapshot_test::shallow_snapshot_drops_deleted_text_but_retains_dead_style_values ... FAILED

failures:
    integration_test::shallow_snapshot_test::shallow_snapshot_drops_deleted_text_but_retains_dead_style_values

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 178 filtered out; finished in 0.00s
```

The failure is on the *style* assertion. The deleted-character control assertion immediately above it passes, which is the point: the export does redact character content, just not style values.

## Context

I hit this in production: a local-first app that prunes document history before sharing a document with another peer. The pruning uses exactly the documented `shallow_snapshot(doc.frontiers())` flow, and mark values on deleted text are user-authored comment/annotation content — so the shared bytes carried data the UI had already shown as deleted.
