### PR TITLE
perf(wasm): cache container ids in JavaScript wrappers

### DIFF
--- a/.changeset/calm-containers-cache.md
+++ b/.changeset/calm-containers-cache.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Cache immutable container ids per JavaScript wrapper to avoid repeated WASM string decoding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ Loro is a Rust CRDT workspace with JS/WASM packaging and a MoonBit codec.
 - WASM panic/OOM reporting channels, `__wbindgen_start` glue invariant, and
   trap-testing recipes:
   [context/wasm-error-reporting.md](context/wasm-error-reporting.md).
+- WASM container id wrapper identity, lazy caching, and benchmark:
+  [context/wasm-container-id-cache.md](context/wasm-container-id-cache.md).
 - Context backlog: [context/CONTEXT-GAPS.md](context/CONTEXT-GAPS.md).
 
 ## Commands

--- a/context/wasm-container-id-cache.md
+++ b/context/wasm-container-id-cache.md
@@ -1,0 +1,40 @@
+# WASM container id cache
+
+Verified against code 2026-08-29.
+
+`LoroMap`, `LoroList`, `LoroText`, `LoroTree`, `LoroMovableList`, and
+`LoroCounter` expose `id` from Rust through wasm-bindgen. The generated getter
+crosses into WASM and creates a new JS string on every call.
+
+## Identity and lifetime
+
+- `HandlerTrait::id` in `crates/loro-internal/src/handler.rs` reads the immutable
+  `BasicHandler.id` for an attached handler. Detached handlers return their
+  type-specific `ID::NONE_ID` placeholder.
+- Attaching does not rebind the detached JS wrapper. `insertContainer` returns a
+  new attached wrapper, while the original detached handler records an attached
+  back-reference used by `getAttached()`.
+- Calling `getAttached()` on an already attached wrapper clones the Rust handler
+  into another JS wrapper. The two wrappers have the same container id but
+  separate wasm-bindgen pointers and cache entries.
+- wasm-bindgen sets `__wbg_ptr` to zero in `__destroy_into_raw()`. An `id` read
+  after `free()` must keep raising wasm-bindgen's null-pointer error.
+
+`scripts/container_id_cache_patch.js` therefore stores the id in a
+non-enumerable, module-private Symbol property on the JS wrapper. It clears the
+property during `__destroy_into_raw()` and bypasses the cache for a zero
+pointer. The cache has exactly the wrapper's lifetime and does not retain the
+wrapper from another object.
+
+## Package targets and checks
+
+`scripts/build.ts` appends the cache patch to the raw wasm-bindgen module for
+each of `nodejs`, `web`, `browser`, and `bundler`. Normal package entrypoints
+and exported raw-binding subpaths therefore use the same decorated classes;
+`post-rollup.ts` derives `base64` from the patched bundler target. Do not patch
+generated `loro_wasm*.js` files by hand.
+
+Run `pnpm bench-wasm-container-id` from the repository root after a dev or
+release WASM build. The benchmark separates repeated reads of one wrapper,
+first reads of many wrappers, a mirror-like reused-wrapper pass, and a
+fresh-wrapper boundary.

--- a/crates/loro-wasm/AGENTS.md
+++ b/crates/loro-wasm/AGENTS.md
@@ -71,6 +71,10 @@ and pitfalls (the `__wbindgen_start` glue invariant, why OOM uses a global
 allocator wrapper, stack-frame limits): see
 [context/wasm-error-reporting.md](../../context/wasm-error-reporting.md).
 
+Container `id` wrapper identity, lazy-cache lifetime, and the focused benchmark
+are documented in
+[context/wasm-container-id-cache.md](../../context/wasm-container-id-cache.md).
+
 ## Packaging Rules
 
 - Preserve the public `loro-crdt` API names and package export paths used by

