### PR TITLE
perf(wasm): cache container kind() on JS wrappers

### DIFF
--- a/.changeset/wasm-kind-cache.md
+++ b/.changeset/wasm-kind-cache.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+perf: cache `kind()` results on container wrappers. `kind()` returns a constant string per container class; it is now memoized after the first call, so repeated reads (e.g. tree traversal in loro-mirror) no longer cross into WASM or allocate a fresh JS string. This extends the existing `id` cache to `kind()`.

--- a/context/wasm-container-id-cache.md
+++ b/context/wasm-container-id-cache.md
@@ -1,10 +1,11 @@
 # WASM container id cache
 
-Verified against code 2026-08-29.
+Verified against code 2026-09-04.
 
 `LoroMap`, `LoroList`, `LoroText`, `LoroTree`, `LoroMovableList`, and
 `LoroCounter` expose `id` from Rust through wasm-bindgen. The generated getter
-crosses into WASM and creates a new JS string on every call.
+crosses into WASM and creates a new JS string on every call. The same holds for
+`kind()`, which returns a constant string per container class.
 
 ## Identity and lifetime
 
@@ -25,6 +26,13 @@ non-enumerable, module-private Symbol property on the JS wrapper. It clears the
 property during `__destroy_into_raw()` and bypasses the cache for a zero
 pointer. The cache has exactly the wrapper's lifetime and does not retain the
 wrapper from another object.
+
+`kind()` is memoized once per container class (the value is class-constant, so
+no per-wrapper entry is needed). Both the id cache and the kind memo bypass the
+cache for a zero `__wbg_ptr`, so reads after `free()` keep raising
+wasm-bindgen's null-pointer error. Rust-side `kind()` reads
+(`js_to_container` in `src/convert.rs`) go through the same patched prototype
+method and share the memo.
 
 ## Package targets and checks
 

--- a/crates/loro-wasm/scripts/container_id_cache_patch.js
+++ b/crates/loro-wasm/scripts/container_id_cache_patch.js
@@ -56,6 +56,35 @@ function __loroCacheContainerIdGetter(ContainerClass) {
   });
 }
 
