### PR TITLE
fix: keep no-op `checkout` from re-attaching a detached doc (#1048), plus a regression test for #1046

### DIFF
--- a/.changeset/noop-checkout-stays-detached.md
+++ b/.changeset/noop-checkout-stays-detached.md
@@ -1,0 +1,10 @@
+---
+"loro-crdt": patch
+---
+
+Fix `checkout()` to the frontiers a detached doc is already at silently
+re-attaching the doc (1.13.6 -> 1.13.7 regression). Detached is an explicit
+mode: it is entered via `checkout` and left via `checkoutToLatest`/`attach`.
+The no-op early return no longer derives the attached flag from the oplog
+frontiers, so `isDetached()` at HEAD no longer depends on how the doc got
+there.

--- a/crates/loro-internal/src/loro.rs
+++ b/crates/loro-internal/src/loro.rs
@@ -1745,7 +1745,18 @@ impl LoroDoc {
         );
 
         if &from_frontiers == frontiers {
-            self.set_detached(frontiers != &self.oplog_frontiers());
+            // Deriving the attached/detached flag here must only go in the
+            // detaching direction. Detached is an explicit mode: it is entered
+            // via `checkout` and left via `checkout_to_latest`/`attach`, which
+            // clear the flag themselves after this returns. Re-attaching a
+            // detached doc just because it is parked at the oplog frontiers
+            // would make `is_detached()` at HEAD depend on how the doc got
+            // there (a no-op checkout vs. a checkout that lands on HEAD), and
+            // silently resumes auto-commit while the user believes the doc is
+            // still in history view (#1048).
+            if frontiers != &self.oplog_frontiers() {
+                self.set_detached(true);
+            }
             return Ok(());
         }
 

--- a/crates/loro/tests/issue.rs
+++ b/crates/loro/tests/issue.rs
@@ -809,3 +809,43 @@ fn issue_1046_movable_list_delete_vs_edit_then_move_as_two_batches() {
         .unwrap();
     assert_eq!(fresh.get_deep_value(), pa.get_deep_value());
 }
+
+/// https://github.com/loro-dev/loro/issues/1048
+///
+/// `checkout()` to the frontiers a detached doc is already at must keep the doc
+/// detached. On 1.13.7 (a one-line change in #974's `b81abfc`) the no-op early
+/// return started deriving the detached flag from `frontiers == oplog_frontiers()`,
+/// so a doc parked at HEAD silently re-attached — while a normal checkout that
+/// *lands* on HEAD stays detached. Detached is an explicit mode, left only via
+/// `checkout_to_latest()`/`attach()` (the 1.13.6 behavior).
+#[test]
+fn issue_1048_checkout_to_current_frontiers_should_stay_detached() {
+    let doc = LoroDoc::new();
+    let text = doc.get_text("t");
+    let mut checkpoints = Vec::new();
+    for (i, ch) in ["a", "b", "c"].iter().enumerate() {
+        text.insert(i, ch).unwrap();
+        doc.commit();
+        checkpoints.push(doc.oplog_frontiers());
+    }
+
+    // Scrub forward through every checkpoint: each checkout detaches the doc.
+    for f in &checkpoints {
+        doc.checkout(f).unwrap();
+        assert!(doc.is_detached());
+    }
+
+    // The forward pass ended at HEAD, so scrubbing back starts by re-checking-out
+    // the frontiers the doc already occupies. It must stay detached.
+    for f in checkpoints.iter().rev() {
+        doc.checkout(f).unwrap();
+        assert!(
+            doc.is_detached(),
+            "checkout({f:?}) to the current frontiers re-attached the doc"
+        );
+    }
+
+    // Explicit re-attach still works.
+    doc.checkout_to_latest();
+    assert!(!doc.is_detached());
+}

--- a/crates/loro/tests/issue.rs
+++ b/crates/loro/tests/issue.rs
@@ -718,3 +718,94 @@ fn checkout_with_low_lamport_concurrent_branch_stays_canonical() {
     d.checkout(&v2).unwrap(); // and retreat it again
     assert_eq!(d.get_deep_value(), ref2.get_deep_value());
 }
+
+/// https://github.com/loro-dev/loro/issues/1046
+///
+/// A movable list of containers takes a delete on one peer concurrently with an
+/// edit-then-move of the same element on another peer. When the edit and the move
+/// arrive as two *separate* update batches, importing the second batch used to
+/// panic (`unwrap` on `None` in `movable_list_state.rs`) and poison the doc mutex.
+/// Regression introduced by #974; importing both commits as one batch is fine.
+#[test]
+fn issue_1046_movable_list_delete_vs_edit_then_move_as_two_batches() {
+    use loro::{Container, LoroMap, LoroValue, ValueOrContainer};
+
+    fn index_of(d: &LoroDoc, id: &str) -> Option<usize> {
+        let l = d.get_movable_list("list");
+        (0..l.len()).find(|&i| match l.get(i) {
+            Some(ValueOrContainer::Container(Container::Map(m))) => match m.get("id") {
+                Some(ValueOrContainer::Value(v)) => v == LoroValue::from(id),
+                _ => false,
+            },
+            _ => false,
+        })
+    }
+
+    fn map_at(d: &LoroDoc, idx: usize) -> LoroMap {
+        match d.get_movable_list("list").get(idx) {
+            Some(ValueOrContainer::Container(Container::Map(m))) => m,
+            _ => panic!("expected map container"),
+        }
+    }
+
+    // Base doc: a movable list of two map containers, tagged "a" and "c".
+    let base = LoroDoc::new();
+    base.set_peer_id(1).unwrap();
+    let list = base.get_movable_list("list");
+    for tag in ["a", "c"] {
+        let m = list.insert_container(list.len(), LoroMap::new()).unwrap();
+        m.insert("id", tag).unwrap();
+    }
+    base.commit();
+    let snap = base.export(ExportMode::Snapshot).unwrap();
+
+    let mk = |peer: u64| {
+        let d = LoroDoc::new();
+        d.import(&snap).unwrap();
+        d.set_peer_id(peer).unwrap();
+        d.commit();
+        d
+    };
+    let pa = mk(0xA0);
+    let pb = mk(0xA1);
+
+    // Peer A: delete "c".
+    pa.get_movable_list("list")
+        .delete(index_of(&pa, "c").unwrap(), 1)
+        .unwrap();
+    pa.commit();
+
+    // Peer B, commit 1: edit c's map.
+    let v0 = pb.oplog_vv();
+    map_at(&pb, index_of(&pb, "c").unwrap())
+        .insert("contents", "zombie")
+        .unwrap();
+    pb.commit();
+    let b_edit = pb.export(ExportMode::updates(&v0)).unwrap();
+
+    // Peer B, commit 2: move c to the front.
+    let v1 = pb.oplog_vv();
+    pb.get_movable_list("list")
+        .mov(index_of(&pb, "c").unwrap(), 0)
+        .unwrap();
+    pb.commit();
+    let b_move = pb.export(ExportMode::updates(&v1)).unwrap();
+
+    // Importing the move as a second, separate batch used to panic here.
+    pa.import(&b_edit).unwrap();
+    pa.import(&b_move).unwrap();
+
+    // Full sync in both directions; peers must converge.
+    pb.import(&pa.export(ExportMode::updates(&pb.oplog_vv())).unwrap())
+        .unwrap();
+    pa.import(&pb.export(ExportMode::updates(&pa.oplog_vv())).unwrap())
+        .unwrap();
+    assert_eq!(pa.get_deep_value(), pb.get_deep_value());
+
+    // The converged state must match a fresh-doc replay of the same ops.
+    let fresh = LoroDoc::new();
+    fresh
+        .import(&pa.export(ExportMode::all_updates()).unwrap())
+        .unwrap();
+    assert_eq!(fresh.get_deep_value(), pa.get_deep_value());
+}


### PR DESCRIPTION
Two commits: the #1048 fix with its test, and a test-only pin for #1046 (already fixed on `main` by #1058; the issue is still open).

## #1048: `checkout()` to the current frontiers re-attaches a detached doc

### Problem

On 1.13.6 a detached doc that called `checkout(f)` with `f` equal to its current frontiers stayed detached. Since 1.13.7 it silently re-attaches whenever those frontiers are also the oplog frontiers. An editor that drives read-only state off `isDetached()` while the user scrubs a history timeline becomes writable (and resumes auto-commit) when the user re-selects the entry they are already parked on. Reporter bisected it to `b81abfc` (#974).

### Root cause

`b81abfc` added one line to the no-op early return of `_checkout_without_emitting_with_event` (`crates/loro-internal/src/loro.rs:1748`):

```rust
if &from_frontiers == frontiers {
    self.set_detached(frontiers != &self.oplog_frontiers());
    return Ok(());
}
```

Only the no-op path derives the flag this way; a normal checkout that *lands* on HEAD still sets detached unconditionally, so `isDetached()` at HEAD depended on how the doc got there. Detached is an explicit mode elsewhere in the API: entered via `checkout`, left via `checkout_to_latest`/`attach`, which clear the flag themselves after this function returns (`_checkout_to_latest_without_commit_with_event` sets `detached = false` itself), so neither needed the derived line.

### Fix

Restrict the no-op path to the detaching direction: a doc whose state frontiers differ from the oplog frontiers is still (defensively) marked detached, preserving whatever desync-healing #974 intended, but a detached doc parked at HEAD is never silently re-attached. Restores the 1.13.6 semantics.

### Test

`issue_1048_checkout_to_current_frontiers_should_stay_detached` in `crates/loro/tests/issue.rs`: the reporter's JS repro translated to Rust, a forward then reverse scrub over three checkpoints. Red on unmodified `main` at the first reverse step, green with the fix; explicit `checkout_to_latest()` still re-attaches.

## #1046: movable-list panic on delete vs concurrent edit-then-move as two batches (test only)

A movable list of containers taking a delete on one peer concurrently with an edit-then-move of the same element on another peer panicked (`unwrap` on `None`, `movable_list_state.rs:1210`, the `value_id.unwrap()` in the create-new-element arm of `apply_diff_and_convert`) when the edit and the move arrived as two separate update batches; the panic poisons the doc mutex and the process aborts on drop. Root cause: #974 made the diff calc treat the second batch as a concurrent-import replay whose element diff carries `value_id: None` while the element was already deleted from the target state.

Verified by running the issue's repro at three points: crates.io `loro 1.13.7` + `loro-internal =1.13.7` panics; the tree at `ddc47ecc^` panics; current `main` passes. `ddc47ecc` ("fix: avoid false concurrent import replay", #1058) is the only commit touching `diff_calc.rs`/`movable_list_state.rs` after #974 and fixes it. #1046 can be closed against #1058.

`issue_1046_movable_list_delete_vs_edit_then_move_as_two_batches` (test only, no code change): the two-batch import must not panic, both peers converge, and the converged state equals a fresh-doc replay.

## Validation

`cargo test -p loro --test issue` and `cargo test -p loro-internal`: green. Neither commit touches an encode path; identical op runs still produce byte-identical exports.

## References

- Fixes #1048. Pins #1046 (fixed by #1058). Both regressions introduced by #974 (`b81abfc`).