### PR TITLE
fix: root shallow-snapshot exports of multi-id frontiers at a true common ancestor

### DIFF
--- a/crates/loro-internal/src/encoding/shallow_snapshot.rs
+++ b/crates/loro-internal/src/encoding/shallow_snapshot.rs
@@ -404,6 +404,18 @@ fn calc_shallow_doc_start(oplog: &crate::OpLog, frontiers: &Frontiers) -> Fronti
                 let (gca, _) = oplog
                     .dag()
                     .find_common_ancestor(&Frontiers::from(ids[i]), &Frontiers::from(ids[i + 1]));
+                if gca.is_empty() {
+                    // An empty meet is the bottom of the causal lattice: these two
+                    // heads share no history, so no non-empty version is an ancestor
+                    // of the whole cut. Dropping the empty meet from `next` instead
+                    // would let the remaining heads pose as their own "common
+                    // ancestor", yielding a shallow root that is NOT an ancestor of
+                    // the requested cut — a blob every later import of the other
+                    // branches' updates rejects with
+                    // `ImportUpdatesThatDependsOnOutdatedVersion`.
+                    // Fall back to empty frontiers, meaning export full history.
+                    return clamp_to_shallow_root(oplog, Frontiers::default());
+                }
                 for id in gca.iter() {
                     next.push(id);
                 }

--- a/crates/loro/tests/integration_test/shallow_snapshot_test.rs
+++ b/crates/loro/tests/integration_test/shallow_snapshot_test.rs
@@ -468,43 +468,54 @@ fn test_export_shallow_snapshot_from_shallow_doc() -> anyhow::Result<()> {
 
 /// Regression for a branch-specific import bug on `feat/diff-text-lca-review`.
 ///
-/// Setup: 3 peers each commit a few ops, then sync. Peer 1 then commits enough
-/// post-mid_f ops that `shallow_snapshot(&mid_f)` actually trims peer 1's
-/// pre-mid_f history (`shallow_since_vv = {1: 2}`,
-/// `shallow_since_frontiers = [2@1]`). A second peer commits one cross-peer op
-/// whose deps equal mid_f (`[2@1, 2@2, 2@3]`).
+/// Setup: p1 writes a shared base `R`; p2 and p3 fork from it and diverge
+/// concurrently; p1 merges both. `shallow_snapshot` at p1's two-head frontier
+/// picks their common ancestor `R` as the root, and p1's extra post-cut ops
+/// make the trim real (`shallow_since_frontiers = [R]`). A fourth peer that
+/// only ever saw the base then commits a cross-peer op whose deps ARE the
+/// boundary (`[R]`).
 ///
 /// The import preflight should not reuse checkout's conservative
 /// `is_before_shallow_root` semantics here: deps that touch the boundary
 /// together with valid same-or-other-peer post-shallow ids should be
 /// importable.
+///
+/// (This test originally built its shallow doc from three fully-disjoint
+/// heads, which only "trimmed" because the export kept a single peer's head
+/// as the root — a root that was not an ancestor of the cut. The export no
+/// longer produces that unsound root, so the setup now manufactures the same
+/// boundary shape from a sound common ancestor. The missing-peer mixture is
+/// still covered by the `import_deps_before_shallow_root_*` unit tests in
+/// `loro-internal/src/oplog/loro_dag.rs`.)
 #[test]
 fn shallow_doc_accepts_cross_peer_op_whose_deps_include_boundary() -> anyhow::Result<()> {
     let p1 = LoroDoc::new();
     p1.set_peer_id(1)?;
-    let p2 = LoroDoc::new();
-    p2.set_peer_id(2)?;
-    let p3 = LoroDoc::new();
-    p3.set_peer_id(3)?;
-
     for _ in 0..3 {
         p1.get_text("t").insert(0, "1")?;
         p1.commit();
+    }
+    let base = p1.export(ExportMode::all_updates())?;
+    let base_f = p1.oplog_frontiers();
+
+    // p2 and p3 fork from the base and diverge without ever syncing again.
+    let p2 = LoroDoc::new();
+    p2.set_peer_id(2)?;
+    p2.import(&base)?;
+    let p3 = LoroDoc::new();
+    p3.set_peer_id(3)?;
+    p3.import(&base)?;
+    for _ in 0..3 {
         p2.get_text("t").insert(0, "2")?;
         p2.commit();
         p3.get_text("t").insert(0, "3")?;
         p3.commit();
     }
-    let docs = [&p1, &p2, &p3];
-    for i in 0..3 {
-        for j in 0..3 {
-            if i != j {
-                docs[j].import(&docs[i].export(ExportMode::all_updates())?)?;
-            }
-        }
-    }
+    p1.import(&p2.export(ExportMode::all_updates())?)?;
+    p1.import(&p3.export(ExportMode::all_updates())?)?;
 
     let mid_f = p1.oplog_frontiers();
+    assert_eq!(mid_f.len(), 2, "the cut must be genuinely multi-id");
     for k in 0..5 {
         p1.get_text("t").insert(0, &format!("{k}"))?;
         p1.commit();
@@ -517,12 +528,20 @@ fn shallow_doc_accepts_cross_peer_op_whose_deps_include_boundary() -> anyhow::Re
         !s.shallow_since_vv().is_empty(),
         "test setup must produce a real shallow trim"
     );
+    assert_eq!(
+        s.shallow_since_frontiers(),
+        base_f,
+        "the root must be the common ancestor of the cut"
+    );
 
-    p2.get_text("t").insert(0, "Y")?;
-    p2.commit();
+    // p4 saw only the base, so its op's deps are exactly the shallow boundary.
+    let p4 = LoroDoc::new();
+    p4.set_peer_id(4)?;
+    p4.import(&base)?;
+    p4.get_text("t").insert(0, "Y")?;
+    p4.commit();
 
-    let p2_updates = p2.export(ExportMode::all_updates())?;
-    s.import(&p2_updates)
+    s.import(&p4.export(ExportMode::all_updates())?)
         .expect("shallow doc should accept cross-peer op whose deps include the shallow boundary");
 
     Ok(())
@@ -769,5 +788,244 @@ fn shallow_snapshot_redacts_dead_styles_for_all_non_both_expands() -> anyhow::Re
             "expand={expand:?}"
         );
     }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Multi-id-frontier shallow exports (the concurrent-client shape).