--- a/crates/loro-wasm/scripts/build.ts
+++ b/crates/loro-wasm/scripts/build.ts
@@ -233,6 +233,7 @@ async function buildTarget(target: string) {
   console.log();
 
   await postProcessWasm(targetDirPath, target);
+  await installContainerIdCache(targetDirPath, target);
 
   if (target === "nodejs") {
     console.log("🔨  Patching nodejs target");
@@ -271,6 +272,19 @@ async function buildTarget(target: string) {
       patch,
     );
   }
+}
+
+async function installContainerIdCache(targetDirPath: string, target: string) {
+  const generatedBinding =
+    target === "bundler" || target === "browser"
+      ? "loro_wasm_bg.js"
+      : "loro_wasm.js";
+  const generatedBindingPath = path.resolve(targetDirPath, generatedBinding);
+  const patch = await Deno.readTextFile(
+    path.resolve(__dirname, "./container_id_cache_patch.js"),
+  );
+  const generated = await Deno.readTextFile(generatedBindingPath);
+  await Deno.writeTextFile(generatedBindingPath, `${generated}\n${patch}`);
 }
 
 function renderBrowserPatch(template: string, wasmBg: string): string {

--- a/crates/loro-wasm/scripts/container_id_cache_patch.js
+++ b/crates/loro-wasm/scripts/container_id_cache_patch.js
@@ -1,0 +1,68 @@
+// A container handler never changes identity during one JS wrapper's lifetime.
+// Attaching a detached handler returns a different wrapper, and getAttached()
+// also returns a new wrapper. Cache on the wrapper, not by container id.
+const __loroContainerIdCache = Symbol("loroContainerId");
+
+function __loroCacheContainerIdGetter(ContainerClass) {
+  const prototype = ContainerClass.prototype;
+  const idDescriptor = Object.getOwnPropertyDescriptor(prototype, "id");
+  const getId = idDescriptor && idDescriptor.get;
+  const destroyDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "__destroy_into_raw",
+  );
+  const destroy = destroyDescriptor && destroyDescriptor.value;
+
+  if (!getId || !destroyDescriptor || !destroy) {
+    throw new Error("Unexpected wasm-bindgen container wrapper shape");
+  }
+
+  Object.defineProperty(prototype, "id", {
+    ...idDescriptor,
+    get() {
+      // Preserve wasm-bindgen's post-free error instead of returning stale data.
+      if (this.__wbg_ptr === 0) {
+        return getId.call(this);
+      }
+
+      const cached = this[__loroContainerIdCache];
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      const id = getId.call(this);
+      try {
+        Object.defineProperty(this, __loroContainerIdCache, {
+          configurable: true,
+          value: id,
+        });
+      } catch {
+        // Caching must not make a non-extensible wrapper's id unreadable.
+      }
+      return id;
+    },
+  });
+
+  Object.defineProperty(prototype, "__destroy_into_raw", {
+    ...destroyDescriptor,
+    value() {
+      try {
+        delete this[__loroContainerIdCache];
+      } catch {
+        // Cache cleanup must not replace wasm-bindgen's free behavior.
+      }
+      return destroy.call(this);
+    },
+  });
+}
+
+for (const ContainerClass of [
+  LoroMap,
+  LoroText,
+  LoroList,
+  LoroTree,
+  LoroMovableList,
+  LoroCounter,
+]) {
+  __loroCacheContainerIdGetter(ContainerClass);
+}

