### PR TITLE
fix: `importBatch` applies snapshot members instead of dropping their state

### DIFF
--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1479,6 +1479,44 @@ impl LoroDoc {
         });
 
         let (options, txn) = self.implicit_commit_then_stop();
+
+        // Relates #1066: a snapshot member cannot go
+        // through the detached batch lane below. That lane imports each blob as oplog
+        // changes only (`decode_oplog_changes`), which is sound for full snapshots
+        // (their oplog carries the whole history) but drops a SHALLOW snapshot's
+        // state contribution entirely: only its trimmed oplog window is decoded, the
+        // shallow-root state bytes are never read, so on a fresh doc every change in
+        // the window has unmet deps and the whole batch parks as pending — an empty
+        // doc, silently. When the doc can still be reset by a snapshot (empty, not
+        // mid-batch), peel the best snapshot member — the sort above puts it first —
+        // and import it through the regular snapshot lane while we hold the txn
+        // guard, exactly as `import()` would inside its barrier. The remaining blobs
+        // then run through the unchanged batch lane on top of the initialized doc,
+        // which is the documented-equivalent "import(snapshot) + import_batch(tail)"
+        // sequence. Member-error semantics are unchanged: `import_batch` already
+        // keeps prior members' progress when a later member fails.
+        if meta_arr[0].0.mode.is_snapshot() && self.can_reset_with_snapshot() {
+            let (_, data) = meta_arr.remove(0);
+            match self._import_with(data, Default::default()) {
+                Ok(s) => {
+                    for (peer, (start, end)) in s.success.iter() {
+                        success.insert(*peer, *start, *end);
+                    }
+                }
+                Err(e) => {
+                    self._renew_txn_if_auto_commit_with_guard(options, txn);
+                    return Err(e);
+                }
+            }
+            if meta_arr.is_empty() {
+                self._renew_txn_if_auto_commit_with_guard(options, txn);
+                return Ok(ImportStatus {
+                    success,
+                    pending: None,
+                });
+            }
+        }
+
         // Why we should keep locking `txn` here
         //
         // In a multi-threaded environment, `import_batch` used to drop the txn lock