+//
+// Every existing test in this file takes the shallow cut on a doc whose
+// frontier is a single id. A doc that merges envelope streams from peers that
+// never import each other has a *genuinely multi-id* frontier, and the shallow
+// root the export picks must be a common ancestor of ALL of the cut's heads —
+// otherwise every later update from the other branches is rejected with
+// `ImportUpdatesThatDependsOnOutdatedVersion` (its deps can never cover the
+// bogus root's version), permanently wedging snapshot+tail hydration.
+// ---------------------------------------------------------------------------
+
+/// A peer that never imports anyone — every envelope stream is fully disjoint,
+/// so a doc merging them has one frontier head per peer.
+struct IsolatedPeer {
+    doc: LoroDoc,
+    from: loro::VersionVector,
+}
+
+impl IsolatedPeer {
+    fn new(peer: u64) -> Self {
+        let doc = LoroDoc::new();
+        doc.set_peer_id(peer).unwrap();
+        doc.set_record_timestamp(false);
+        Self {
+            from: doc.oplog_vv(),
+            doc,
+        }
+    }
+
+    /// Edit, commit, and return the update envelope since the last envelope.
+    fn envelope(&mut self, text: &str) -> Vec<u8> {
+        self.doc.get_text("t").insert(0, text).unwrap();
+        self.doc.commit();
+        let bytes = self.doc.export(ExportMode::updates(&self.from)).unwrap();
+        self.from = self.doc.oplog_vv();
+        bytes
+    }
+}
+
+/// The shallow root recorded in the blob must be a common ancestor of the
+/// requested cut. Before the fix, with three disjoint heads the export kept a
+/// single peer's head as the "root" (not an ancestor of the others at all).
+#[test]
+fn shallow_export_root_is_common_ancestor_of_multi_id_cut() -> anyhow::Result<()> {
+    let mut genesis = IsolatedPeer::new(0);
+    let mut a = IsolatedPeer::new(1);
+    let mut b = IsolatedPeer::new(2);
+
+    let server = LoroDoc::new();
+    for envelope in [
+        genesis.envelope("gggggggg"),
+        a.envelope("aaaaaaaa"),
+        b.envelope("bbbbbbbb"),
+    ] {
+        server.import(&envelope)?;
+    }
+    let cut = server.oplog_frontiers();
+    assert_eq!(cut.len(), 3, "the cut must be genuinely multi-id");
+
+    let blob = server.export(ExportMode::shallow_snapshot(&cut))?;
+    let meta = LoroDoc::decode_import_blob_meta(&blob, false)?;
+    let root_vv = server
+        .frontiers_to_vv(&meta.start_frontiers)
+        .expect("blob root must be reachable in the exporting doc");
+    for id in cut.iter() {
+        let head_vv = server.frontiers_to_vv(&Frontiers::from(id)).unwrap();
+        assert!(
+            head_vv.includes_vv(&root_vv),
+            "shallow root {:?} is not an ancestor of head {id} of the requested cut",
+            meta.start_frontiers,
+        );
+    }
+    Ok(())
+}
+
+/// Snapshot + post-cut tail must hydrate: a periodic-compaction model at the
+/// smallest scale that has the bug (two concurrent peers plus a genesis peer,
+/// one envelope each). Before the fix the tail import dies with
+/// `ImportUpdatesThatDependsOnOutdatedVersion`.
+#[test]
+fn shallow_export_at_multi_id_frontier_accepts_post_cut_tail() -> anyhow::Result<()> {
+    let mut genesis = IsolatedPeer::new(0);
+    let mut a = IsolatedPeer::new(1);
+    let mut b = IsolatedPeer::new(2);
+
+    let early = [
+        genesis.envelope("gggggggg"),
+        a.envelope("aaaaaaaa"),
+        b.envelope("bbbbbbbb"),
+    ];
+    let server = LoroDoc::new();
+    for envelope in &early {
+        server.import(envelope)?;
+    }
+    let cut = server.oplog_frontiers();
+    assert_eq!(cut.len(), 3, "the cut must be genuinely multi-id");
+    let blob = server.export(ExportMode::shallow_snapshot(&cut))?;
+
+    let hydrated = LoroDoc::new();
+    let status = hydrated.import(&blob)?;
+    assert!(status.pending.is_none(), "snapshot import parked: {status:?}");
+    assert_eq!(hydrated.get_deep_value(), server.get_deep_value());
+
+    // The post-cut tail: one more envelope per concurrent peer.
+    let tail = [a.envelope("AAAAAAAA"), b.envelope("BBBBBBBB")];
+    for envelope in &tail {
+        let status = hydrated.import(envelope)?;
+        assert!(status.pending.is_none(), "tail import parked: {status:?}");
+    }
+
+    let reference = LoroDoc::new();
+    for envelope in early.iter().chain(tail.iter()) {
+        reference.import(envelope)?;
+    }
+    assert_eq!(hydrated.get_deep_value(), reference.get_deep_value());
+    assert_eq!(hydrated.oplog_vv(), reference.oplog_vv());
+    Ok(())
+}
+
+/// The full compactor loop: every pass appends one envelope per peer, hydrates
+/// snapshot + tail into a fresh doc, and re-exports a shallow snapshot at the
+/// doc's own (multi-id) frontier. Before the fix pass 3 wedges — and every
+/// pass after it, forever.
+#[test]
+fn shallow_compaction_loop_survives_concurrent_peers() -> anyhow::Result<()> {
+    let mut genesis = IsolatedPeer::new(0);
+    let mut a = IsolatedPeer::new(1);
+    let mut b = IsolatedPeer::new(2);
+
+    let mut log: Vec<Vec<u8>> = vec![genesis.envelope("gggggggg")];
+    let mut snapshot: Option<Vec<u8>> = None;
+    let mut last: Option<LoroDoc> = None;
+    for pass in 0..4 {
+        log.push(a.envelope(&format!("a{pass:07}")));
+        log.push(b.envelope(&format!("b{pass:07}")));
+
+        // Hydrate: snapshot = single import into a fresh doc, then the tail.
+        let doc = LoroDoc::new();
+        if let Some(snapshot) = &snapshot {
+            let status = doc
+                .import(snapshot)
+                .map_err(|e| anyhow::anyhow!("pass {pass}: snapshot import: {e}"))?;
+            assert!(status.pending.is_none(), "pass {pass}: snapshot parked");
+        }
+        for envelope in &log {
+            let status = doc
+                .import(envelope)
+                .map_err(|e| anyhow::anyhow!("pass {pass}: tail import: {e}"))?;
+            assert!(status.pending.is_none(), "pass {pass}: tail parked");
+        }
+
+        let cut = doc.oplog_frontiers();
+        snapshot = Some(
+            doc.export(ExportMode::shallow_snapshot(&cut))
+                .map_err(|e| anyhow::anyhow!("pass {pass}: shallow export: {e}"))?,
+        );
+        log.clear();
+        last = Some(doc);
+    }
+
+    // The final hydrated doc carries every peer's whole stream.
+    let doc = last.unwrap();
+    let vv = doc.oplog_vv();
+    assert_eq!(vv.get(&0).copied(), Some(8));
+    assert_eq!(vv.get(&1).copied(), Some(32));
+    assert_eq!(vv.get(&2).copied(), Some(32));
+    Ok(())
+}
+
+/// The fix must not cost trimming where trimming is sound: when the concurrent
+/// heads share ancestry (clients fork from a common genesis and then diverge),
+/// the export still picks that common ancestor as the root and the blob is
+/// genuinely shallow — and the post-cut tail still hydrates.
+#[test]
+fn shallow_export_still_trims_when_concurrent_heads_share_ancestry() -> anyhow::Result<()> {
+    let base = LoroDoc::new();
+    base.set_peer_id(0)?;
+    base.set_record_timestamp(false);
+    base.get_text("t").insert(0, "gggggggg")?;
+    base.commit();
+    let genesis = base.export(ExportMode::all_updates())?;
+    let genesis_head = base.oplog_frontiers();
+
+    // Two clients fork from the genesis and never sync with each other again.
+    let make_client = |peer: u64| -> anyhow::Result<LoroDoc> {
+        let doc = LoroDoc::new();
+        doc.set_peer_id(peer)?;
+        doc.set_record_timestamp(false);
+        doc.import(&genesis)?;
+        Ok(doc)
+    };
+    let a = make_client(1)?;
+    let b = make_client(2)?;
+    let mut from_a = a.oplog_vv();
+    let mut from_b = b.oplog_vv();
+    a.get_text("t").insert(0, "aaaaaaaa")?;
+    a.commit();
+    b.get_text("t").insert(0, "bbbbbbbb")?;
+    b.commit();
+
+    let server = LoroDoc::new();
+    server.import(&genesis)?;
+    server.import(&a.export(ExportMode::updates(&from_a))?)?;
+    server.import(&b.export(ExportMode::updates(&from_b))?)?;
+    from_a = a.oplog_vv();
+    from_b = b.oplog_vv();
+    let cut = server.oplog_frontiers();
+    assert_eq!(cut.len(), 2, "the cut must be genuinely multi-id");
+
+    let blob = server.export(ExportMode::shallow_snapshot(&cut))?;
+    let meta = LoroDoc::decode_import_blob_meta(&blob, false)?;
+    assert_eq!(
+        meta.start_frontiers, genesis_head,
+        "the shared genesis is the greatest common ancestor of the cut"
+    );
+
+    let hydrated = LoroDoc::new();
+    hydrated.import(&blob)?;
+    assert!(hydrated.is_shallow(), "shared ancestry must still trim");
+    assert_eq!(hydrated.get_deep_value(), server.get_deep_value());
+
+    // Post-cut tail from both concurrent clients.
+    a.get_text("t").insert(0, "AAAAAAAA")?;
+    a.commit();
+    b.get_text("t").insert(0, "BBBBBBBB")?;
+    b.commit();
+    for envelope in [
+        a.export(ExportMode::updates(&from_a))?,
+        b.export(ExportMode::updates(&from_b))?,
+    ] {
+        let status = hydrated.import(&envelope)?;
+        assert!(status.pending.is_none(), "tail import parked: {status:?}");
+    }
+    assert_eq!(hydrated.oplog_vv().get(&1).copied(), Some(16));
+    assert_eq!(hydrated.oplog_vv().get(&2).copied(), Some(16));
     Ok(())
 }