--- a/crates/loro-wasm/scripts/measure-container-id.cjs
+++ b/crates/loro-wasm/scripts/measure-container-id.cjs
@@ -1,0 +1,125 @@
+const { performance } = require("node:perf_hooks");
+const { TextDecoder } = require("node:util");
+const { LoroDoc } = require("../nodejs/index.js");
+
+const DISTINCT_COUNT = 20_000;
+const REPEATED_READS = 1_000_000;
+const WARMUP_ROUNDS = 3;
+const ROUNDS = 7;
+let blackhole = 0;
+
+function makeContainers(count = DISTINCT_COUNT) {
+  const doc = new LoroDoc();
+  const getters = [
+    (name) => doc.getMap(name),
+    (name) => doc.getList(name),
+    (name) => doc.getText(name),
+    (name) => doc.getTree(name),
+    (name) => doc.getMovableList(name),
+    (name) => doc.getCounter(name),
+  ];
+  const containers = Array.from({ length: count }, (_, index) =>
+    getters[index % getters.length](`container-${index}`),
+  );
+  return { doc, containers };
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function timed(name, setup, run) {
+  const samples = [];
+  for (let round = 0; round < WARMUP_ROUNDS + ROUNDS; round++) {
+    global.gc?.();
+    const state = setup();
+    const start = performance.now();
+    run(state);
+    const elapsed = performance.now() - start;
+    if (round >= WARMUP_ROUNDS) samples.push(elapsed);
+    state.doc?.free();
+  }
+  return { name, medianMs: median(samples), samplesMs: samples };
+}
+
+function countDecodes(setup, run) {
+  const state = setup();
+  const original = TextDecoder.prototype.decode;
+  let decodes = 0;
+  TextDecoder.prototype.decode = function (...args) {
+    decodes++;
+    return original.apply(this, args);
+  };
+  try {
+    run(state);
+  } finally {
+    TextDecoder.prototype.decode = original;
+    state.doc?.free();
+  }
+  return decodes;
+}
+
+const repeatedSetup = () => {
+  const doc = new LoroDoc();
+  return { doc, container: doc.getText("repeated-container-id") };
+};
+const repeatedRun = ({ container }) => {
+  for (let i = 0; i < REPEATED_READS; i++) blackhole += container.id.length;
+};
+
+const firstRun = ({ containers }) => {
+  for (const container of containers) blackhole += container.id.length;
+};
+
+const mirrorReuseRun = ({ containers }) => {
+  for (const container of containers) {
+    blackhole += container.id.length;
+    blackhole += container.id.length;
+    blackhole += container.id.length;
+    blackhole += container.id.length;
+    const json = container.toJSON();
+    if (json != null) blackhole++;
+  }
+};
+
+const churnSetup = () => {
+  const state = makeContainers();
+  state.ids = state.containers.map((container) => container.id);
+  return state;
+};
+const churnRun = ({ doc, ids }) => {
+  for (const id of ids) {
+    const container = doc.getContainerById(id);
+    blackhole += container.id.length;
+    const json = container.toJSON();
+    if (json != null) blackhole++;
+  }
+};
+
+const cases = [
+  ["same-wrapper-repeated-id", repeatedSetup, repeatedRun],
+  ["distinct-wrappers-first-id", makeContainers, firstRun],
+  ["mirror-reuse-wrapper", makeContainers, mirrorReuseRun],
+  ["mirror-new-wrapper-per-id", churnSetup, churnRun],
+];
+
+const result = cases.map(([name, setup, run]) => ({
+  ...timed(name, setup, run),
+  decoderCalls: countDecodes(setup, run),
+}));
+
+console.log(
+  JSON.stringify(
+    {
+      distinctCount: DISTINCT_COUNT,
+      repeatedReads: REPEATED_READS,
+      warmupRounds: WARMUP_ROUNDS,
+      rounds: ROUNDS,
+      blackhole,
+      result,
+    },
+    null,
+    2,
+  ),
+);

--- a/crates/loro-wasm/tests/container_id_cache.test.ts
+++ b/crates/loro-wasm/tests/container_id_cache.test.ts
@@ -1,0 +1,114 @@
+import { TextDecoder } from "node:util";
+import { describe, expect, it } from "vitest";
+import { Container, LoroDoc, LoroText } from "../bundler/index";
+
+function countTextDecodes<T>(callback: () => T): {
+  result: T;
+  decoderCalls: number;
+} {
+  const original = TextDecoder.prototype.decode;
+  let decoderCalls = 0;
+  TextDecoder.prototype.decode = function (...args) {
+    decoderCalls += 1;
+    return original.apply(this, args);
+  };
+
+  try {
+    return { result: callback(), decoderCalls };
+  } finally {
+    TextDecoder.prototype.decode = original;
+  }
+}
+
+describe("container id cache", () => {
+  it("decodes once per wrapper for every container type", () => {
+    const doc = new LoroDoc();
+    const containers: Container[] = [
+      doc.getMap("map"),
+      doc.getText("text"),
+      doc.getList("list"),
+      doc.getTree("tree"),
+      doc.getMovableList("movable-list"),
+      doc.getCounter("counter"),
+    ];
+
+    const { result: ids, decoderCalls } = countTextDecodes(() =>
+      containers.map((container) => [container.id, container.id]),
+    );
+
+    expect(decoderCalls).toBe(containers.length);
+    for (const [first, second] of ids) {
+      expect(second).toBe(first);
+    }
+  });
+
+  it("keeps cache identity scoped to one wrapper", () => {
+    const doc = new LoroDoc();
+    const first = doc.getMap("map");
+    const second = doc.getMap("map");
+
+    const { result: ids, decoderCalls } = countTextDecodes(() => [
+      first.id,
+      first.id,
+      second.id,
+      second.id,
+    ]);
+
+    expect(first).not.toBe(second);
+    expect(new Set(ids).size).toBe(1);
+    expect(decoderCalls).toBe(2);
+  });
+
+  it("does not rebind a detached wrapper when it is attached", () => {
+    const doc = new LoroDoc();
+    const detached = new LoroText();
+    const detachedId = detached.id;
+    const attached = doc
+      .getMap("map")
+      .setContainer("text", detached) as LoroText;
+    const attachedClone = attached.getAttached()!;
+
+    expect(detached.isAttached()).toBe(false);
+    expect(detached.id).toBe(detachedId);
+    expect(attached.isAttached()).toBe(true);
+    expect(attached.id).not.toBe(detachedId);
+    expect(attachedClone).not.toBe(attached);
+    expect(attachedClone.id).toBe(attached.id);
+  });
+
+  it("preserves container identity across snapshot import", () => {
+    const source = new LoroDoc();
+    source.setPeerId("1");
+    const sourceText = source
+      .getMap("map")
+      .setContainer("text", new LoroText()) as LoroText;
+    const id = sourceText.id;
+
+    const imported = LoroDoc.fromSnapshot(source.export({ mode: "snapshot" }));
+    const importedText = imported.getContainerById(id)!;
+
+    expect(importedText.id).toBe(id);
+    expect(importedText.id).toBe(id);
+  });
+
+  it("does not return a cached id after free", () => {
+    const text = new LoroText();
+    void text.id;
+    text.free();
+
+    expect(() => text.id).toThrow("null pointer passed to rust");
+  });
+
+  it("keeps a non-extensible wrapper readable without caching it", () => {
+    const text = Object.preventExtensions(new LoroText());
+
+    const { result: ids, decoderCalls } = countTextDecodes(() => [
+      text.id,
+      text.id,
+    ]);
+
+    expect(ids[1]).toBe(ids[0]);
+    expect(decoderCalls).toBe(2);
+    text.free();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test-bundlers": "pnpm --dir examples/bundler-smoke-tests run test:fast",
     "test-bundlers-next": "pnpm --dir examples/bundler-smoke-tests run test:next",
     "run-fuzz-corpus": "node ./scripts/cargo-fuzz-run.mjs all -- -max_total_time=1",
+    "bench-wasm-container-id": "node --expose-gc ./crates/loro-wasm/scripts/measure-container-id.cjs",
     "fix": "cargo clippy --fix --features=test_utils",
     "vet": "cargo vet",
     "release-rust": "deno run -A ./scripts/cargo-release.ts"


### PR DESCRIPTION
## Summary

- lazily cache immutable container ids on each JavaScript wrapper
- cover LoroMap, LoroText, LoroList, LoroTree, LoroMovableList, and LoroCounter across nodejs, web, browser, bundler, and base64 outputs
- preserve free, detached/attached, cloned wrapper, snapshot import, and non-extensible wrapper behavior
- add focused regression tests, a reproducible microbenchmark, a changeset, and lifecycle documentation

## Rationale

Every container id getter currently crosses into WASM and decodes a fresh UTF-8 JavaScript string. A wrapper-local cache removes repeated crossings without conflating distinct wrappers that reference the same container.

The cache is injected by the binding build script instead of editing generated output. Fresh wrappers remain cold by design, so callers such as loro-mirror can still benefit from passing known ids and avoiding repeated wrapper creation.

## Benchmark

Release WASM, 20,000 wrappers, 1,000,000 repeated reads, 3 warmup rounds, 7 measured rounds:

- same wrapper repeated id: 153.64 ms to 1.61 ms; decoder calls 1,000,000 to 1
- mirror-like reused wrapper pass: 17.35 ms to 8.63 ms; decoder calls 83,333 to 23,333
- distinct wrapper first reads: 4.29 ms to 6.31 ms; decoder calls remain 20,000
- fresh wrapper per lookup: 23.40 ms to 22.83 ms; decoder calls remain 23,333

## Validation

- release WASM generation for bundler, browser, nodejs, web, and base64
- Vitest: 26 files passed; 345 tests passed, 2 skipped, 2 todo
- focused container id cache tests: 6 passed
- TypeScript typecheck
- Deno tests: 4 passed
- Bun tests: 4 passed
- 14 bundler smoke fixtures
- 13 real Chromium runtime fixtures
- Prettier check
- Changesets status
- git diff checks

Root pnpm check still reports three unrelated existing Clippy errors in crates/loro-internal: one unused import and two obfuscated-if-else warnings. This PR does not touch those files.