### PR TITLE
fix: apply pending changes unlocked during the same import

### DIFF
--- a/.changeset/pending-change-unlocked-during-import.md
+++ b/.changeset/pending-change-unlocked-during-import.md
@@ -1,0 +1,21 @@
+---
+"loro-crdt": patch
+---
+
+Fix a panic on import that could permanently break a document's sync.
+
+`import_changes_to_oplog` defers the changes whose deps are not yet in the DAG
+and hands them to `extend_pending_changes_with_unknown_lamport` to be parked.
+`try_apply_pending` runs in between and applies changes parked by earlier
+imports, which advances the oplog version, so a deferred change can become
+applicable — or already applied — by the time it is parked. Both outcomes used
+to hit `unreachable!`, compiling to `RuntimeError: unreachable` in WASM.
+
+The re-classification is now handled instead of asserted: a change that became
+applicable is applied and cascaded into whatever it unblocks, an already-applied
+one is skipped, and `ImportStatus` reports only what genuinely stayed pending.
+
+This mattered most through `import_batch`, which force-detaches the document for
+the duration of the batch and reattaches after the loop. The panic unwound past
+the reattach and left the document detached, so every later import and export
+failed and the document stopped syncing until the process restarted.

--- a/crates/loro-internal/src/encoding.rs
+++ b/crates/loro-internal/src/encoding.rs
@@ -274,15 +274,13 @@ pub(crate) fn apply_decoded_changes_to_oplog(
         changes_that_have_deps_before_shallow_root,
     } = import_changes_to_oplog(changes, oplog);
 
-    let mut pending = VersionRange::default();
-    pending_changes.iter().for_each(|c| {
-        pending.extends_to_include_id_span(c.id_span());
-    });
     // TODO: PERF: should we use hashmap to filter latest_ids with the same peer first?
     oplog.try_apply_pending(latest_ids, Some(&mut imported));