--- a/crates/loro/tests/integration_test/import_batch_test.rs
+++ b/crates/loro/tests/integration_test/import_batch_test.rs
@@ -1,0 +1,207 @@
+//! `import_batch([snapshot, ...updates])` must produce the same
+//! document as importing the same blobs sequentially.
+//!
+//! At base 1.15.1 a shallow snapshot handed to `import_batch` on a FRESH doc is
+//! routed through the update lane (`decode_oplog` extracts only the trimmed oplog
+//! window; the shallow-root state bytes are never decoded), so every change in the
+//! window has unmet deps, everything parks as pending, and the doc stays empty —
+//! silently. Upstream #1066 fixed detached-mode stranding in the same path but not
+//! this. These tests pin batch ≡ sequential across the failure surface.
+
+use loro::{ExportMode, LoroDoc};
+
+/// Long single-peer history with a movable list — the fixture shape used by the fresh-doc cases below.
+/// Single peer ⇒ single-head frontier ⇒ the shallow cut is genuinely well-formed
+/// (shared ancestry; independent of the P2 multi-head shallow-root bug).
+fn build_long_history_doc(words: usize) -> LoroDoc {
+    let doc = LoroDoc::new();
+    doc.set_peer_id(1).unwrap();
+    let list = doc.get_movable_list("words");
+    for i in 0..words {
+        list.insert(i, format!("word{i}")).unwrap();
+        if i % 200 == 199 {
+            doc.commit();
+        }
+    }
+    doc.commit();
+    doc
+}
+
+/// Export a snapshot at the doc's current frontier plus `n_tail` single-commit
+/// update blobs made after the cut.
+fn snapshot_plus_tail(doc: &LoroDoc, shallow: bool, n_tail: usize) -> (Vec<u8>, Vec<Vec<u8>>) {
+    let snapshot = if shallow {
+        doc.export(ExportMode::shallow_snapshot(&doc.oplog_frontiers()))
+            .unwrap()
+    } else {
+        doc.export(ExportMode::Snapshot).unwrap()
+    };
+    let mut tail = Vec::new();
+    for i in 0..n_tail {
+        let vv = doc.oplog_vv();
+        doc.get_movable_list("words")
+            .set(i, format!("TAIL-{i}"))
+            .unwrap();
+        doc.commit();
+        tail.push(doc.export(ExportMode::updates(&vv)).unwrap());
+    }
+    (snapshot, tail)
+}
+
+/// Batch result must equal the sequential-import oracle, blob for blob.
+fn assert_batch_equals_sequential(blobs: &[Vec<u8>], source: &LoroDoc) {
+    let batched = LoroDoc::new();
+    let status = batched.import_batch(blobs).unwrap();
+
+    let sequential = LoroDoc::new();
+    for b in blobs {
+        sequential.import(b).unwrap();
+    }
+
+    assert_eq!(
+        batched.get_deep_value(),
+        sequential.get_deep_value(),
+        "batched state != sequential state"
+    );
+    assert_eq!(batched.oplog_frontiers(), sequential.oplog_frontiers());
+    assert_eq!(batched.state_frontiers(), sequential.state_frontiers());
+    assert_eq!(batched.get_deep_value(), source.get_deep_value());
+    assert_eq!(batched.oplog_frontiers(), source.oplog_frontiers());
+    assert!(
+        status.pending.is_none(),
+        "nothing may park as pending, got {:?}",
+        status.pending
+    );
+    assert!(!batched.is_detached(), "import_batch must leave the doc attached");
+}
+
+/// The core scenario: fresh doc, batch = [shallow snapshot, tail updates].
+/// RED on base 5c6b9f6f: empty doc, empty success, whole tail pending.
+#[test]
+fn import_batch_shallow_snapshot_plus_tail_into_fresh_doc() {
+    let doc = build_long_history_doc(500);
+    let (snapshot, tail) = snapshot_plus_tail(&doc, true, 2);
+    let mut blobs = vec![snapshot];
+    blobs.extend(tail);
+    assert_batch_equals_sequential(&blobs, &doc);
+}
+
+/// Member order must not matter (`import_batch` docs: "data can be in arbitrary
+/// order") — the snapshot placed LAST must still be applied first via sorting.
+/// (The oracle is the source doc / snapshot-first batch, not same-order
+/// sequential imports: plain sequential `import` is order-sensitive by design.)
+#[test]
+fn import_batch_shallow_snapshot_last_in_batch() {
+    let doc = build_long_history_doc(300);
+    let (snapshot, tail) = snapshot_plus_tail(&doc, true, 2);
+    let mut blobs = tail;
+    blobs.push(snapshot);
+
+    let batched = LoroDoc::new();
+    let status = batched.import_batch(&blobs).unwrap();
+
+    assert_eq!(batched.get_deep_value(), doc.get_deep_value());
+    assert_eq!(batched.oplog_frontiers(), doc.oplog_frontiers());
+    assert!(status.pending.is_none());
+    assert!(!batched.is_detached());
+}
+
+/// Full (non-shallow) snapshot + tail into a fresh doc — does the bug hit full
+/// snapshots too? (Full snapshots carry the whole oplog, so the update lane can
+/// reconstruct them; this arm maps the failure surface either way.)
+#[test]
+fn import_batch_full_snapshot_plus_tail_into_fresh_doc() {
+    let doc = build_long_history_doc(300);
+    let (snapshot, tail) = snapshot_plus_tail(&doc, false, 2);
+    let mut blobs = vec![snapshot];
+    blobs.extend(tail);
+    assert_batch_equals_sequential(&blobs, &doc);
+}
+
+/// Mixed batch into a NON-empty doc that already holds the history below the cut:
+/// the shallow window's deps are satisfied, so batch must equal sequential here too.
+#[test]
+fn import_batch_shallow_snapshot_plus_tail_into_doc_with_history() {
+    let doc = build_long_history_doc(300);
+    let pre_cut = doc.export(ExportMode::Snapshot).unwrap();
+    let (snapshot, tail) = snapshot_plus_tail(&doc, true, 2);
+    let mut blobs = vec![snapshot];
+    blobs.extend(tail);
+
+    let batched = LoroDoc::new();
+    batched.import(&pre_cut).unwrap();
+    let status = batched.import_batch(&blobs).unwrap();
+
+    let sequential = LoroDoc::new();
+    sequential.import(&pre_cut).unwrap();
+    for b in &blobs {
+        sequential.import(b).unwrap();
+    }
+
+    assert_eq!(batched.get_deep_value(), sequential.get_deep_value());
+    assert_eq!(batched.oplog_frontiers(), sequential.oplog_frontiers());
+    assert_eq!(batched.get_deep_value(), doc.get_deep_value());
+    assert!(status.pending.is_none());
+    assert!(!batched.is_detached());
+}
+
+/// Sequential import stays equivalent: single snapshot import, then a pure-update
+/// batch — and that equals the mixed batch after the fix.
+#[test]
+fn import_batch_snapshot_then_update_batch_equivalence() {
+    let doc = build_long_history_doc(300);
+    let (snapshot, tail) = snapshot_plus_tail(&doc, true, 3);
+
+    let hydrated = LoroDoc::new();
+    hydrated.import(&snapshot).unwrap();
+    let status = hydrated.import_batch(&tail).unwrap();
+    assert!(status.pending.is_none());
+
+    let mut blobs = vec![snapshot];
+    blobs.extend(tail);
+    let batched = LoroDoc::new();
+    batched.import_batch(&blobs).unwrap();
+
+    assert_eq!(batched.get_deep_value(), hydrated.get_deep_value());
+    assert_eq!(batched.oplog_frontiers(), hydrated.oplog_frontiers());
+    assert_eq!(
+        batched.export(ExportMode::Snapshot).unwrap(),
+        hydrated.export(ExportMode::Snapshot).unwrap()
+    );
+}
+
+/// Pure-update batches are the hot tail path for incremental sync: bytes and semantics must
+/// not move. Same ops through the batch lane on two docs ⇒ identical exports.
+#[test]
+fn import_batch_pure_updates_unchanged_and_deterministic() {
+    let doc = build_long_history_doc(50);
+    let mut updates = Vec::new();
+    for i in 0..3 {
+        let vv = doc.oplog_vv();
+        doc.get_movable_list("words")
+            .set(i, format!("edit{i}"))
+            .unwrap();
+        doc.commit();
+        updates.push(doc.export(ExportMode::updates(&vv)).unwrap());
+    }
+
+    let a = LoroDoc::new();
+    let base = doc.export(ExportMode::updates(&Default::default())).unwrap();
+    // History below the tail delivered as one update blob, then the tail batch —
+    // updates-only batches, both docs.
+    let b = LoroDoc::new();
+    for d in [&a, &b] {
+        d.import(&base).unwrap();
+        let st = d.import_batch(&updates).unwrap();
+        assert!(st.pending.is_none());
+    }
+    assert_eq!(a.get_deep_value(), doc.get_deep_value());
+    assert_eq!(
+        a.export(ExportMode::Snapshot).unwrap(),
+        b.export(ExportMode::Snapshot).unwrap()
+    );
+    assert_eq!(
+        a.export(ExportMode::updates(&Default::default())).unwrap(),
+        b.export(ExportMode::updates(&Default::default())).unwrap()
+    );
+}

