### PR TITLE
perf: avoid re-decoding oversized SSTable blocks on every `export(update)` after a snapshot round

### DIFF
--- a/crates/kv-store/src/block.rs
+++ b/crates/kv-store/src/block.rs
@@ -497,6 +497,25 @@ impl BlockIter {
         iter
     }
 
+    /// An iterator with nothing to yield in either direction; decodes no block.
+    pub(crate) fn new_empty() -> Self {
+        Self {
+            block: Arc::new(Block::Normal(NormalBlock {
+                data: Bytes::new(),
+                encoded_data: OnceCell::new(),
+                first_key: Bytes::new(),
+                offsets: Vec::new(),
+            })),
+            next_key: Bytes::new(),
+            next_value_range: 0..0,
+            prev_key: Bytes::new(),
+            prev_value_range: 0..0,
+            next_idx: 0,
+            prev_idx: -1,
+            first_key: Bytes::new(),
+        }
+    }
+
     pub fn new_seek_to_key(block: Arc<Block>, key: &[u8]) -> Self {
         let prev_idx = block.len() as isize - 1;
         let mut iter = Self {

--- a/crates/kv-store/src/mem_store.rs
+++ b/crates/kv-store/src/mem_store.rs
@@ -643,6 +643,44 @@ mod tests {
     }
 
     #[test]
+    fn scan_does_not_decode_blocks_outside_its_bounds() {
+        // An entry whose decompressed size exceeds the block cache's byte budget
+        // can never be admitted to the cache. A scan whose bounds exclude that
+        // block must not decode it at all — otherwise every scan that merely
+        // starts (or ends) near it pays the full decompression again.
+        let mut source = MemKvStore::new(MemKvConfig::default().should_encode_none(true));
+        // > 4 MiB decompressed, so it cannot be admitted to the block cache.
+        source.set(b"big", Bytes::from(vec![7u8; 5 * 1024 * 1024]));
+        source.set(b"tail-1", Bytes::from_static(b"v1"));
+        source.set(b"tail-2", Bytes::from_static(b"v2"));
+        let bytes = source.export_all();
+        let mut imported = MemKvStore::new(MemKvConfig::default().should_encode_none(true));
+        imported.import_all(bytes).unwrap();
+
+        let scan_tail = |store: &MemKvStore| {
+            store
+                .scan(
+                    std::ops::Bound::Included(b"tail".as_ref()),
+                    std::ops::Bound::Unbounded,
+                )
+                .map(|(k, v)| (k, v))
+                .collect::<Vec<_>>()
+        };
+        // Warm-up: small in-range blocks may be decoded once and cached.
+        let first = scan_tail(&imported);
+        assert_eq!(first.len(), 2);
+
+        let before = crate::sstable::BLOCK_DECODES_FOR_TEST.with(|c| c.get());
+        let second = scan_tail(&imported);
+        let decodes = crate::sstable::BLOCK_DECODES_FOR_TEST.with(|c| c.get()) - before;
+        assert_eq!(second, first);
+        assert_eq!(
+            decodes, 0,
+            "a repeated scan past the oversized block must not re-decode any block"
+        );
+    }
+
+    #[test]
     fn block_cache_stays_bounded_during_full_scan() {
         // More decompressed bytes than the block cache budget, so an unbounded cache would
         // exceed it after one full scan.

--- a/crates/kv-store/src/sstable.rs
+++ b/crates/kv-store/src/sstable.rs
@@ -22,6 +22,12 @@ pub const SIZE_OF_U32: usize = std::mem::size_of::<u32>();
 const BLOCK_CACHE_MAX_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_BLOCK_NUM: u32 = 10_000_000;
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only count of raw (uncached) block decodes on this thread.
+    pub(crate) static BLOCK_DECODES_FOR_TEST: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
 /// ```log
 /// ┌──────────────────────────────────────────────────────────────────────────────────────────┐
 /// │ Block Meta                                                                               │
@@ -553,6 +559,8 @@ impl SsTable {
     }
 
     fn read_block(&self, block_idx: usize) -> Arc<Block> {
+        #[cfg(test)]
+        BLOCK_DECODES_FOR_TEST.with(|c| c.set(c.get() + 1));
         let offset = self.meta[block_idx].offset;
         let offset_end = self
             .meta
@@ -634,9 +642,73 @@ impl Debug for SsTableIter<'_> {
     }
 }
 
+enum StartPosition {
+    /// The scan start falls inside this block; seek within it.
+    InBlock(usize),
+    /// Every key of the start's candidate block sorts before the scan start;
+    /// begin from this (fully in-range) block instead.
+    NextBlock(usize),
+    /// The scan start sorts after every key in the table.
+    PastTable,
+}
+
 impl<'a> SsTableIter<'a> {
     fn new(table: &'a SsTable) -> Self {
         Self::new_scan(table, Bound::Unbounded, Bound::Unbounded)
+    }
+
+    /// Locate the block the scan should start in without decoding any block.
+    ///
+    /// When every key of the candidate block sorts before the scan start, the
+    /// block cannot contribute to the scan, so it is skipped: decoding is
+    /// expensive for large blocks and the block cache does not retain blocks
+    /// bigger than its byte budget, which would make the decode repeat on every
+    /// scan. Every key of the following block sorts after `start`, so it can be
+    /// iterated from its beginning (and an excluded start key can never match) —
+    /// unless its first key already sorts past the `end` bound, in which case
+    /// the whole scan is empty and nothing needs decoding at all.
+    fn start_within_or_after_block(
+        table: &SsTable,
+        start: &[u8],
+        exclusive: bool,
+        end: Bound<&[u8]>,
+    ) -> StartPosition {
+        let idx = table.find_block_idx(start);
+        let meta = &table.meta[idx];
+        let block_last_key: &[u8] = meta.last_key.as_ref().unwrap_or(&meta.first_key);
+        let starts_past_block = if exclusive {
+            block_last_key <= start
+        } else {
+            block_last_key < start
+        };
+        if !starts_past_block {
+            return StartPosition::InBlock(idx);
+        }
+        notify_cov("kv-store::SstableIter::new_scan::start skips block");
+        if idx + 1 >= table.meta.len() {
+            return StartPosition::PastTable;
+        }
+        let next_first_key: &[u8] = &table.meta[idx + 1].first_key;
+        let next_block_in_range = match end {
+            Bound::Included(end) => next_first_key <= end,
+            Bound::Excluded(end) => next_first_key < end,
+            Bound::Unbounded => true,
+        };
+        if next_block_in_range {
+            StartPosition::NextBlock(idx + 1)
+        } else {
+            StartPosition::PastTable
+        }
+    }
+
+    /// An exhausted iterator that never touches (or decodes) any block.
+    fn new_empty(table: &'a SsTable) -> Self {
+        SsTableIter {
+            table,
+            iter: SsTableIterInner::Same(BlockIter::new_empty()),
+            next_block_idx: 1,
+            back_block_idx: 0,
+        }
     }
 
     pub fn new_scan(table: &'a SsTable, start: Bound<&[u8]>, end: Bound<&[u8]>) -> Self {
@@ -644,17 +716,33 @@ impl<'a> SsTableIter<'a> {
         let (table_idx, mut iter, excluded) = match start {
             Bound::Included(start) => {
                 notify_cov("kv-store::SstableIter::new_scan::start included");
-                let idx = table.find_block_idx(start);
-                let block = read_block(idx);
-                let iter = BlockIter::new_seek_to_key(block, start);
-                (idx, iter, None)
+                match Self::start_within_or_after_block(table, start, false, end) {
+                    StartPosition::PastTable => return Self::new_empty(table),
+                    StartPosition::NextBlock(idx) => {
+                        let block = read_block(idx);
+                        (idx, BlockIter::new(block), None)
+                    }
+                    StartPosition::InBlock(idx) => {
+                        let block = read_block(idx);
+                        let iter = BlockIter::new_seek_to_key(block, start);
+                        (idx, iter, None)
+                    }
+                }
             }
             Bound::Excluded(start) => {
                 notify_cov("kv-store::SstableIter::new_scan::start excluded");
-                let idx = table.find_block_idx(start);
-                let block = read_block(idx);
-                let iter = BlockIter::new_seek_to_key(block, start);
-                (idx, iter, Some(start))
+                match Self::start_within_or_after_block(table, start, true, end) {
+                    StartPosition::PastTable => return Self::new_empty(table),
+                    StartPosition::NextBlock(idx) => {
+                        let block = read_block(idx);
+                        (idx, BlockIter::new(block), None)
+                    }
+                    StartPosition::InBlock(idx) => {
+                        let block = read_block(idx);
+                        let iter = BlockIter::new_seek_to_key(block, start);
+                        (idx, iter, Some(start))
+                    }
+                }
             }
             Bound::Unbounded => {
                 notify_cov("kv-store::SstableIter::new_scan::start unbounded");
@@ -667,6 +755,10 @@ impl<'a> SsTableIter<'a> {
             Bound::Included(end) => {
                 notify_cov("kv-store::SstableIter::new_scan::end included");
                 let end_idx = table.find_back_block_idx(end);
+                if end_idx < table_idx {
+                    // The whole range sits inside the skipped prefix: empty scan.
+                    return Self::new_empty(table);
+                }
                 if end_idx == table_idx {
                     iter.back_to_key(end);
                     // if the next back is invalid, the next should also be invalid
@@ -683,6 +775,10 @@ impl<'a> SsTableIter<'a> {
             Bound::Excluded(end) => {
                 notify_cov("kv-store::SstableIter::new_scan::end excluded");
                 let end_idx = table.find_back_block_idx(end);
+                if end_idx < table_idx {
+                    // The whole range sits inside the skipped prefix: empty scan.
+                    return Self::new_empty(table);
+                }
                 if end_idx == table_idx {
                     iter.back_to_key(end);
                     // if the next back is invalid, the next should also be invalid

--- a/crates/loro-internal/src/oplog/change_store.rs
+++ b/crates/loro-internal/src/oplog/change_store.rs
@@ -78,6 +78,8 @@ pub struct ChangeStore {
     root_history_names: Arc<Mutex<RootHistoryNamesState>>,
     #[cfg(test)]
     root_history_scan_count: Arc<AtomicUsize>,
+    #[cfg(test)]
+    ensure_id_lte_scan_count: Arc<AtomicUsize>,
 }
 
 /// A conservative, size-capped set of every top-level root name that appears in the store's
@@ -200,6 +202,8 @@ impl ChangeStore {
             root_history_names: Arc::new(Mutex::new(RootHistoryNamesState::Uninitialized)),
             #[cfg(test)]
             root_history_scan_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
+            ensure_id_lte_scan_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -508,6 +512,14 @@ impl ChangeStore {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// The number of times `ensure_id_lte` had to fall back to scanning the
+    /// external kv store (i.e. the covering parsed block was not already loaded).
+    #[cfg(test)]
+    pub(crate) fn ensure_id_lte_scan_count_for_test(&self) -> usize {
+        self.ensure_id_lte_scan_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     pub(crate) fn iter_blocks(&self, id_span: IdSpan) -> Vec<(Arc<ChangesBlock>, usize, usize)> {
         if id_span.counter.start == id_span.counter.end {
             return vec![];
@@ -704,6 +716,8 @@ impl ChangeStore {
             root_history_names: Arc::new(Mutex::new(RootHistoryNamesState::Uninitialized)),
             #[cfg(test)]
             root_history_scan_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
+            ensure_id_lte_scan_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -1451,6 +1465,27 @@ mod mut_inner_kv {
         }
 
         pub(super) fn ensure_id_lte(&self, id: ID) {
+            {
+                let inner = self.inner.lock();
+                if let Some((_, block)) = inner.mem_parsed_kv.range(..=id).next_back() {
+                    if block.peer == id.peer
+                        && block.counter_range.0 <= id.counter
+                        && id.counter < block.counter_range.1
+                    {
+                        // The parsed block covering `id` is already loaded. Blocks of the
+                        // same peer cover disjoint, contiguous counter ranges and the
+                        // external store is only ever written from these parsed blocks
+                        // (or from the initial load, when nothing is parsed yet), so it
+                        // cannot hold a closer predecessor. Skipping also avoids a kv
+                        // scan that may re-decode a block bigger than the block cache's
+                        // byte budget on every call.
+                        return;
+                    }
+                }
+            }
+            #[cfg(test)]
+            self.ensure_id_lte_scan_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let kv = self.external_kv.lock();
             let mut inner = self.inner.lock();
             let Some((next_back_id, next_back_bytes)) = kv
@@ -2084,6 +2119,54 @@ mod test {
         assert!(!record_root_name(&mut names, &mut name_bytes, &oversized));
         assert!(names.is_empty());
         assert_eq!(name_bytes, 0);
+    }
+
+    #[test]
+    fn export_updates_does_not_rescan_kv_for_covered_spans() {
+        // After a snapshot export flushed history into the external kv store,
+        // repeated `export(mode=update)` calls iterate spans that the parsed
+        // block cache (`mem_parsed_kv`) already covers. `ensure_id_lte` must not
+        // fall back to a kv scan for those spans: the scan may re-decode a block
+        // bigger than the kv block cache's byte budget on every call (the
+        // export-update perf regression after a snapshot export).
+        let doc = LoroDoc::new_auto_commit();
+        doc.set_record_timestamp(false);
+        let t = doc.get_text("t");
+        for i in 0..64 {
+            t.insert(0, &format!("hello world {i}"), PosType::Unicode)
+                .unwrap();
+            doc.commit_then_renew();
+        }
+        let vv_mid = doc.oplog_vv();
+        for i in 0..8 {
+            t.insert(0, &format!("tail {i}"), PosType::Unicode).unwrap();
+            doc.commit_then_renew();
+        }
+
+        // Flush everything into the external kv store.
+        let _snapshot = doc.export(crate::loro::ExportMode::Snapshot).unwrap();
+
+        // Warm-up: both before and after the fix the first export may load state.
+        let first = doc
+            .export(crate::loro::ExportMode::updates(&vv_mid))
+            .unwrap();
+        let scans_before = {
+            let oplog = doc.oplog().lock();
+            oplog.change_store().ensure_id_lte_scan_count_for_test()
+        };
+        let second = doc
+            .export(crate::loro::ExportMode::updates(&vv_mid))
+            .unwrap();
+        let scans_after = {
+            let oplog = doc.oplog().lock();
+            oplog.change_store().ensure_id_lte_scan_count_for_test()
+        };
+        assert_eq!(second, first);
+        assert_eq!(
+            scans_after - scans_before,
+            0,
+            "a steady-state export(update) must not rescan the external kv store"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Since 1.13.8, an incremental `export({ mode: "update", from })` on a document that has been through one snapshot export or import becomes 20-140x slower per call, and stays that way for the life of the document. Measured on a 24k-word movable-list document (~8 MB decompressed change store):

| build | cold `export(update)` p50 | after one snapshot round | ratio | raw block decodes / call |
|---|---|---|---|---|
| 1.13.7 | 0.074 ms | 0.073 ms | 1.0x | - |
| 1.15.1 | 0.075 ms | 1.87 ms (10.7 ms under CPU-frequency variance) | 25x (up to 141x) | 2 |
| 1.15.1 + this PR | 0.077 ms | 0.080 ms | 1.0x | 0 |

Same shape through the npm package (vitest, node 22, nodejs and base64 entries): 1.15.1 goes from 0.24 ms cold to 5.9 ms / 5.4 ms after a snapshot round (24.7x / 22.8x); with this PR 0.25 ms / 0.24 ms (0.7x). The "fresh snapshot import, then edit, then export update" path drops from 0.9-1.7 ms per call to 0.004 ms.

This does not appear to be reported upstream; the nearest issue (#992, shallow-doc snapshot export) is a different mode and already fixed.

## Root cause

`ac1feb61` (#1049) replaced the SSTable block cache's entry-count bound with a decompressed-byte bound: `BLOCK_CACHE_MAX_BYTES = 4 MiB` with `BlockDataWeighter` (`crates/kv-store/src/sstable.rs:22`, `:330`, `new_block_cache()` at `:339`). `quick_cache` never admits an entry whose weight exceeds the total capacity.

A single-peer document whose mergeable ops coalesce into one `ChangesBlock` (the `is_mergable` arm of `push_change` bypasses the 4 KB `MAX_BLOCK_SIZE` cap, `crates/loro-internal/src/oplog/change_store.rs`) produces one change-store kv value of ~8 MB decompressed (474 KB LZ4) = one SSTable "large block" that can never be cached. After the memtable is flushed into an SSTable (snapshot export) or the kv store arrives SSTable-backed (snapshot import), every `export(update)` re-decompresses that block twice:

1. `ChangeStore::ensure_block_loaded_in_range` (`change_store.rs:1421`) -> `MemKvStore::scan` -> `SsTableIter::new_scan` (`sstable.rs:714`): the scan's start bound falls inside the giant block's key range, so the iterator constructor decoded the block only to seek past its single out-of-range key.
2. `ChangeStore::ensure_id_lte` (`change_store.rs:1467`), the backward predecessor scan: decoded the giant block to yield a (key, value) pair whose block was already parsed in `mem_parsed_kv`; the value was materialised and discarded.

Instrumented: exactly 2 raw block decodes per export before, 0 after.

## Fix

No cache-policy change, no encoding change, no public API change.

- `crates/kv-store/src/sstable.rs`: `SsTableIter::new_scan` resolves the start block from `BlockMeta.first_key/last_key` before decoding anything (`start_within_or_after_block`, `:670`). A block wholly before the range start is skipped undecoded; if the next block already starts past the end bound (or nothing follows), the scan returns a decode-free exhausted iterator (`SsTableIter::new_empty`, `:705`, backed by `BlockIter::new_empty` in `block.rs`). End-bound arms gain an `end_idx < table_idx -> empty` guard. Scan results are byte-identical: the skipped blocks could never contribute an entry.
- `crates/loro-internal/src/oplog/change_store.rs`: `ensure_id_lte` returns early when a `mem_parsed_kv` block of the same peer already covers the id. Same-peer blocks cover disjoint contiguous counter ranges and the external kv store is only written from parsed blocks (or the initial load, when nothing is parsed), so the kv store cannot hold a closer predecessor.

## Tests

Two fail-first tests, red on unmodified `main`, green with the fix:

- `loro-kv-store` `mem_store::tests::scan_does_not_decode_blocks_outside_its_bounds` (`crates/kv-store/src/mem_store.rs:646`): a repeated scan past an oversized block performs zero raw block decodes (test-only thread-local decode counter).
- `loro-internal` `export_updates_does_not_rescan_kv_for_covered_spans` (`crates/loro-internal/src/oplog/change_store.rs:2125`): steady-state `export(update)` never falls back to the external kv scan (test-only scan counter mirroring `root_history_scan_count`).

`cargo test -p loro-kv-store -p loro-internal -p loro`: all green. Touched files are rustfmt-clean.

## Memory (the concern #1049 addressed)

Re-ran #1049's own `crates/loro-wasm/scripts/measure-snapshot-round-memory.cjs` with a 796 KB snapshot, both scenarios: wasm linear-memory high-water unchanged at 67.0 MiB, maxRSS unchanged (~155 MiB). The `afterSnapshotImport` phase improves 50.9 -> 30.7 MiB wasm / 107.6 -> 92.0 MiB RSS because the import path stops decoding blocks its scans never needed. #1049's memory win is preserved.

## Not covered

A steady-state export whose in-range span itself spans more than 4 MiB of blocks would still re-decode per call (cache thrash inside the range proper). That would need value-lazy scans or per-table adaptive budgets and is out of scope here.

## References

- Regression introduced in `ac1feb61` (#1049 "perf: reduce snapshot round memory usage").
- Related closed: #992 (different mode).