-    oplog
-        .import_unknown_lamport_pending_changes(pending_changes)
-        .expect("importing unknown-lamport pending changes is infallible");
+    // Applying previously parked pending ops can unlock deps of `pending_changes`.
+    // Those are applied here (and counted in `imported`); only still-blocked ones
+    // remain in the returned pending range.
+    let pending =
+        oplog.import_unknown_lamport_pending_changes(pending_changes, Some(&mut imported));
     ApplyDecodedChangesResult {
         status: ImportStatus {
             success: imported,

--- a/crates/loro-internal/src/oplog.rs
+++ b/crates/loro-internal/src/oplog.rs
@@ -525,8 +525,9 @@ impl OpLog {
     pub(crate) fn import_unknown_lamport_pending_changes(
         &mut self,
         remote_changes: Vec<Change>,
-    ) -> Result<(), LoroError> {
-        self.extend_pending_changes_with_unknown_lamport(remote_changes)
+        would_affect: Option<&mut crate::version::VersionRange>,
+    ) -> crate::version::VersionRange {
+        self.extend_pending_changes_with_unknown_lamport(remote_changes, would_affect)
     }
 
     /// lookup change by id.

--- a/crates/loro-internal/src/oplog/pending_changes.rs
+++ b/crates/loro-internal/src/oplog/pending_changes.rs
@@ -147,14 +147,14 @@ impl OpLog {
         remote_changes: Vec<Change>,
         mut would_affect: Option<&mut VersionRange>,
     ) -> VersionRange {
-        let mut still_pending = VersionRange::default();
+        let mut parked = Vec::new();
         let mut newly_applied_ids = Vec::new();
 
         for change in remote_changes {
             let local_change = PendingChange::Unknown(change);
             match remote_change_apply_state(self.vv(), self.shallow_since_vv(), &local_change) {
                 ChangeState::AwaitingMissingDependency(miss_dep) => {
-                    still_pending.extends_to_include_id_span(local_change.id_span());
+                    parked.push(local_change.id_span());
                     self.push_pending_change(miss_dep, local_change);
                 }
                 ChangeState::Applied => {}
@@ -169,19 +169,26 @@ impl OpLog {
             self.try_apply_pending(newly_applied_ids, would_affect);
         }
 
-        // `try_apply_pending` may have applied some of the changes we just parked.
-        // Report only spans that are still not fully covered by the oplog VV.
-        if !still_pending.is_empty() {
-            let vv = self.vv();
-            let mut remaining = VersionRange::default();
-            for (peer, (start, end)) in still_pending.iter() {
-                let vv_end = vv.get(peer).copied().unwrap_or(0);
-                if vv_end < *end {
-                    let pending_start = (*start).max(vv_end);
-                    remaining.extends_to_include_id_span(IdSpan::new(*peer, pending_start, *end));
-                }
+        // A parked change can already be partially covered by the oplog VV: a change whose
+        // span straddles the VV head is not `Applied`, and it still gets parked when one of
+        // its cross-peer deps is missing. Only the uncovered tail of such a span is pending.
+        //
+        // Trim each span on its own rather than merging first. `VersionRange` keeps a single
+        // (start, end) per peer, so trimming a merged range would attribute the gap between
+        // two disjoint parked spans to the covered one. That is defensive here — the input
+        // is lamport-ordered, so a parked change is unlikely to be unblocked by the
+        // `try_apply_pending` above — but it keeps the reported range honest regardless.
+        let mut still_pending = VersionRange::default();
+        for span in parked {
+            let vv_end = self.vv().get(&span.peer).copied().unwrap_or(0);
+            if vv_end < span.ctr_end() {
+                let start = span.counter.start.max(vv_end);
+                still_pending.extends_to_include_id_span(IdSpan::new(
+                    span.peer,
+                    start,
+                    span.ctr_end(),
+                ));
             }
-            still_pending = remaining;
         }
 
         still_pending
@@ -469,6 +476,10 @@ mod test {
         d.import(&u_a0).unwrap();
         d.import(&u_a1_only).unwrap();
         d.import_batch(std::slice::from_ref(&u_b0_b1)).unwrap();
+        // `import_batch` force-detaches for the duration of the batch and reattaches
+        // after the loop; a panic inside used to unwind past the reattach and strand
+        // the doc detached, failing every later import and export.
+        assert!(!d.is_detached(), "import_batch must leave the doc attached");
         assert_eq!(d.get_deep_value(), expected.get_deep_value());
         assert_eq!(d.oplog_vv(), expected.oplog_vv());
     }
@@ -485,6 +496,7 @@ mod test {
         d.import(&u_a0).unwrap();
         // Sorted by change_num inside import_batch; either order must work.
         d.import_batch(&[u_a1_only, u_b0_b1]).unwrap();
+        assert!(!d.is_detached(), "import_batch must leave the doc attached");
         assert_eq!(d.get_deep_value(), expected.get_deep_value());
         assert_eq!(d.oplog_vv(), expected.oplog_vv());
     }

--- a/crates/loro-internal/src/oplog/pending_changes.rs
+++ b/crates/loro-internal/src/oplog/pending_changes.rs
@@ -6,7 +6,7 @@ use crate::{
     OpLog, VersionVector,
 };
 use loro_common::{
-    ContainerType, Counter, CounterSpan, HasCounterSpan, HasIdSpan, LoroResult, PeerID, ID,
+    ContainerType, Counter, CounterSpan, HasCounterSpan, HasIdSpan, IdSpan, PeerID, ID,
 };
 use rustc_hash::FxHashMap;
 
@@ -133,22 +133,58 @@ impl OpLog {
             .push(change);
     }
 
+    /// Store or apply changes that could not get a lamport during the main import pass.
+    ///
+    /// These changes were deferred because some deps were missing from the DAG when
+    /// first seen. By the time this runs, `try_apply_pending` may already have unlocked
+    /// those deps (e.g. applying peer B unlocked previously pending peer A ops that a
+    /// later B change depended on). Treat that as normal: apply when possible, skip if
+    /// already present, and only park changes that are still waiting on a missing dep.
+    ///
+    /// Returns the version range of changes from `remote_changes` that remain pending.
     pub(super) fn extend_pending_changes_with_unknown_lamport(
         &mut self,
         remote_changes: Vec<Change>,
-    ) -> LoroResult<()> {
+        mut would_affect: Option<&mut VersionRange>,
+    ) -> VersionRange {
+        let mut still_pending = VersionRange::default();
+        let mut newly_applied_ids = Vec::new();
+
         for change in remote_changes {
             let local_change = PendingChange::Unknown(change);
             match remote_change_apply_state(self.vv(), self.shallow_since_vv(), &local_change) {
                 ChangeState::AwaitingMissingDependency(miss_dep) => {
-                    self.push_pending_change(miss_dep, local_change)
+                    still_pending.extends_to_include_id_span(local_change.id_span());
+                    self.push_pending_change(miss_dep, local_change);
                 }
-                ChangeState::Applied => unreachable!("already applied"),
-                ChangeState::CanApplyDirectly => unreachable!("can apply directly"),
+                ChangeState::Applied => {}
+                ChangeState::CanApplyDirectly => {
+                    newly_applied_ids.push(local_change.id_last());
+                    self.apply_change_from_remote(local_change, would_affect.as_deref_mut());
+                }
             }
         }
 
-        Ok(())
+        if !newly_applied_ids.is_empty() {
+            self.try_apply_pending(newly_applied_ids, would_affect);
+        }
+
+        // `try_apply_pending` may have applied some of the changes we just parked.
+        // Report only spans that are still not fully covered by the oplog VV.
+        if !still_pending.is_empty() {
+            let vv = self.vv();
+            let mut remaining = VersionRange::default();
+            for (peer, (start, end)) in still_pending.iter() {
+                let vv_end = vv.get(peer).copied().unwrap_or(0);
+                if vv_end < *end {
+                    let pending_start = (*start).max(vv_end);
+                    remaining.extends_to_include_id_span(IdSpan::new(*peer, pending_start, *end));
+                }
+            }
+            still_pending = remaining;
+        }
+
+        still_pending
     }
 }
 
@@ -389,6 +425,111 @@ mod test {
         c.import(&a.export(ExportMode::Snapshot).unwrap()).unwrap();
         a.import(&b_change).unwrap();
         assert_eq!(c.get_deep_value(), a.get_deep_value());
+    }
+
+    /// Regression: importing a blob can both apply ops that unlock previously pending
+    /// changes *and* contain later ops that depended on those pending changes.
+    ///
+    /// Sequence:
+    /// 1. D has A0.
+    /// 2. Import A1 (deps B0) → A1 parked as pending.
+    /// 3. Import a single blob with B0 (deps A0) + B1 (deps A1):
+    ///    - B0 applies; B1 is deferred (A1 not yet in the DAG).
+    ///    - `try_apply_pending` then applies A1 (unlocked by B0).
+    ///    - B1 must now apply instead of hitting `unreachable!("can apply directly")`.
+    #[test]
+    fn pending_change_becomes_applicable_after_try_apply_pending() {
+        let (u_a0, u_a1_only, u_b0_b1, expected) = concurrent_pending_unlock_fixture();
+
+        let d = LoroDoc::new_auto_commit();
+        d.set_peer_id(3).unwrap();
+        d.import(&u_a0).unwrap();
+        let status_a1 = d.import(&u_a1_only).unwrap();
+        assert!(
+            status_a1.pending.is_some(),
+            "A1 should be pending without B0: {status_a1:?}"
+        );
+        assert!(status_a1.success.is_empty(), "{status_a1:?}");
+
+        // This used to panic with unreachable!("can apply directly").
+        let status_b = d.import(&u_b0_b1).unwrap();
+        assert!(status_b.pending.is_none(), "{status_b:?}");
+        assert_eq!(d.get_deep_value(), expected.get_deep_value());
+        assert_eq!(d.oplog_vv(), expected.oplog_vv());
+    }
+
+    /// Same causal pattern via `import_batch` (path that hit WASM `unreachable`
+    /// with the lody snapshot+updates fixture).
+    #[test]
+    fn import_batch_applies_pending_unlocked_within_blob() {
+        let (u_a0, u_a1_only, u_b0_b1, expected) = concurrent_pending_unlock_fixture();
+
+        let d = LoroDoc::new_auto_commit();
+        d.set_peer_id(3).unwrap();
+        d.import(&u_a0).unwrap();
+        d.import(&u_a1_only).unwrap();
+        d.import_batch(std::slice::from_ref(&u_b0_b1)).unwrap();
+        assert_eq!(d.get_deep_value(), expected.get_deep_value());
+        assert_eq!(d.oplog_vv(), expected.oplog_vv());
+    }
+
+    /// Multi-blob `import_batch` (like lody drain): a large peer-A blob that
+    /// leaves pending ops, then a peer-B blob that both unlocks them and depends
+    /// on the previously pending range.
+    #[test]
+    fn import_batch_multi_blob_unlocks_and_applies_chained_pending() {
+        let (u_a0, u_a1_only, u_b0_b1, expected) = concurrent_pending_unlock_fixture();
+
+        let d = LoroDoc::new_auto_commit();
+        d.set_peer_id(3).unwrap();
+        d.import(&u_a0).unwrap();
+        // Sorted by change_num inside import_batch; either order must work.
+        d.import_batch(&[u_a1_only, u_b0_b1]).unwrap();
+        assert_eq!(d.get_deep_value(), expected.get_deep_value());
+        assert_eq!(d.oplog_vv(), expected.oplog_vv());
+    }
+
+    fn concurrent_pending_unlock_fixture() -> (Vec<u8>, Vec<u8>, Vec<u8>, LoroDoc) {
+        use loro_common::IdSpan;
+
+        let a = LoroDoc::new_auto_commit();
+        a.set_peer_id(1).unwrap();
+        let text_a = a.get_text("text");
+        text_a.insert(0, "A0", PosType::Unicode).unwrap();
+        let u_a0 = a
+            .export(ExportMode::updates(&VersionVector::default()))
+            .unwrap();
+        let vv_a0 = a.oplog_vv();
+        let a_counter_after_a0 = *vv_a0.get(&1).unwrap();
+
+        let b = LoroDoc::new_auto_commit();
+        b.set_peer_id(2).unwrap();
+        b.import(&u_a0).unwrap();
+        b.get_text("text")
+            .insert(2, "B0", PosType::Unicode)
+            .unwrap();
+        let u_b0 = b.export(ExportMode::updates(&vv_a0)).unwrap();
+
+        a.import(&u_b0).unwrap();
+        text_a.insert(4, "A1", PosType::Unicode).unwrap();
+        let a_counter_after_a1 = *a.oplog_vv().get(&1).unwrap();
+        // Peer-A ops only (A1), not B0 — so this stays pending on a doc that only has A0.
+        let u_a1_only = a
+            .export(ExportMode::updates_in_range(vec![IdSpan::new(
+                1,
+                a_counter_after_a0,
+                a_counter_after_a1,
+            )]))
+            .unwrap();
+
+        b.import(&u_a1_only).unwrap();
+        b.get_text("text")
+            .insert(6, "B1", PosType::Unicode)
+            .unwrap();
+        // Single blob containing B0 and B1. B1 depends on A1.
+        let u_b0_b1 = b.export(ExportMode::updates(&vv_a0)).unwrap();
+
+        (u_a0, u_a1_only, u_b0_b1, b)
     }
 
     // Change cannot be merged now


### PR DESCRIPTION
## Summary

- Fix `unreachable!("can apply directly")` in `extend_pending_changes_with_unknown_lamport` when `try_apply_pending` unlocks deps of changes deferred earlier in the same import.
- That panic compiled to WASM `RuntimeError: unreachable` and was reproducible via `import_batch` on real multi-peer update streams (lody snapshot + updates fixture: blob that parks peer-A ops, then a blob that both unlocks them and depends on them).
- Treat `CanApplyDirectly` / `Applied` as normal outcomes (apply or skip), update import `success`/`pending` ranges accordingly, and add regression tests for single-blob and multi-blob `import_batch`.

## Root cause

`apply_decoded_changes_to_oplog` order:

1. Defer changes whose deps are not yet in the DAG
2. `try_apply_pending` — newly applied ops may unlock *older* pending ops
3. Park the deferred list — but some deferred changes are now directly applicable

Step 3 used to `unreachable!` on `CanApplyDirectly`.

## Test plan

- [x] `cargo test -p loro-internal --lib oplog::pending_changes::test`
- [x] `cargo test -p loro-internal --lib import` (37 tests)
- [x] Local lody fixture: sequential import, `import_batch` of 112 updates, and snap+blob109+blob111 all complete without panic
- [ ] CI green