### PR DESCRIPTION
## Problem

`export({ mode: "shallow-snapshot", frontiers })` with a multi-id frontier whose heads have fully disjoint histories produces a blob whose shallow root is not an ancestor of the requested cut. Two shapes, both reproduced on 1.13.7 through 1.15.1:

- 3 disjoint heads (two peers that never synced with each other, plus a third "genesis" peer): the blob's root becomes one of the heads (`7@1` in the test), one peer's counter is kept and everything else is truncated. Every later import of the other branches' updates fails `import_deps_before_shallow_root` (`crates/loro-internal/src/oplog/loro_dag.rs`) with `ImportUpdatesThatDependsOnOutdatedVersion`, and on 1.15.1 re-importing the blob itself into a fresh doc fails with "cannot switch to a version before the shallow history's start version". A periodic "hydrate, export shallow, hydrate" compaction loop wedges on its first pass.
- 4 disjoint heads: the blob silently degrades to full history: `isShallow()` is `false` while `decodeImportBlobMeta().mode` still says `shallow-snapshot`.

## Root cause

`calc_shallow_doc_start` (`crates/loro-internal/src/encoding/shallow_snapshot.rs:394`) reduces a multi-id frontier to a single-id shallow root by iterative pairwise `find_common_ancestor` (`:406`). A pair whose GCA is **empty** (disjoint histories) contributed nothing to the next round, so the surviving heads passed through as their own "common ancestor". With heads (h0, h1, h2): (h0, h1) -> {} drops out, h2 becomes the root. With four heads both pairs meet at {} and the result is the empty root (the documented full-history fallback), which is at least correct.