--- a/crates/loro/tests/integration_test/mod.rs
+++ b/crates/loro/tests/integration_test/mod.rs
@@ -1,6 +1,7 @@
 use loro::LoroDoc;
 
 mod detached_editing_test;
+mod import_batch_test;
 mod event_test;
 #[cfg(feature = "jsonpath")]
 mod jsonpath_test;


### PR DESCRIPTION
## Problem

`doc.importBatch([shallowSnapshotBytes, ...tailUpdateBytes])` into a **fresh** doc yields an empty doc: `status.success` is empty, `status.pending` holds the snapshot peer, `toJSON()` is `{}`, `frontiers()` is `[]`, and nothing is reported. The `importBatch` docstring's own example (`doc2.importBatch([snapshot, updates])`) does not hold for shallow snapshots. Reproduced on 1.13.7 through 1.15.1 (so #1066 did not cover it, see below).

Measured on a 500-word doc through the npm package: before, `success.size = 0`, `pending = Map{ "1" }`, `{}`; after, `success` covers peer 1, `pending = null`, full doc, frontiers `[{peer:"1", counter:501}]`, equal to `import(snapshot); importBatch(tail)` and to the source doc.

## Root cause

`import_batch` (`crates/loro-internal/src/loro.rs:1461`) force-detaches the doc and pushes every member through the update-import lane (`import_changes_and_apply_delta_to_state_if_needed` -> `decode_oplog_changes`), which for a FastSnapshot blob extracts only the `oplog_bytes` section of the body. That is sound for **full** snapshots (their oplog carries the whole history; the closing reattach rebuilds state), but a **shallow** snapshot's body is `{trimmed oplog window, state_bytes, shallow_root_state_bytes}` and the update lane never reads the two state sections. On a fresh doc every change in the trimmed window has unmet deps (they reach below the cut, into history the blob carries only as state), so the window and the entire tail behind it park as pending.

Failure surface (all mapped in the new integration test):

| batch | fresh doc | doc already holding pre-cut history |
|---|---|---|
| shallow snapshot + tail (any member order) | **empty doc** | works |
| full snapshot + tail | works | works |
| pure updates | works | works |

## Fix

One insertion in `import_batch` (~25 lines, `loro.rs:1498`): after the existing mode sort and `implicit_commit_then_stop()`, if the first sorted member is a snapshot and `can_reset_with_snapshot()` holds (empty doc, not mid-batch), peel that member and run it through the regular snapshot lane (`_import_with` -> `decode_snapshot`, which reads all three body sections) while the txn guard is held, which is exactly what `import()` does inside its barrier. The remaining members then run through the unchanged detached batch machinery on top of the initialised doc: the documented-good `import(snapshot); importBatch(tail)` sequence, inside one txn-guard hold.

Atomicity is not weakened: `import_batch` was never member-atomic (a member `Err` keeps other members' progress; only a failed closing reattach rolls the batch back), and the peel errors out before any batch state exists. Non-empty docs, full snapshots and pure-update batches take exactly the code they took before; no encode path changed.

## Tests

`crates/loro/tests/integration_test/import_batch_test.rs` (new, 6 tests): 3 red on unmodified `main` (fresh-doc shallow batch in both member orders, mixed-vs-sequential equivalence), all 6 green with the fix; the other 3 pin the cases that already worked. `cargo test -p loro-internal -p loro`: all 30 test binaries green, no new warnings. Verified from the built npm package: `import + importBatch(tail)` = sequential = mixed batch (snapshot first and last) = source doc; pure-update batch determinism unchanged (identical ops -> identical exported bytes).

## References

- Relates #1066 ("import_batch must never exit in detached mode"): same code region, fixed detached-mode stranding on this path but never touched the member routing, so this shape still failed after it.