### PR TITLE
fix: restore selection when undoing the last history item

### DIFF
--- a/.changeset/last-undo-selection.md
+++ b/.changeset/last-undo-selection.md
@@ -1,0 +1,5 @@
+---
+"loro-crdt": patch
+---
+
+Fix selection restoration after remote edits when undoing the last history item.

--- a/crates/loro-internal/src/undo.rs
+++ b/crates/loro-internal/src/undo.rs
@@ -432,7 +432,7 @@ impl Stack {
     }
 
     pub fn transform_based_on_this_delta(&mut self, diff: &DiffBatch) {
-        if self.is_empty() {
+        if self.stack.is_empty() {
             return;
         }
         let remote_diff = &mut self.stack.back_mut().unwrap().1;

--- a/crates/loro/tests/undo_last_item_selection.rs
+++ b/crates/loro/tests/undo_last_item_selection.rs
@@ -1,0 +1,80 @@
+use loro::{cursor::Side, ExportMode, LoroDoc, UndoItemMeta, UndoManager};
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn last_undo_item_restores_selection_after_remote_edits() {
+    // The control differs only by an older, unrelated undo item. Neither arm
+    // imports a snapshot or clears the manager before editing.
+    for older_item in [true, false] {
+        let doc = LoroDoc::new();
+        doc.set_peer_id(1).unwrap();
+        let text = doc.get_text("text");
+        text.insert(0, "Hello world!").unwrap();
+        doc.commit();
+        let mut undo = UndoManager::new(&doc);
+        undo.set_merge_interval(0);
+        assert_eq!(undo.undo_count(), 0);
+
+        if older_item {
+            doc.get_map("unrelated").insert("key", true).unwrap();
+            doc.commit();
+        }
+        let remaining = usize::from(older_item);
+        assert_eq!(undo.undo_count(), remaining);
+
+        let selection = [
+            text.get_cursor(1, Side::Left).unwrap(),
+            text.get_cursor(5, Side::Right).unwrap(),
+        ];
+        undo.set_on_push(Some(Box::new(move |_, _, _| {
+            let mut meta = UndoItemMeta::new();
+            for cursor in &selection {
+                meta.add_cursor(cursor);
+            }
+            meta
+        })));
+        let popped = Arc::new(Mutex::new(Vec::new()));
+        let captured = popped.clone();
+        undo.set_on_pop(Some(Box::new(move |_, _, meta| {
+            *captured.lock().unwrap() = meta.cursors;
+        })));
+
+        text.delete(1, 4).unwrap();
+        doc.commit();
+        assert_eq!(undo.undo_count(), remaining + 1);
+        let peer = doc.fork();
+        peer.set_peer_id(2).unwrap();
+        peer.get_text("text").insert(0, "Hi ").unwrap();
+        peer.get_text("text").insert(4, "ii").unwrap();
+        peer.commit();
+        doc.import(&peer.export(ExportMode::updates(&doc.oplog_vv())).unwrap())
+            .unwrap();
+        assert_eq!(undo.undo_count(), remaining + 1);
+        assert!(undo.undo().unwrap());
+        assert_eq!(undo.undo_count(), remaining);
+        assert_eq!(text.to_string(), "Hi Helloii world!");
+
+        let restored = LoroDoc::from_snapshot(&doc.export(ExportMode::Snapshot).unwrap()).unwrap();
+        assert_eq!(restored.get_deep_value(), doc.get_deep_value());
+        assert_eq!(restored.oplog_vv(), doc.oplog_vv());
+        peer.import(&doc.export(ExportMode::updates(&peer.oplog_vv())).unwrap())
+            .unwrap();
+        assert_eq!(peer.get_deep_value(), doc.get_deep_value());
+        assert_eq!(peer.oplog_vv(), doc.oplog_vv());
+
+        let cursors = popped.lock().unwrap();
+        let positions: Vec<_> = cursors
+            .iter()
+            .map(|cursor| doc.get_cursor_pos(&cursor.cursor).unwrap().current.pos)
+            .collect();
+        assert_eq!(positions, vec![4, 8], "older_item={older_item}");
+        assert_eq!(
+            cursors
+                .iter()
+                .map(|cursor| cursor.pos.pos)
+                .collect::<Vec<_>>(),
+            vec![4, 8],
+            "older_item={older_item}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1100.

`Stack::pop()` decreases the logical item count but keeps the row containing its
remote delta alive for cursor restoration. When the popped item was the last
one, `transform_based_on_this_delta()` returned early because `self.is_empty()`
checks that logical count. The subsequent cursor transform therefore used the
remote delta without rebasing it through the undo.

Check `self.stack.is_empty()` instead. This keeps the empty-storage guard while
allowing the retained row's delta to be transformed. It does not introduce a new
history or change the merge algorithm.

The regression starts with `Hello world!`, commits it, and then creates the
UndoManager. It deletes the selected `ello`, imports a peer's `Hi ` and `ii`
insertions, and undoes the deletion. The text must be `Hi Helloii world!` and
the absolute selection positions delivered in `on_pop` metadata
(`CursorWithPos.pos.pos`) must be `[4,8]`, not `[4,10]`. Resolving the retained
cursors through `doc.get_cursor_pos(...).current.pos` already returns `[4,8]`
before the fix; the regression distinguishes these two results.

The same test first runs a control with one unrelated map edit in the history.
The control passes without the fix; the last-item arm fails. Neither arm loads
a snapshot or calls `clear()` before editing. Both also check fresh snapshot
and peer readback of the document value and version vector.

## Validation

Base: `d9ddfba195f9363653ac1d83e744641dcb337f4e`.
Prepared commit: `7db750e38d61fb83200d9f9665931e77bce5fad7`.

- Before the fix: the new test fails with `older_item=false` at the `on_pop`
  metadata assertion, actual `[4,10]`, expected `[4,8]`. The older-item control,
  text/readback checks and cursor-resolution assertion pass first.
- After the fix: `cargo test --locked -p loro -p loro-internal --lib --tests -- --test-threads=1`
  passes 1,050 tests; 12 existing tests are ignored. Native macOS, Rust 1.94.0,
  dev debug information disabled and incremental compilation disabled.
- The focused test also passes after committing the patch.
- WASM/browser tests, release-mode performance and fuzzing were not run.

Includes the repository-required patch changeset. No public API or storage
format changes are proposed.