+// `kind()` returns a constant string per container class and never depends on
+// instance state, so one module-level memo per class is enough. Repeated reads
+// (e.g. loro-mirror's traversal) must not cross into WASM again.
+function __loroCacheKindMethod(ContainerClass) {
+  const prototype = ContainerClass.prototype;
+  const kindDescriptor = Object.getOwnPropertyDescriptor(prototype, "kind");
+  const kind = kindDescriptor && kindDescriptor.value;
+
+  if (typeof kind !== "function") {
+    throw new Error("Unexpected wasm-bindgen container wrapper shape");
+  }
+
+  let cached;
+  Object.defineProperty(prototype, "kind", {
+    ...kindDescriptor,
+    value() {
+      // Preserve wasm-bindgen's post-free error instead of returning stale data.
+      if (this.__wbg_ptr === 0) {
+        return kind.call(this);
+      }
+
+      if (cached === undefined) {
+        cached = kind.call(this);
+      }
+      return cached;
+    },
+  });
+}
+
 for (const ContainerClass of [
   LoroMap,
   LoroText,
@@ -65,4 +94,5 @@ for (const ContainerClass of [
   LoroCounter,
 ]) {
   __loroCacheContainerIdGetter(ContainerClass);
+  __loroCacheKindMethod(ContainerClass);
 }

--- a/crates/loro-wasm/scripts/measure-container-id.cjs
+++ b/crates/loro-wasm/scripts/measure-container-id.cjs
@@ -68,6 +68,10 @@ const repeatedRun = ({ container }) => {
   for (let i = 0; i < REPEATED_READS; i++) blackhole += container.id.length;
 };
 
+const repeatedKindRun = ({ container }) => {
+  for (let i = 0; i < REPEATED_READS; i++) blackhole += container.kind().length;
+};
+
 const firstRun = ({ containers }) => {
   for (const container of containers) blackhole += container.id.length;
 };
@@ -78,6 +82,8 @@ const mirrorReuseRun = ({ containers }) => {
     blackhole += container.id.length;
     blackhole += container.id.length;
     blackhole += container.id.length;
+    blackhole += container.kind().length;
+    blackhole += container.kind().length;
     const json = container.toJSON();
     if (json != null) blackhole++;
   }
@@ -99,6 +105,7 @@ const churnRun = ({ doc, ids }) => {
 
 const cases = [
   ["same-wrapper-repeated-id", repeatedSetup, repeatedRun],
+  ["same-wrapper-repeated-kind", repeatedSetup, repeatedKindRun],
   ["distinct-wrappers-first-id", makeContainers, firstRun],
   ["mirror-reuse-wrapper", makeContainers, mirrorReuseRun],
   ["mirror-new-wrapper-per-id", churnSetup, churnRun],

--- a/crates/loro-wasm/tests/container_id_cache.test.ts
+++ b/crates/loro-wasm/tests/container_id_cache.test.ts
@@ -112,3 +112,51 @@ describe("container id cache", () => {
     text.free();
   });
 });
+
+describe("container kind cache", () => {
+  it("returns the same kind string on repeated calls without re-decoding", () => {
+    const doc = new LoroDoc();
+    const first = doc.getMap("a");
+    const second = doc.getMap("b");
+    // Warm the class-level memo; kind() is constant per container class.
+    first.kind();
+
+    const { result: kinds, decoderCalls } = countTextDecodes(() => [
+      first.kind(),
+      first.kind(),
+      second.kind(),
+    ]);
+
+    expect(kinds).toEqual(["Map", "Map", "Map"]);
+    expect(decoderCalls).toBe(0);
+  });
+
+  it("decodes kind() at most once per container class", () => {
+    const doc = new LoroDoc();
+    const containers: Container[] = [
+      doc.getMap("map"),
+      doc.getText("text"),
+      doc.getList("list"),
+      doc.getTree("tree"),
+      doc.getMovableList("movable-list"),
+      doc.getCounter("counter"),
+    ];
+
+    const { result: kinds, decoderCalls } = countTextDecodes(() =>
+      containers.map((container) => [container.kind(), container.kind()]),
+    );
+
+    expect(decoderCalls).toBeLessThanOrEqual(containers.length);
+    for (const [first, second] of kinds) {
+      expect(second).toBe(first);
+    }
+  });
+
+  it("does not return a cached kind after free", () => {
+    const text = new LoroText();
+    expect(text.kind()).toBe("Text");
+    text.free();
+
+    expect(() => text.kind()).toThrow("null pointer passed to rust");
+  });
+});


### PR DESCRIPTION
Stack: 2/6 — merge order: #1093 → #1085 → #1086 → #1087 → #1090 → #1091

## Summary

`kind()` on container wrappers (`LoroMap`/`LoroList`/`LoroText`/`LoroTree`/`LoroMovableList`/`LoroCounter`) returns a constant string per class, but every call crossed into WASM and allocated a fresh JS string via `getStringFromWasm0`. On a real document with ~70k containers, loro-mirror-style traversal called `kind()` 230k times per full read (and `id` 333k times; the `id` cache already landed in #1073).

This extends the existing `container_id_cache_patch.js` mechanism with a class-level memo for `kind()`. Reads after `free()` still raise wasm-bindgen's null-pointer error (the memo is bypassed for a zero `__wbg_ptr`), and Rust-side `kind()` reads in `js_to_container` share the same memo.

## Measured (scripts/measure-container-id.cjs, 1M repeated reads of one wrapper)

| case | before | after |
|---|---|---|
| same-wrapper-repeated-kind | 164.5 ms, 1,000,000 string decodes | ~1.0 ms, 0 decodes |
| mirror-reuse-wrapper (id + kind + toJSON, 20k containers) | 51.1 ms, 63,333 decodes | 42.4 ms, 23,333 decodes |

## Tests

- `tests/container_id_cache.test.ts`: repeated `kind()` calls return the same string with zero additional wasm string decodes; at most one decode per container class; post-`free()` reads still throw.
- Full wasm suite: 26 files / 349 tests pass; `tsc --noEmit` clean.

## Wasm binary size

No change — this is a pure JS-glue patch.

Part 1 of the bulk-read series; the follow-up (per-container/range deep reads) stacks on this branch.