### PR TITLE
fix: return `Err` instead of panicking when an imported update's deps were folded into a shallow snapshot (#1068)

### DIFF
--- a/.changeset/folded-deps-import-err.md
+++ b/.changeset/folded-deps-import-err.md
@@ -1,0 +1,10 @@
+---
+"loro-crdt": patch
+---
+
+Fix `import()` panicking (and poisoning the doc, aborting the process on
+drop) when a remote update depends on ops that were folded into a shallow
+snapshot. Such updates now fail cleanly with
+`ImportUpdatesThatDependsOnOutdatedVersion`, and the unknown-lamport pending
+path parks rather than panics if a folded dependency is only discovered at
+apply time.

--- a/crates/loro-internal/src/oplog/loro_dag.rs
+++ b/crates/loro-internal/src/oplog/loro_dag.rs
@@ -802,6 +802,19 @@ impl AppDag {
             return true;
         }
 
+        // A dep covered by `shallow_since_vv` was folded into the shallow
+        // snapshot: its DAG node is trimmed, so a change depending on it can
+        // never compute its lamport here. This must be checked before
+        // `frontiers_to_vv`, whose `shallow_root_frontiers_deps` fast path
+        // resolves exactly those folded deps and would misclassify such a
+        // change as importable — it then panics later in the unknown-lamport
+        // pending path (#1068). Note the retained root node itself is NOT
+        // covered by `shallow_since_vv`, so deps that touch the boundary node
+        // are unaffected.
+        if deps.iter().any(|id| self.shallow_since_vv.includes_id(id)) {
+            return true;
+        }
+
         let shallow_vv = VersionVector::from_im_vv(&self.shallow_since_vv);
         if let Some(vv) = self.frontiers_to_vv(deps) {
             return !vv.includes_vv(&shallow_vv);
@@ -810,15 +823,10 @@ impl AppDag {
         // Import only needs to reject updates whose causal source is older than
         // the shallow root. A dependency set that touches the retained boundary
         // can still be a valid post-root update, even when the rest of the deps
-        // are imported later in the same batch.
-        if deps
-            .iter()
-            .any(|id| self.shallow_since_frontiers.contains(&id))
-        {
-            return false;
-        }
-
-        deps.iter().any(|id| self.shallow_since_vv.includes_id(id))
+        // are imported later in the same batch. Deps that are neither folded
+        // (checked above) nor resolvable are future ops the doc has not seen;
+        // they are importable and will be parked as pending.
+        false
     }
 
     /// Travel the ancestors of the given id, and call the callback for each node

--- a/crates/loro-internal/src/oplog/pending_changes.rs
+++ b/crates/loro-internal/src/oplog/pending_changes.rs
@@ -360,7 +360,7 @@ enum ChangeState {
 
 fn remote_change_apply_state(
     vv: &VersionVector,
-    _shallow_vv: &ImVersionVector,
+    shallow_vv: &ImVersionVector,
     change: &Change,
 ) -> ChangeState {
     let peer = change.id.peer;
@@ -377,6 +377,17 @@ fn remote_change_apply_state(
     for dep in change.deps.iter() {
         let dep_vv_latest_ctr = vv.get(&dep.peer).copied().unwrap_or(0);
         if dep_vv_latest_ctr - 1 < dep.counter {
+            return ChangeState::AwaitingMissingDependency(dep);
+        }
+
+        // The dep is covered by the doc's version, but if it lies below the
+        // shallow root its DAG node was trimmed and the change's lamport can
+        // never be computed here. Claiming `CanApplyDirectly` would panic in
+        // `apply_change_from_remote`'s lamport calculation (#1068); park the
+        // change instead. Imports of such changes are normally rejected up
+        // front by `import_deps_before_shallow_root`, so this only guards
+        // changes that were parked as pending before the doc became shallow.
+        if shallow_vv.includes_id(dep) {
             return ChangeState::AwaitingMissingDependency(dep);
         }
     }

--- a/crates/loro/tests/issue.rs
+++ b/crates/loro/tests/issue.rs
@@ -718,3 +718,64 @@ fn checkout_with_low_lamport_concurrent_branch_stays_canonical() {
     d.checkout(&v2).unwrap(); // and retreat it again
     assert_eq!(d.get_deep_value(), ref2.get_deep_value());
 }
+
+/// https://github.com/loro-dev/loro/issues/1068
+///
+/// Importing a remote update whose dependencies were folded into a shallow
+/// snapshot used to panic inside `OpLog` (`calc_unknown_lamport_change(..).unwrap()`
+/// in `pending_changes.rs`: the dep is covered by the vv but its DAG node was
+/// trimmed, so no lamport can be computed). The panic poisons the doc mutex and
+/// dropping the doc double-panics, aborting the process. It must return `Err`.
+#[test]
+fn issue_1068_import_dep_folded_into_shallow_snapshot_errs_instead_of_panicking() {
+    use loro::IdSpan;
+
+    // Peer B writes one op and publishes it.
+    let b = LoroDoc::new();
+    b.set_peer_id(2).unwrap();
+    b.get_map("m").insert("k0", "v0").unwrap();
+    b.commit();
+    let b0 = b.export(ExportMode::all_updates()).unwrap();
+
+    // Peer A imports it, writes its own op, then exports a shallow snapshot
+    // starting at A's current frontier — so B's op is folded into the state.
+    let a = LoroDoc::new();
+    a.set_peer_id(1).unwrap();
+    a.import(&b0).unwrap();
+    a.get_map("m").insert("k1", "v1").unwrap();
+    a.commit();
+    let snapshot = a
+        .export(ExportMode::shallow_snapshot(&a.oplog_frontiers()))
+        .unwrap();
+
+    // B continues from its own op 0.
+    b.get_map("m").insert("k2", "v2").unwrap();
+    b.commit();
+    let b1 = b
+        .export(ExportMode::updates_in_range(vec![IdSpan::new(2, 1, 2)]))
+        .unwrap();
+
+    // A fresh doc bootstrapped from the shallow snapshot.
+    let fresh = LoroDoc::new();
+    fresh.import(&snapshot).unwrap();
+    fresh.set_peer_id(9).unwrap();
+
+    // Must be a recoverable error, not a panic.
+    let result = fresh.import(&b1);
+    assert!(
+        matches!(
+            result,
+            Err(LoroError::ImportUpdatesThatDependsOnOutdatedVersion)
+        ),
+        "import of an update with deps folded into the shallow snapshot \
+         should return Err, got {result:?}"
+    );
+
+    // The doc must remain usable afterwards (mutex not poisoned).
+    fresh.get_map("m").insert("k3", "v3").unwrap();
+    fresh.commit();
+    assert!(fresh
+        .get_map("m")
+        .get("k3")
+        .is_some_and(|v| !v.is_container()));
+}


### PR DESCRIPTION
## Problem

Importing a remote update whose dependencies were folded into a shallow snapshot panics inside `OpLog` (`called Result::unwrap() on an Err value: ()`, `crates/loro-internal/src/oplog/pending_changes.rs:338` in `apply_change_from_remote`) instead of returning `Err`. The panic poisons the doc mutex, so dropping the doc double-panics and aborts the process; a sync engine that truncates history with shallow snapshots and imports per-peer update ranges cannot even `catch_unwind` its way out. Still present on `main` after #1064. Regression from #974's "allow shallow imports at dependency boundary".

## Root cause (two coupled holes)

1. `import_deps_before_shallow_root()` (`crates/loro-internal/src/oplog/loro_dag.rs:~790`) is the classifier that should reject changes depending on trimmed history. Its final check does exactly that, but it first consults `frontiers_to_vv()`, whose fast path resolves deps equal to `shallow_root_frontiers_deps` (the trimmed deps *of* the retained root node) to `shallow_since_vv`. A change concurrent with the shallow root, all of whose deps are folded, therefore resolved to a vv that trivially includes `shallow_since_vv` and was classified importable, although its lamport is incomputable (the dep DAG nodes are gone).
2. Such a change then lands in the unknown-lamport pending path. `remote_change_apply_state()` (`pending_changes.rs:361`) received the shallow vv but ignored it (`_shallow_vv`), saw the deps covered by the doc version, claimed `CanApplyDirectly`, and `calc_unknown_lamport_change().unwrap()` panicked.

Deps that touch the **retained** root node are fine (its lamport exists); deps strictly below it are not.

## Fix

1. `import_deps_before_shallow_root()`: check deps against `shallow_since_vv` (the folded region) **before** the `frontiers_to_vv` fast path. Such imports now fail up front with the existing `ImportUpdatesThatDependsOnOutdatedVersion` error through the existing preflight/rollback plumbing (arena rollback included), matching how other before-shallow-root deps are already reported. The retained root is not covered by `shallow_since_vv`, so boundary deps are unaffected; #974's own `shallow_doc_accepts_cross_peer_op_whose_deps_include_boundary` stays green. The trailing `shallow_since_frontiers.contains` / `shallow_since_vv.includes_id` tail becomes `false` (unresolvable, non-folded deps are future ops that get parked as pending, as before).
2. `remote_change_apply_state()`: use the shallow vv; a dep covered by it can never yield a lamport, so the change is parked as `AwaitingMissingDependency` instead of claiming `CanApplyDirectly`. This guards the remaining corner where a change was parked as pending *before* the doc became shallow (classification never saw it).

The deeper fix, actually applying such updates by recovering lamports across the boundary, is explicitly out of scope; this is the panic -> `Err` the issue asks for.

## Test

`issue_1068_import_dep_folded_into_shallow_snapshot_errs_instead_of_panicking` in `crates/loro/tests/issue.rs`: the issue's Rust repro, asserting `Err(LoroError::ImportUpdatesThatDependsOnOutdatedVersion)` and that the doc stays usable afterwards (mutex not poisoned). Red on unmodified `main` (SIGABRT via the poisoned-mutex double panic), green with the fix.

`cargo test -p loro-internal -p loro`: green, including the `import_deps_before_shallow_root_*` unit tests in `loro_dag.rs` and the #974 boundary test. No encode path touched.

## References

- Fixes #1068. Regression from #974 (`b81abfc`). Related: #1040 (shallow-root import classification, same area).