The shallow-root format is single-id-or-empty by design (`set_version_by_fast_snapshot_import` asserts `f.len() == 1`), so "root == the multi-id cut" is not reachable without an encoding change. The sound root for a multi-id cut is the true common ancestor of its heads.

## Fix

12 lines at one site. Inside the pairwise loop, an empty GCA is the bottom of the causal lattice: if any pair of heads shares no history, no non-empty version is a common ancestor of the whole cut, so return `clamp_to_shallow_root(oplog, Frontiers::default())` immediately (full-history export, the same arm the existing non-convergence case already takes, `:430`) instead of dropping the empty meet. Cuts whose heads share ancestry are untouched and still trim at their real common ancestor. Normal-op encoding is untouched; only the chosen shallow root of previously-unsound exports changes.

## Test changes

Four new tests in `crates/loro/tests/integration_test/shallow_snapshot_test.rs`, all red on unmodified `main`, all green with the fix:

- `shallow_export_root_is_common_ancestor_of_multi_id_cut`: 3 disjoint heads; base picked root `7@1`, not an ancestor of head `7@0`.
- `shallow_export_at_multi_id_frontier_accepts_post_cut_tail`: base died re-importing its own blob.
- `shallow_compaction_loop_survives_concurrent_peers`: 2 concurrent peers + genesis, 4 hydrate+export passes; base wedged at pass 1.
- `shallow_export_still_trims_when_concurrent_heads_share_ancestry`: shared-genesis forks keep a genuinely shallow blob (root = genesis head) whose post-cut tail imports.

One existing test changed: #974's `shallow_doc_accepts_cross_peer_op_whose_deps_include_boundary` manufactured its shallow doc from three fully-disjoint heads "trimming" to `[2@1]`, which was only possible via the unsound root removed here. Its setup now builds the same boundary shape soundly (two peers forking from a shared base; a fourth peer commits with deps equal to the boundary). The missing-peer dependency mixture it guarded stays covered by the `import_deps_before_shallow_root_*` unit tests in `loro_dag.rs`.

`cargo test -p loro-internal -p loro`: all green (`loro_rust_test` 192/192 incl. the rewritten test). Verified from the built npm package too: the compaction loop passes 4/4, shared-ancestry root round-trips, identical ops still produce identical `export({mode:'update'})` bytes.

## References

- Relates #1040 (import behaviour depends on the shape of the shallow root frontier); closed relatives #1012, #928, #924.
- The rewritten test is from #974.